### PR TITLE
Remove completion command

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -47,5 +47,6 @@ func init() {
 	rootCmd.AddCommand(deleteCmd.NewCmdCreate())
 	rootCmd.AddCommand(resticCmd.NewCmdCreate())
 	rootCmd.AddCommand(maintenanceCmd.NewCmdCreate())
-  rootCmd.CompletionOptions.DisableDefaultCmd = true
+	
+  	rootCmd.CompletionOptions.DisableDefaultCmd = true
 }

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -33,4 +33,6 @@ func init() {
 	rootCmd.AddCommand(stopCmd.NewCmdCreate())
 	rootCmd.AddCommand(listCmd.NewCmdCreate())
 	rootCmd.AddCommand(deleteCmd.NewCmdCreate())
+
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
 }


### PR DESCRIPTION
This hides the command `completion`, which is confusing and not yet properly tested.