### PR TITLE
Fix config dir

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -107,28 +107,32 @@ func read(details *Canasta) error {
 func GetConfigDir() string {
 	dir := configdir.LocalConfig("canasta")
 	exists := false
-	fi, err := os.Stat(dir)
-	if err != nil {
-		msg := fmt.Sprintf("error statting %s (%s)", dir, err)
-		log.Print(msg)
-	} else {
-		mode := fi.Mode()
-		if mode.IsDir() {
-			exists = true
-		}
-	}
-
+	
 	// Checks if this is running as root
 	currentUser, err := user.Current()
 	if err != nil {
 		errReport := fmt.Errorf("Unable to get the current user: %s", err)
 		log.Fatal(errReport)
 	}
+
 	if currentUser.Username == "root" {
 		dir = directory
-	} else if currentUser.Username != "root" && exists != true {
-		msg := fmt.Sprintf("Using %s for configuration...", dir)
-		log.Print(msg)
+	} else if currentUser.Username != "root" {
+		fi, err := os.Stat(dir)
+		if err != nil {
+			msg := fmt.Sprintf("error statting %s (%s)", dir, err)
+			log.Print(msg)
+		} else {
+			mode := fi.Mode()
+			if mode.IsDir() {
+				exists = true
+			}
+		}
+
+		if exists != true {
+			msg := fmt.Sprintf("Using %s for configuration...", dir)
+			log.Print(msg)
+		}
 	}
 
 	return dir

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -107,7 +107,7 @@ func read(details *Canasta) error {
 func GetConfigDir() string {
 	dir := configdir.LocalConfig("canasta")
 	exists := false
-	
+
 	// Checks if this is running as root
 	currentUser, err := user.Current()
 	if err != nil {
@@ -117,15 +117,15 @@ func GetConfigDir() string {
 
 	if currentUser.Username == "root" {
 		dir = directory
-	} else if currentUser.Username != "root" {
+	} else {
 		fi, err := os.Stat(dir)
 		if os.IsNotExist(err) {
-			var configDir string = ".config"
-			log.Print(fmt.Sprintf("Creating %s\n", configDir))
-			err = os.Mkdir(configDir, os.ModePerm)
+			log.Print(fmt.Sprintf("Creating %s\n", dir))
+			err = os.MkdirAll(dir, os.ModePerm)
 			if err != nil {
 				log.Fatal(err)
 			}
+			exists = true
 		} else if err != nil {
 			msg := fmt.Sprintf("error statting %s (%s)", dir, err)
 			log.Print(msg)
@@ -162,7 +162,7 @@ func init() {
 		// Creating configuration folder
 		if os.IsNotExist(err) {
 			log.Print(fmt.Sprintf("Creating %s\n", directory))
-			err = os.Mkdir(directory, os.ModePerm)
+			err = os.MkdirAll(directory, os.ModePerm)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -119,7 +119,14 @@ func GetConfigDir() string {
 		dir = directory
 	} else if currentUser.Username != "root" {
 		fi, err := os.Stat(dir)
-		if err != nil {
+		if os.IsNotExist(err) {
+			var configDir string = ".config"
+			log.Print(fmt.Sprintf("Creating %s\n", configDir))
+			err = os.Mkdir(configDir, os.ModePerm)
+			if err != nil {
+				log.Fatal(err)
+			}
+		} else if err != nil {
 			msg := fmt.Sprintf("error statting %s (%s)", dir, err)
 			log.Print(msg)
 		} else {


### PR DESCRIPTION
Fix #42
1. Remove error saying missing "/root/.config" directory which is not used.
2. Create ".config" in users home directory if it does not exist.