### PR TITLE
Add Maintenance script command

### DIFF
--- a/cmd/maintenanceUpdate/maintenance.go
+++ b/cmd/maintenanceUpdate/maintenance.go
@@ -21,6 +21,7 @@ func NewCmdCreate() *cobra.Command {
 	}
 
 	maintenanceCmd.AddCommand(updateCmdCreate())
+	maintenanceCmd.AddCommand(scriptCmdCreate())
 	if pwd, err = os.Getwd(); err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/maintenanceUpdate/maintenance.go
+++ b/cmd/maintenanceUpdate/maintenance.go
@@ -1,0 +1,31 @@
+package maintenance
+
+import (
+	"log"
+	"os"
+
+	"github.com/CanastaWiki/Canasta-CLI-Go/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var (
+	instance config.Installation
+	pwd      string
+	err      error
+)
+
+func NewCmdCreate() *cobra.Command {
+	maintenanceCmd := &cobra.Command{
+		Use:   "maintenance",
+		Short: "Use to run update and other maintenance scripts",
+	}
+
+	maintenanceCmd.AddCommand(updateCmdCreate())
+	if pwd, err = os.Getwd(); err != nil {
+		log.Fatal(err)
+	}
+
+	maintenanceCmd.PersistentFlags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
+	maintenanceCmd.PersistentFlags().StringVarP(&instance.Path, "path", "p", pwd, "Canasta installation directory")
+	return maintenanceCmd
+}

--- a/cmd/maintenanceUpdate/maintenanceScript.go
+++ b/cmd/maintenanceUpdate/maintenanceScript.go
@@ -1,0 +1,42 @@
+package maintenance
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/CanastaWiki/Canasta-CLI-Go/internal/canasta"
+	"github.com/CanastaWiki/Canasta-CLI-Go/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI-Go/internal/logging"
+	"github.com/CanastaWiki/Canasta-CLI-Go/internal/orchestrators"
+	"github.com/spf13/cobra"
+)
+
+func scriptCmdCreate() *cobra.Command {
+
+	scriptCmd := &cobra.Command{
+		Use:   `script "[scriptname.php] [args]"`,
+		Short: "Run maintenance scripts",
+		Args:  cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			instance, err = canasta.CheckCanastaId(instance)
+			return err
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			logging.SetVerbose(true)
+			runMaintenanceScript(instance, args[0])
+		},
+	}
+
+	if pwd, err = os.Getwd(); err != nil {
+		log.Fatal(err)
+	}
+	return scriptCmd
+}
+
+func runMaintenanceScript(instance config.Installation, script string) {
+	fmt.Println("Running maintenance script " + script)
+	orchestrators.Exec(instance.Path, instance.Orchestrator, "web", "php maintenance/"+script)
+	fmt.Println("Completed running maintenance script")
+
+}

--- a/cmd/maintenanceUpdate/maintenanceUpdate.go
+++ b/cmd/maintenanceUpdate/maintenanceUpdate.go
@@ -1,4 +1,4 @@
-package maintenanceupdate
+package maintenance
 
 import (
 	"fmt"
@@ -12,15 +12,10 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/orchestrators"
 )
 
-var (
-	instance config.Installation
-	pwd      string
-	err      error
-)
+func updateCmdCreate() *cobra.Command {
 
-func NewCmdCreate() *cobra.Command {
-	maintenanceCmd := &cobra.Command{
-		Use:   "maintenance",
+	updateCmd := &cobra.Command{
+		Use:   "update",
 		Short: "Run maintenance update jobs",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			instance, err = canasta.CheckCanastaId(instance)
@@ -34,9 +29,7 @@ func NewCmdCreate() *cobra.Command {
 	if pwd, err = os.Getwd(); err != nil {
 		log.Fatal(err)
 	}
-	maintenanceCmd.PersistentFlags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
-	maintenanceCmd.PersistentFlags().StringVarP(&instance.Path, "path", "p", pwd, "Canasta installation directory")
-	return maintenanceCmd
+	return updateCmd
 }
 
 func runMaintenanceUpdate(instance config.Installation) {


### PR DESCRIPTION
1. Move existing `maintenance` command to `maintenance update`.
2. Add `maintenance script` command to run any PHP scripts inside core MW maintenance/ directory. 

Fixes #43.