### PR TITLE
Add --install and --list-versions flags to install.sh.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -45,7 +45,7 @@ containsElement () {
 	return 1
 }
 download_package() {
-	if [[ "$1" =~ ^[0-9]+$ ]] && [[ "$1" < ${#versions[@]} ]]; then
+	if [[ "$1" =~ ^[0-9]$ ]] && [[ "$1" < ${#versions[@]} ]]; then
 			version=${versions[$1]}
 	elif containsElement "$1" "${versions[@]}"; then
 			version=${1:-latest}

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ is_command_available() {
 result=$(is_command_available git docker jq docker-compose)
 
 if [[ $? -ne 0 ]]; then
-    echo "${result} is not installed"
+    echo "${result} is not installed; exiting."
     exit 1
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -13,10 +13,10 @@ else
 fi
 
 loc=$(command -v docker)
-if [ -z $loc ]
+if [ -z "$loc" ]
 then
     echo "Docker is not installed; please follow the guide at https://docs.docker.com/engine/install/ to install it."
-elif [ -x $loc ]
+elif [ -x "$loc" ]
 then
     echo "Docker is already installed."
 else
@@ -24,10 +24,10 @@ else
 fi
 
 loc=$(command -v docker-compose)
-if [ -z $loc ]
+if [ -z "$loc" ]
 then
     echo "Docker Compose is not installed; please follow the guide at https://docs.docker.com/compose/install/ to install it."
-elif [ -x $loc ]
+elif [ -x "$loc" ]
 then
     echo "Docker Compose is already installed."
 else
@@ -42,7 +42,7 @@ repo="repos/CanastaWiki/Canasta-CLI/git/refs/tags"
 data=$(curl ${github_api}/${repo} 2>/dev/null)
 
 refs=$(jq -r '.. | select(.ref?) | .ref' <<< "${data}")
-versions=( $(cut -d '/' -f 3 <<< "${refs}" | sort -h | tac | head -n 5) )
+mapfile -t versions < <(cut -d '/' -f 3 <<< "${refs}" | sort -h | tac | head -n 5)
 
 get_versions() {
 	for index in "${!versions[@]}"; do
@@ -52,7 +52,7 @@ get_versions() {
 
 query_version() {
 	read -r -p "Pick a version (index): " choice # Read stdin and save the value on the $choice var
-	echo ${choice}
+	echo "${choice}"
 }
 download_package() {
 	version=${versions[${1}]}
@@ -61,26 +61,15 @@ download_package() {
 		wgetOptions=$(wget --help)
 		if [[ $wgetOptions == *"show-progress"* ]]
 		then
-		    wget -q --show-progress $canastaURL
+		    wget -q --show-progress "$canastaURL"
 		else
-		    wget -q $canastaURL
+		    wget -q "$canastaURL"
 		fi
-		echo "Installing ${version} Canasta CLI"
+		echo "Installing ${version:-latest} Canasta CLI"
 		chmod u=rwx,g=xr,o=x canasta
 		sudo mv canasta /usr/local/bin/canasta
 	else
-		canastaURL="https://github.com/CanastaWiki/Canasta-CLI/releases/download/latest/canasta"
-                wgetOptions=$(wget --help)
-                if [[ $wgetOptions == *"show-progress"* ]]
-                then
-                    wget -q --show-progress $canastaURL
-                else
-                    wget -q $canastaURL
-                fi
-                echo "Installing latest Canasta CLI"
-                chmod u=rwx,g=xr,o=x canasta
-		sudo mv canasta /usr/local/bin/Canasta
-		#echo "Invalid version"
+		echo "Invalid version"
 	fi
 }
 
@@ -91,12 +80,12 @@ while true; do
 			break
 			;;
 		-i|--install)
-			if [[ -n ${2} ]]; then
-				download_package ${2}
+			if [[ -n "${2}" ]]; then
+				download_package "${2}"
 				shift
 			else
 				get_versions
-				download_package $(query_version)
+				download_package "$(query_version)"
 			fi
 		        break	
 			;;

--- a/install.sh
+++ b/install.sh
@@ -26,12 +26,12 @@ repo="repos/CanastaWiki/Canasta-CLI/git/refs/tags"
 data=$(curl ${github_api}/${repo} 2>/dev/null)
 
 refs=$(jq -r '.. | select(.ref?) | .ref' <<< "${data}")
-mapfile -t versions < <(cut -d '/' -f 3 <<< "${refs}" | sort -h | tac | head -n 5)
+mapfile -t versions < <(echo "latest";cut -d '/' -f 3 <<< "${refs}" | sort -h | tac | head -n 5)
 
 get_versions() {
 	for index in "${!versions[@]}"; do
 	  echo "  $((index))) ${versions[$index]}"
-	done
+  	done
 }
 
 query_version() {
@@ -39,14 +39,14 @@ query_version() {
 	echo "${choice}"
 }
 download_package() {
-	if [[ $1 ]]; then
-		version=${versions[$1]}
-		if ! [[ $version ]]; then echo "Invalid version" >&2 ; exit 1; fi
-		canastaURL="https://github.com/CanastaWiki/Canasta-CLI/releases/download/$version/canasta"
-	else
-		version=latest
-		canastaURL="https://github.com/CanastaWiki/Canasta-CLI/releases/latest/download/canasta"
-    	fi
+        if [[ $1 -eq 0 ]]; then
+                version=latest
+                canastaURL="https://github.com/CanastaWiki/Canasta-CLI/releases/$version/download/canasta"
+             else
+                version=${versions[$1]}
+                   canastaURL="https://github.com/CanastaWiki/Canasta-CLI/releases/download/$version/canasta"
+        fi
+
 	wargs=(-q)
         if wget --help | grep -q -e --show-progress ; then
 		wargs+=(--show-progress)
@@ -55,7 +55,7 @@ download_package() {
 	wget "${wargs[@]}" "$canastaURL"
 	echo "Installing ${version} Canasta CLI"
 	chmod u=rwx,g=xr,o=x canasta
-        sudo mv canasta /usr/local/bin/canasta
+        mv canasta /usr/local/bin/canasta
  }
 while true; do
 	case "${1}" in

--- a/install.sh
+++ b/install.sh
@@ -39,14 +39,16 @@ query_version() {
 	echo "${choice}"
 }
 download_package() {
-        if [[ $1 -eq 0 ]]; then
-                version=latest
-                canastaURL="https://github.com/CanastaWiki/Canasta-CLI/releases/$version/download/canasta"
-             else
-                version=${versions[$1]}
-                   canastaURL="https://github.com/CanastaWiki/Canasta-CLI/releases/download/$version/canasta"
-        fi
-
+	if [[ $1 =~ '^[0-9]+$' ]]; then
+			version=${version_list[$1]}
+		else    
+		        version=${1:-latest}
+	fi
+	if [[ "$version" == latest ]]; then
+		canastaURL="https://github.com/CanastaWiki/Canasta-CLI/releases/$version/download/canasta"
+	else
+		canastaURL="https://github.com/CanastaWiki/Canasta-CLI/releases/download/$version/canasta"
+	fi
 	wargs=(-q)
         if wget --help | grep -q -e --show-progress ; then
 		wargs+=(--show-progress)

--- a/install.sh
+++ b/install.sh
@@ -46,7 +46,6 @@ containsElement () {
 }
 download_package() {
 	if [[ "$1" =~ ^[0-9]+$ ]] && [[ "$1" < ${#versions[@]} ]]; then
-	#if [[ "$1" =~ ^[0-9]+$ ]]; then
 			version=${versions[$1]}
 	elif containsElement "$1" "${versions[@]}"; then
 			version=${1:-latest}

--- a/install.sh
+++ b/install.sh
@@ -38,17 +38,29 @@ query_version() {
 	read -r -p "Pick a version (index): " choice # Read stdin and save the value on the $choice var
 	echo "${choice}"
 }
+containsElement () {
+	local e match="$1"
+	shift
+	for e; do [[ $e == "$match" ]] && return 0; done
+	return 1
+}
 download_package() {
-	if [[ $1 =~ '^[0-9]+$' ]]; then
-			version=${version_list[$1]}
-		else    
-		        version=${1:-latest}
+	if [[ "$1" =~ ^[0-9]+$ ]]; then
+			version=${versions[$1]}
+	elif containsElement "$1" "${versions[@]}"; then
+			version=${1:-latest}
+	elif [[ -z "$1" ]]; then
+		version=latest
+	else	
+		echo "Invalid version."
+		exit
 	fi
 	if [[ "$version" == latest ]]; then
 		canastaURL="https://github.com/CanastaWiki/Canasta-CLI/releases/$version/download/canasta"
 	else
 		canastaURL="https://github.com/CanastaWiki/Canasta-CLI/releases/download/$version/canasta"
 	fi
+
 	wargs=(-q)
         if wget --help | grep -q -e --show-progress ; then
 		wargs+=(--show-progress)
@@ -66,15 +78,17 @@ while true; do
 			break
 			;;
 		-i|--install)
-			if [[ -n "${2}" ]]; then
-				download_package "${2}"
-				shift
+			 if [[ -n "${2}" ]]; then
+                  	   		download_package "${2}"
+
 			else
 				get_versions
 				download_package "$(query_version)"
-			fi
-		        break	
-			;;
+			 fi
+			break
+
+                  	;;
+
 		-*)
 			die "Illegal option ${1}"
 			;;

--- a/install.sh
+++ b/install.sh
@@ -29,13 +29,14 @@ refs=$(jq -r '.. | select(.ref?) | .ref' <<< "${data}")
 mapfile -t versions < <(echo "latest";cut -d '/' -f 3 <<< "${refs}" | sort -h | tac | head -n 5)
 
 get_versions() {
+	echo "The following are the possible Canasta versions:"
 	for index in "${!versions[@]}"; do
 	  echo "  $((index))) ${versions[$index]}"
   	done
 }
 
 query_version() {
-	read -r -p "Pick a version by index or version: " choice # Read stdin and save the value on the $choice var
+	read -r -p "Pick a version using index or by name: " choice # Read stdin and save the value on the $choice var
 	echo "${choice}"
 }
 containsElement () {

--- a/install.sh
+++ b/install.sh
@@ -1,39 +1,23 @@
 #!/usr/bin/env bash
-unset choice canastaURL
+#unset choice canastaURL
 die() { echo "$*" >&2; exit 2; }  # complain to STDERR and exit with error
 needs_arg() { if [ -z "$OPTARG" ]; then die "No arg for --$OPT option"; fi; }
 
-git --version >/dev/null 2>&1
-GIT_IS_AVAILABLE=$?
-if [ $GIT_IS_AVAILABLE -ne 0 ]; 
-then echo "Git was not found, please install before continuing.";
-     exit; 
-else
-     echo "Git was found on the system"
-fi
+is_command_available() {
+    for cmd in "$@"; do
+        if [[ -z $(command -v ${cmd}) ]]; then
+            echo ${cmd}
+            return 1
+        fi
+    done
+}
 
-loc=$(command -v docker)
-if [ -z "$loc" ]
-then
-    echo "Docker is not installed; please follow the guide at https://docs.docker.com/engine/install/ to install it."
-elif [ -x "$loc" ]
-then
-    echo "Docker is already installed."
-else
-    echo "Docker appears to be installed at $loc but is not executable; please check permissions."
-fi
+result=$(is_command_available git docker jq docker-compose)
 
-loc=$(command -v docker-compose)
-if [ -z "$loc" ]
-then
-    echo "Docker Compose is not installed; please follow the guide at https://docs.docker.com/compose/install/ to install it."
-elif [ -x "$loc" ]
-then
-    echo "Docker Compose is already installed."
-else
-    echo "Docker Compose appears to be installed at $loc but is not executable; please check permissions."
+if [[ $? -ne 0 ]]; then
+    echo "${result} is not installed"
+    exit 1
 fi
-
 
 github_api="https://api.github.com"
 
@@ -92,7 +76,7 @@ while true; do
 		-*)
 			die "Illegal option ${1}"
 			;;
-		*) 		
+		*) 	
 			wget -q  --show-progress "https://github.com/CanastaWiki/Canasta-CLI/releases/latest/download/canasta"
 			echo "Installing latest Canasta CLI"
 	                chmod u=rwx,g=xr,o=x canasta

--- a/install.sh
+++ b/install.sh
@@ -35,7 +35,7 @@ get_versions() {
 }
 
 query_version() {
-	read -r -p "Pick a version (index): " choice # Read stdin and save the value on the $choice var
+	read -r -p "Pick a version by index or version: " choice # Read stdin and save the value on the $choice var
 	echo "${choice}"
 }
 containsElement () {
@@ -45,7 +45,8 @@ containsElement () {
 	return 1
 }
 download_package() {
-	if [[ "$1" =~ ^[0-9]+$ ]]; then
+	if [[ "$1" =~ ^[0-9]+$ ]] && [[ "$1" < ${#versions[@]} ]]; then
+	#if [[ "$1" =~ ^[0-9]+$ ]]; then
 			version=${versions[$1]}
 	elif containsElement "$1" "${versions[@]}"; then
 			version=${1:-latest}
@@ -65,7 +66,7 @@ download_package() {
         if wget --help | grep -q -e --show-progress ; then
 		wargs+=(--show-progress)
 	fi
-	echo "Downloading Canasta"
+	echo "Downloading Canasta ${version}"
 	wget "${wargs[@]}" "$canastaURL"
 	echo "Installing ${version} Canasta CLI"
 	chmod u=rwx,g=xr,o=x canasta
@@ -98,3 +99,4 @@ while true; do
 			;;
   esac
 done
+


### PR DESCRIPTION
Finds availability for git,jq,docker,docker-compose. Allows to install different versions based on the tags.
Added also when no no flag used it autoinstalls latest version.
Added flag "-l/--list-versions" to list the versions available.
Added flag "-i/--install", it also lists and installs the version we have available.