### PR TITLE
Add script to install CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,14 @@
 The Canasta command line interface, written in Go
 
 # Installation
-Make sure you have the `go` compiler installed (at least 1.18) and set your `$GOPATH`
 
-Clone the repo
+Make sure you have Docker and DockerCompose installed on your computer running the CLI.
 
-`git clone git@github.com:CanastaWiki/Canasta-CLI-Go.git`
+Run the following line of scirpt to install the Canasta CLI on your computer.
 
-Checkout into the `dev` branch
-
-`git checkout dev`
-
-Install Canasta.go
-
-`go install canasta.go`
-
-Now you should be able to access the `canasta` cli from any directories
+```
+curl -fsL https://raw.githubusercontent.com/CanastaWiki/Canasta-CLI/installer/install.sh | bash
+```
 
 # Documentation
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ curl -fsL https://raw.githubusercontent.com/CanastaWiki/Canasta-CLI/installer/in
 ``` A CLI tool to create, import, start, stop and backup multiple Canasta installations
 
 Usage:
-  canasta [command]
+  sudo canasta [command]
 
 Available Commands:
 

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 # Requirements Docker Engine 18.06.0+ and DockerCompose 
 
 echo "Downloading Canasta CLI latest release"
-wget -q https://github.com/CanastaWiki/Canasta-CLI/releases/latest/download/canasta
+wget -q --show-progress https://github.com/CanastaWiki/Canasta-CLI/releases/latest/download/canasta
 
 echo "Installing Canasta CLI"
 chmod u=rwx,g=xr,o=x canasta
@@ -15,7 +15,7 @@ if [ -x $loc ]
 then
     echo "Docker is installed"
 else
-    echo "Docker is not installed, Please follow the guide at https://docs.docker.com/engine/install/ to install docker"
+    echo "Docker is not installed, Please follow the guide at https://docs.docker.com/engine/install/ to install Docker."
 fi
 
 loc=$(which docker-compose)
@@ -23,8 +23,8 @@ if [ -x $loc ]
 then
     echo "DockerCompose is installed"
 else
-    echo "DockerCompose is not installed, Please follow the guide at https://docs.docker.com/compose/install/compose-plugin/#installing-compose-on-linux-systems to install DockerCompose"
+    echo "DockerCompose is not installed, Please follow the guide at https://docs.docker.com/compose/install/compose-plugin/#installing-compose-on-linux-systems to install DockerCompose."
 fi
 
-echo "Please make sure you have installed and configured orchestrator required for Canasta to run properly"
-echo -e "\n\nUsage sudo canasta [COMMAND] [ARGUMENTS...]"
+echo "Please make sure you have a working kubectl if you wish to use Kubernetes as an orchestrator."
+echo -e "\nUsage: sudo canasta [COMMAND] [ARGUMENTS...]"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Canasta CLI installer
+# Requirements Docker Engine 18.06.0+ and DockerCompose 
+
+echo "Downloading Canasta CLI latest release"
+wget -q https://github.com/CanastaWiki/Canasta-CLI/releases/latest/download/canasta
+
+echo "Installing Canasta CLI"
+chmod u=rwx,g=xr,o=x canasta
+sudo mv canasta /usr/local/bin/canasta
+
+loc=$(which docker)
+if [ -x $loc ]
+then
+    echo "Docker is installed"
+else
+    echo "Docker is not installed, Please follow the guide at https://docs.docker.com/engine/install/ to install docker"
+fi
+
+loc=$(which docker-compose)
+if [ -x $loc ]
+then
+    echo "DockerCompose is installed"
+else
+    echo "DockerCompose is not installed, Please follow the guide at https://docs.docker.com/compose/install/compose-plugin/#installing-compose-on-linux-systems to install DockerCompose"
+fi
+
+echo "Please make sure you have installed and configured orchestrator required for Canasta to run properly"
+echo -e "\n\nUsage sudo canasta [COMMAND] [ARGUMENTS...]"


### PR DESCRIPTION
1. Created a bash script to install the latest release of the CLI with a Docker and Docker Compose install check.
2. Update the README.md #Installation section to use the bash script.