### PR TITLE
Add Upgrade command

### DIFF
--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -1,4 +1,4 @@
-package start
+package list
 
 import (
 	"github.com/spf13/cobra"

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -12,6 +12,7 @@ import (
 	skinCmd "github.com/CanastaWiki/Canasta-CLI-Go/cmd/skin"
 	startCmd "github.com/CanastaWiki/Canasta-CLI-Go/cmd/start"
 	stopCmd "github.com/CanastaWiki/Canasta-CLI-Go/cmd/stop"
+	upgradeCmd "github.com/CanastaWiki/Canasta-CLI-Go/cmd/upgrade"
 	versionCmd "github.com/CanastaWiki/Canasta-CLI-Go/cmd/version"
 
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/logging"
@@ -55,5 +56,6 @@ func init() {
 	rootCmd.AddCommand(skinCmd.NewCmdCreate())
 	rootCmd.AddCommand(startCmd.NewCmdCreate())
 	rootCmd.AddCommand(stopCmd.NewCmdCreate())
+	rootCmd.AddCommand(upgradeCmd.NewCmdCreate())
 	rootCmd.AddCommand(versionCmd.NewCmdCreate())
 }

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -1,0 +1,66 @@
+package upgrade
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CanastaWiki/Canasta-CLI-Go/internal/canasta"
+	"github.com/CanastaWiki/Canasta-CLI-Go/internal/git"
+	"github.com/CanastaWiki/Canasta-CLI-Go/internal/logging"
+	"github.com/CanastaWiki/Canasta-CLI-Go/internal/orchestrators"
+)
+
+var (
+	pwd      string
+	err      error
+	instance logging.Installation
+)
+
+func NewCmdCreate() *cobra.Command {
+	var upgradeCmd = &cobra.Command{
+		Use:   "upgrade",
+		Short: "Upgrade a Canasta installation to the latest version",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if instance.Id == "" && len(args) > 0 {
+				instance.Id = args[0]
+			}
+			if err := Upgrade(instance); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	if pwd, err = os.Getwd(); err != nil {
+		log.Fatal(err)
+	}
+
+	upgradeCmd.Flags().StringVarP(&instance.Path, "path", "p", pwd, "Canasta installation directory")
+	upgradeCmd.Flags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
+	return upgradeCmd
+}
+
+func Upgrade(instance logging.Installation) error {
+
+	var err error
+	//Checking Installation existence
+	instance, err = canasta.CheckCanastaId(instance)
+	if err != nil {
+		return err
+	}
+	fmt.Print("Pulling the latest changes")
+	//Pulling the latest changes from github
+	if err = git.Pull(instance.Path); err != nil {
+		return err
+	}
+
+	//Restarting the containers
+	if err = orchestrators.StopAndStart(instance.Path, instance.Orchestrator); err != nil {
+		return err
+	}
+
+	fmt.Print("Canasta Upgraded!")
+	return nil
+}

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/canasta"
+	"github.com/CanastaWiki/Canasta-CLI-Go/internal/execute"
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/git"
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/orchestrators"
@@ -45,12 +46,13 @@ func NewCmdCreate() *cobra.Command {
 func Upgrade(instance logging.Installation) error {
 
 	var err error
+
 	//Checking Installation existence
 	instance, err = canasta.CheckCanastaId(instance)
 	if err != nil {
 		return err
 	}
-	fmt.Print("Pulling the latest changes")
+	fmt.Print("Pulling the latest changes\n")
 	//Pulling the latest changes from github
 	if err = git.Pull(instance.Path); err != nil {
 		return err
@@ -61,6 +63,10 @@ func Upgrade(instance logging.Installation) error {
 		return err
 	}
 
-	fmt.Print("Canasta Upgraded!")
+	//Touch LocalSettings.php
+	fmt.Print("Running 'touch LocalSettings.php' to flush cache\n")
+	execute.Run(instance.Path, "touch", "config/LocalSettings.php")
+
+	fmt.Print("Canasta Upgraded!\n")
 	return nil
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -13,3 +13,11 @@ func Clone(repo, path string) error {
 	}
 	return nil
 }
+
+func Pull(path string) error {
+	err, output := execute.Run(path, "git", "pull", "origin", "main")
+	if err != nil {
+		return fmt.Errorf(output)
+	}
+	return nil
+}


### PR DESCRIPTION
Add the “canasta upgrade” command, which will update the canasta installation to the latest version.

Currently, it runs “git pull origin main” inside the configuration folder, which is a git clone of the original stack repo. So by pulling the updates and restarting the containers, it gets updated.