### PR TITLE
Delete installation on failure

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -33,18 +33,19 @@ func NewCmdCreate() *cobra.Command {
 			fmt.Println("Setting up Canasta")
 			if err = createCanasta(canastaInfo, pwd, path, orchestrator); err != nil {
 				fmt.Print(err.Error(), "\n")
-				fmt.Println("A fatal error occured during the installation\nDo you want to delete the files related to it? (y/n)")
+				fmt.Println("A fatal error occured during the installation\nDo you want to keep the files related to it? (y/n)")
 				scanner := bufio.NewScanner(os.Stdin)
 				scanner.Scan()
 				input := scanner.Text()
-				if input == "y" {
-					installationDir := path + "/" + canastaInfo.Id
-					fmt.Println("Removing containers")
-					orchestrators.DeleteContainers(installationDir, orchestrator)
-					fmt.Println("Deleting config files")
-					orchestrators.DeleteConfig(installationDir)
+				if input == "y" || input == "Y" || input == "yes" {
 					logging.Fatal(fmt.Errorf("Exiting"))
 				}
+				installationDir := path + "/" + canastaInfo.Id
+				fmt.Println("Removing containers")
+				orchestrators.DeleteContainers(installationDir, orchestrator)
+				fmt.Println("Deleting config files")
+				orchestrators.DeleteConfig(installationDir)
+				fmt.Println("Deleted all containers and config files")
 			}
 			fmt.Println("Done")
 			return nil

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -31,6 +31,8 @@ func NewCmdCreate() *cobra.Command {
 			fmt.Println("Setting up Canasta")
 			if err = createCanasta(canastaInfo, pwd, path, orchestrator); err != nil {
 				orchestrators.Delete(path, orchestrator)
+				//For testing to be removed
+				fmt.Print("Printed at create.go")
 				logging.Fatal(err)
 			}
 			fmt.Println("Done")

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -21,7 +21,7 @@ var (
 func NewCmdCreate() *cobra.Command {
 	var deleteCmd = &cobra.Command{
 		Use:   "delete",
-		Short: "Delete a  Canasta installation",
+		Short: "Delete a Canasta installation",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if instance.Id == "" && len(args) > 0 {
 				instance.Id = args[0]
@@ -51,7 +51,14 @@ func Delete(instance logging.Installation) error {
 	}
 
 	//Stopping and deleting Contianers and it's volumes
-	orchestrators.Delete(instance.Path, instance.Orchestrator)
+	if _, err := orchestrators.DeleteContainers(instance.Path, instance.Orchestrator); err != nil {
+		return err
+	}
+
+	//Delete config files
+	if _, err := orchestrators.DeleteConfig(instance.Path); err != nil {
+		return err
+	}
 
 	//Deleting installation details from conf.json
 	if err = logging.Delete(instance.Id); err != nil {

--- a/cmd/import/importExisting.go
+++ b/cmd/import/importExisting.go
@@ -36,18 +36,19 @@ func NewCmdCreate() *cobra.Command {
 			fmt.Println("Importing Canasta")
 			if err := importCanasta(pwd, canastaId, domainName, path, orchestrator, databasePath, localSettingsPath, envPath); err != nil {
 				fmt.Print(err.Error(), "\n")
-				fmt.Println("A fatal error occured during the installation\nDo you want to delete the files related to it? (y/n)")
+				fmt.Println("A fatal error occured during the installation\nDo you want to keep the files related to it? (y/n)")
 				scanner := bufio.NewScanner(os.Stdin)
 				scanner.Scan()
 				input := scanner.Text()
-				if input == "y" {
-					installationDir := path + "/" + canastaId
-					fmt.Println("Removing containers")
-					orchestrators.DeleteContainers(installationDir, orchestrator)
-					fmt.Println("Deleting config files")
-					orchestrators.DeleteConfig(installationDir)
+				if input == "y" || input == "Y" || input == "yes" {
 					logging.Fatal(fmt.Errorf("Exiting"))
 				}
+				installationDir := path + "/" + canastaId
+				fmt.Println("Removing containers")
+				orchestrators.DeleteContainers(installationDir, orchestrator)
+				fmt.Println("Deleting config files")
+				orchestrators.DeleteConfig(installationDir)
+				fmt.Println("Deleted all containers and config files")
 			}
 			fmt.Println("Done")
 			return nil

--- a/cmd/restic/check.go
+++ b/cmd/restic/check.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/execute"
+	"github.com/CanastaWiki/Canasta-CLI-Go/internal/logging"
 )
 
 func checkCmdCreate() *cobra.Command {
@@ -23,6 +24,10 @@ func checkCmdCreate() *cobra.Command {
 
 func check() {
 	commandArgs = append(commandArgs, "check")
-	output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
-	fmt.Print(output)
+	err, output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
+	if err != nil {
+		logging.Fatal(fmt.Errorf(output))
+	} else {
+		fmt.Print(output)
+	}
 }

--- a/cmd/restic/diff.go
+++ b/cmd/restic/diff.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/execute"
+	"github.com/CanastaWiki/Canasta-CLI-Go/internal/logging"
 )
 
 var (
@@ -31,6 +32,10 @@ func diffCmdCreate() *cobra.Command {
 
 func diff() {
 	commandArgs = append(commandArgs, "diff", tag1, tag2)
-	output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
-	fmt.Print(output)
+	err, output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
+	if err != nil {
+		logging.Fatal(fmt.Errorf(output))
+	} else {
+		fmt.Print(output)
+	}
 }

--- a/cmd/restic/forgetSnapshots.go
+++ b/cmd/restic/forgetSnapshots.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/execute"
+	"github.com/CanastaWiki/Canasta-CLI-Go/internal/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -29,6 +30,10 @@ func forgetSnapshotCmdCreate() *cobra.Command {
 
 func forgetSnapshot() {
 	commandArgs = append(commandArgs, "forget", tag)
-	output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
-	fmt.Print(output)
+	err, output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
+	if err != nil {
+		logging.Fatal(fmt.Errorf(output))
+	} else {
+		fmt.Print(output)
+	}
 }

--- a/cmd/restic/init.go
+++ b/cmd/restic/init.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/execute"
+	"github.com/CanastaWiki/Canasta-CLI-Go/internal/logging"
 )
 
 var (
@@ -28,6 +29,10 @@ func initCmdCreate() *cobra.Command {
 func initRestic() {
 	fmt.Println("Initializing Restic repo in S3")
 	commandArgs = append(commandArgs, "init")
-	output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
-	fmt.Println(output)
+	err, output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
+	if err != nil {
+		logging.Fatal(fmt.Errorf(output))
+	} else {
+		fmt.Print(output)
+	}
 }

--- a/cmd/restic/listFiles.go
+++ b/cmd/restic/listFiles.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/execute"
+	"github.com/CanastaWiki/Canasta-CLI-Go/internal/logging"
 )
 
 func listFilesCmdCreate() *cobra.Command {
@@ -29,6 +30,10 @@ func listFilesCmdCreate() *cobra.Command {
 
 func listFiles() {
 	commandArgs = append(commandArgs, "ls", tag)
-	output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
-	fmt.Print(output)
+	err, output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
+	if err != nil {
+		logging.Fatal(fmt.Errorf(output))
+	} else {
+		fmt.Print(output)
+	}
 }

--- a/cmd/restic/restoreSnapshot.go
+++ b/cmd/restic/restoreSnapshot.go
@@ -53,8 +53,10 @@ func restoreSnapshot(snapshotId string, skipBeforeSnapshot bool) {
 	logging.Print("Restoring snapshot to /currentsnapshot")
 	command := fmt.Sprintf("docker run --rm -i --env-file %s/.env -v %s:/currentsnapshot restic/restic -r s3:%s/%s restore %s --target /currentsnapshot", instance.Path, currentSnapshotFolder, EnvVariables["AWS_S3_API"], EnvVariables["AWS_S3_BUCKET"], snapshotId)
 	commandArgs := strings.Fields(command)
-	execute.Run("", "sudo", commandArgs...)
-
+	err, output := execute.Run("", "sudo", commandArgs...)
+	if err != nil {
+		logging.Fatal(fmt.Errorf(output))
+	}
 	logging.Print("Copying files....")
 	folders := [...]string{"/config", "/extensions", "/images", "/skins"}
 	for _, folder := range folders {

--- a/cmd/restic/takeSnapshot.go
+++ b/cmd/restic/takeSnapshot.go
@@ -39,11 +39,17 @@ func takeSnapshot(tag string) {
 	orchestrators.Exec(instance.Path, instance.Orchestrator, "web", fmt.Sprintf("mysqldump -h db -u root -p%s --databases %s > %s", EnvVariables["MYSQL_PASSWORD"], EnvVariables["WG_DB_NAME"], mysqldumpPath))
 	logging.Print("mysqldump mediawiki completed")
 
-	execute.Run(instance.Path, "sudo", "cp", "--preserve=links,mode,ownership,timestamps", "-r", "config", "extensions", "images", "skins", currentSnapshotFolder)
+	err, output := execute.Run(instance.Path, "sudo", "cp", "--preserve=links,mode,ownership,timestamps", "-r", "config", "extensions", "images", "skins", currentSnapshotFolder)
+	if err != nil {
+		logging.Fatal(fmt.Errorf(output))
+	}
 	logging.Print("Copy folders and files completed.")
 
 	hostname, _ := os.Hostname()
-	output := execute.Run(instance.Path, "sudo", "docker", "run", "--rm", "-i", "--env-file", envPath, "-v", currentSnapshotFolder+":/currentsnapshot/", "restic/restic", "-r", "s3:"+EnvVariables["AWS_S3_API"]+"/"+EnvVariables["AWS_S3_BUCKET"], "--tag", fmt.Sprintf("%s__on__%s", tag, hostname), "backup", "/currentsnapshot")
+	err, output = execute.Run(instance.Path, "sudo", "docker", "run", "--rm", "-i", "--env-file", envPath, "-v", currentSnapshotFolder+":/currentsnapshot/", "restic/restic", "-r", "s3:"+EnvVariables["AWS_S3_API"]+"/"+EnvVariables["AWS_S3_BUCKET"], "--tag", fmt.Sprintf("%s__on__%s", tag, hostname), "backup", "/currentsnapshot")
+	if err != nil {
+		logging.Fatal(fmt.Errorf(output))
+	}
 	fmt.Print(output)
 	fmt.Println("Completed running restic backup")
 }

--- a/cmd/restic/unlock.go
+++ b/cmd/restic/unlock.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/execute"
+	"github.com/CanastaWiki/Canasta-CLI-Go/internal/logging"
 )
 
 func unlockCmdCreate() *cobra.Command {
@@ -22,6 +23,9 @@ func unlockCmdCreate() *cobra.Command {
 
 func unlock() {
 	commandArgs = append(commandArgs, "unlock")
-	output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
+	err, output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
+	if err != nil {
+		logging.Fatal(fmt.Errorf(output))
+	}
 	fmt.Print(output)
 }

--- a/cmd/restic/viewSnapshots.go
+++ b/cmd/restic/viewSnapshots.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/execute"
+	"github.com/CanastaWiki/Canasta-CLI-Go/internal/logging"
 )
 
 func viewSnapshotsCmdCreate() *cobra.Command {
@@ -23,6 +24,9 @@ func viewSnapshotsCmdCreate() *cobra.Command {
 
 func viewSnapshots() {
 	commandArgs = append(commandArgs, "snapshots")
-	output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
+	err, output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
+	if err != nil {
+		logging.Fatal(fmt.Errorf(output))
+	}
 	fmt.Print(output)
 }

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -6,8 +6,8 @@ import (
 	extensionCmd "github.com/CanastaWiki/Canasta-CLI-Go/cmd/extension"
 	importCmd "github.com/CanastaWiki/Canasta-CLI-Go/cmd/import"
 	listCmd "github.com/CanastaWiki/Canasta-CLI-Go/cmd/list"
-	restartCmd "github.com/CanastaWiki/Canasta-CLI-Go/cmd/restart"
 	maintenanceCmd "github.com/CanastaWiki/Canasta-CLI-Go/cmd/maintenanceUpdate"
+	restartCmd "github.com/CanastaWiki/Canasta-CLI-Go/cmd/restart"
 	resticCmd "github.com/CanastaWiki/Canasta-CLI-Go/cmd/restic"
 	skinCmd "github.com/CanastaWiki/Canasta-CLI-Go/cmd/skin"
 	startCmd "github.com/CanastaWiki/Canasta-CLI-Go/cmd/start"
@@ -53,5 +53,5 @@ func init() {
 	rootCmd.AddCommand(maintenanceCmd.NewCmdCreate())
 	rootCmd.AddCommand(skinCmd.NewCmdCreate())
 	rootCmd.AddCommand(extensionCmd.NewCmdCreate())
-  rootCmd.CompletionOptions.DisableDefaultCmd = true
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
 }

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -151,3 +151,11 @@ func CheckCanastaId(instance logging.Installation) (logging.Installation, error)
 	}
 	return instance, nil
 }
+
+func DeleteConfigAndContainers(keepConfig bool, installationDir, orchestrator string) {
+	fmt.Println("Removing containers")
+	orchestrators.DeleteContainers(installationDir, orchestrator)
+	fmt.Println("Deleting config files")
+	orchestrators.DeleteConfig(installationDir)
+	fmt.Println("Deleted all containers and config files")
+}

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -39,7 +39,10 @@ func CopyEnv(envPath, domainName, path, pwd string) {
 		envPath = pwd + "/" + envPath
 	}
 	logging.Print(fmt.Sprintf("Copying %s to %s/.env\n", envPath, path))
-	execute.Run("", "cp", envPath, path+"/.env")
+	err, output := execute.Run("", "cp", envPath, path+"/.env")
+	if err != nil {
+		logging.Fatal(fmt.Errorf(output))
+	}
 	if err := SaveEnvVariable(path+"/.env", "MW_SITE_SERVER", "https://"+domainName); err != nil {
 		logging.Fatal(err)
 	}
@@ -53,7 +56,10 @@ func CopyLocalSettings(localSettingsPath, path, pwd string) error {
 	if localSettingsPath != "" {
 		localSettingsPath = pwd + "/" + localSettingsPath
 		logging.Print(fmt.Sprintf("Copying %s to %s/config/LocalSettings.php\n", localSettingsPath, path))
-		execute.Run("", "cp", localSettingsPath, path+"/config/LocalSettings.php")
+		err, output := execute.Run("", "cp", localSettingsPath, path+"/config/LocalSettings.php")
+		if err != nil {
+			logging.Fatal(fmt.Errorf(output))
+		}
 	}
 	return nil
 }
@@ -63,7 +69,10 @@ func CopyDatabase(databasePath, path, pwd string) error {
 	if databasePath != "" {
 		databasePath = pwd + "/" + databasePath
 		logging.Print(fmt.Sprintf("Copying %s to %s/_initdb\n", databasePath, path))
-		execute.Run("", "cp", databasePath, path+"/_initdb/")
+		err, output := execute.Run("", "cp", databasePath, path+"/_initdb/")
+		if err != nil {
+			logging.Fatal(fmt.Errorf(output))
+		}
 	}
 	return nil
 }

--- a/internal/execute/execute.go
+++ b/internal/execute/execute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/logging"
 )
 
-func Run(path, command string, cmdArgs ...string) string {
+func Run(path, command string, cmdArgs ...string) (error, string) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	logging.Print(fmt.Sprint(command, " ", strings.Join(cmdArgs, " ")))
@@ -21,13 +21,11 @@ func Run(path, command string, cmdArgs ...string) string {
 		cmd.Dir = path
 	}
 
-	err := cmd.Start()
-	if err != nil {
+	if err := cmd.Start(); err != nil {
 		logging.Fatal(err)
 	}
-	if err := cmd.Wait(); err != nil {
-		logging.Fatal(fmt.Errorf(stdout.String() + stderr.String()))
-	}
-	logging.Print(stdout.String() + stderr.String())
-	return stdout.String() + stderr.String()
+	err := cmd.Wait()
+	output := stdout.String() + stderr.String()
+	logging.Print(output)
+	return err, output
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/execute"
-	"github.com/CanastaWiki/Canasta-CLI-Go/internal/logging"
 )
 
-func Clone(repo, path string) {
+func Clone(repo, path string) error {
 	err, output := execute.Run("", "git", "clone", repo, path)
 	if err != nil {
-		logging.Fatal(fmt.Errorf(output))
+		return fmt.Errorf(output)
 	}
+	return nil
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,9 +1,15 @@
 package git
 
 import (
+	"fmt"
+
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/execute"
+	"github.com/CanastaWiki/Canasta-CLI-Go/internal/logging"
 )
 
 func Clone(repo, path string) {
-	execute.Run("", "git", "clone", repo, path)
+	err, output := execute.Run("", "git", "clone", repo, path)
+	if err != nil {
+		logging.Fatal(fmt.Errorf(output))
+	}
 }

--- a/internal/orchestrators/orchestrators.go
+++ b/internal/orchestrators/orchestrators.go
@@ -23,7 +23,10 @@ func Start(path, orchestrator string) error {
 	logging.Print("Starting Canasta\n")
 	switch orchestrator {
 	case "docker-compose":
-		execute.Run(path, "docker-compose", "up", "-d")
+		err, output := execute.Run(path, "docker-compose", "up", "-d")
+		if err != nil {
+			logging.Fatal(fmt.Errorf(output))
+		}
 	default:
 		logging.Fatal(fmt.Errorf("orchestrator: %s is not available", orchestrator))
 	}
@@ -34,7 +37,10 @@ func Stop(path, orchestrator string) error {
 	logging.Print("Stoping the containers\n")
 	switch orchestrator {
 	case "docker-compose":
-		execute.Run(path, "docker-compose", "down")
+		err, output := execute.Run(path, "docker-compose", "down")
+		if err != nil {
+			logging.Fatal(fmt.Errorf(output))
+		}
 	default:
 		logging.Fatal(fmt.Errorf("orchestrator: %s is not available", orchestrator))
 	}
@@ -54,13 +60,19 @@ func StopAndStart(path, orchestrator string) error {
 func Delete(path, orchestrator string) {
 	switch orchestrator {
 	case "docker-compose":
-		execute.Run(path, "docker-compose", "down", "-v")
+		err, output := execute.Run(path, "docker-compose", "down", "-v")
+		if err != nil {
+			logging.Fatal(fmt.Errorf(output))
+		}
 	default:
 		logging.Fatal(fmt.Errorf("orchestrator: %s is not available", orchestrator))
 	}
 
 	//Deleting the installation folder
-	execute.Run("", "rm", "-rf", path)
+	err, output := execute.Run("", "rm", "-rf", path)
+	if err != nil {
+		logging.Fatal(fmt.Errorf(output))
+	}
 }
 
 func ExecWithError(path, orchestrator, container, command string) (string, error) {

--- a/internal/orchestrators/orchestrators.go
+++ b/internal/orchestrators/orchestrators.go
@@ -25,7 +25,7 @@ func Start(path, orchestrator string) error {
 	case "docker-compose":
 		err, output := execute.Run(path, "docker-compose", "up", "-d")
 		if err != nil {
-			logging.Fatal(fmt.Errorf(output))
+			return fmt.Errorf(output)
 		}
 	default:
 		logging.Fatal(fmt.Errorf("orchestrator: %s is not available", orchestrator))
@@ -39,7 +39,7 @@ func Stop(path, orchestrator string) error {
 	case "docker-compose":
 		err, output := execute.Run(path, "docker-compose", "down")
 		if err != nil {
-			logging.Fatal(fmt.Errorf(output))
+			return fmt.Errorf(output)
 		}
 	default:
 		logging.Fatal(fmt.Errorf("orchestrator: %s is not available", orchestrator))
@@ -49,30 +49,29 @@ func Stop(path, orchestrator string) error {
 
 func StopAndStart(path, orchestrator string) error {
 	if err := Stop(path, orchestrator); err != nil {
-		logging.Fatal(err)
+		return err
 	}
 	if err := Start(path, orchestrator); err != nil {
-		logging.Fatal(err)
+		return err
 	}
 	return nil
 }
 
-func Delete(path, orchestrator string) {
+func DeleteContainers(path, orchestrator string) (string, error) {
 	switch orchestrator {
 	case "docker-compose":
 		err, output := execute.Run(path, "docker-compose", "down", "-v")
-		if err != nil {
-			logging.Fatal(fmt.Errorf(output))
-		}
+		return output, err
 	default:
 		logging.Fatal(fmt.Errorf("orchestrator: %s is not available", orchestrator))
 	}
+	return "", nil
+}
 
+func DeleteConfig(path string) (string, error) {
 	//Deleting the installation folder
 	err, output := execute.Run("", "rm", "-rf", path)
-	if err != nil {
-		logging.Fatal(fmt.Errorf(output))
-	}
+	return output, err
 }
 
 func ExecWithError(path, orchestrator, container, command string) (string, error) {


### PR DESCRIPTION
Fixes #14
So when a create/import command fails, `canasta` CLI asks the user whether to keep the config files or not.