### PR TITLE
Fix flags when passing parameters to the create subcommand

### DIFF
--- a/internal/mediawiki/mediawiki.go
+++ b/internal/mediawiki/mediawiki.go
@@ -88,14 +88,15 @@ func prompt(value, prompt string) (string, error) {
 }
 
 func promptUserPassword(userValue, passwordValue string) (string, string, error) {
-	username, err := prompt(userValue, "admin name")
+	userPrompt, passwordPrompt := "admin name", "admin password"
+	username, err := prompt(userValue, userPrompt)
 	if err != nil {
 		return "", "", err
 	}
 	if passwordValue != "" {
 		return username, passwordValue, err
 	}
-	fmt.Printf("Enter the %s (Press Enter to autogenerate the password): \n", "admin password")
+	fmt.Printf("Enter the %s (Press Enter to autogenerate the password): \n", passwordPrompt)
 	pass, err := term.ReadPassword(0)
 	
 	if err != nil {
@@ -111,7 +112,7 @@ func promptUserPassword(userValue, passwordValue string) (string, string, error)
 		return "", "", err
 	}
 
-	fmt.Printf("Re-enter the %s: \n", "admin password")
+	fmt.Printf("Re-enter the %s: \n", passwordPrompt)
 	pass, err = term.ReadPassword(0)
 	if err != nil {
 		return "", "", err

--- a/internal/mediawiki/mediawiki.go
+++ b/internal/mediawiki/mediawiki.go
@@ -27,7 +27,7 @@ func PromptUser(canastaInfo canasta.CanastaVariables) (canasta.CanastaVariables,
 	if err != nil {
 		return canastaInfo, err
 	}
-	canastaInfo.AdminName, canastaInfo.AdminPassword, err = promptUserPassword(canastaInfo.AdminName, canastaInfo.AdminPassword, "admin name", "admin password")
+	canastaInfo.AdminName, canastaInfo.AdminPassword, err = promptUserPassword(canastaInfo.AdminName, canastaInfo.AdminPassword)
 	if err != nil {
 		return canastaInfo, err
 	}
@@ -87,15 +87,15 @@ func prompt(value, prompt string) (string, error) {
 	return input, nil
 }
 
-func promptUserPassword(userValue, passwordValue, userPrompt, passwordPrompt string) (string, string, error) {
-	username, err := prompt(userValue, userPrompt)
+func promptUserPassword(userValue, passwordValue string) (string, string, error) {
+	username, err := prompt(userValue, "admin name")
 	if err != nil {
 		return "", "", err
 	}
 	if passwordValue != "" {
 		return username, passwordValue, err
 	}
-	fmt.Printf("Enter the %s (Press Enter to autogenerate the password): \n", passwordPrompt)
+	fmt.Printf("Enter the %s (Press Enter to autogenerate the password): \n", "admin password")
 	pass, err := term.ReadPassword(0)
 	
 	if err != nil {
@@ -111,7 +111,7 @@ func promptUserPassword(userValue, passwordValue, userPrompt, passwordPrompt str
 		return "", "", err
 	}
 
-	fmt.Printf("Re-enter the %s: \n", passwordPrompt)
+	fmt.Printf("Re-enter the %s: \n", "admin password")
 	pass, err = term.ReadPassword(0)
 	if err != nil {
 		return "", "", err

--- a/internal/mediawiki/mediawiki.go
+++ b/internal/mediawiki/mediawiki.go
@@ -93,7 +93,7 @@ func promptUserPassword(userValue, passwordValue, userPrompt, passwordPrompt str
 		return "", "", err
 	}
 	if passwordValue != "" {
-		return userValue, passwordValue, err
+		return username, passwordValue, err
 	}
 	fmt.Printf("Enter the %s (Press Enter to autogenerate the password): \n", passwordPrompt)
 	pass, err := term.ReadPassword(0)

--- a/internal/mediawiki/mediawiki.go
+++ b/internal/mediawiki/mediawiki.go
@@ -93,7 +93,7 @@ func promptUserPassword(userValue, passwordValue, userPrompt, passwordPrompt str
 		return "", "", err
 	}
 	if passwordValue != "" {
-		return "", "", err
+		return username, "", err
 	}
 	fmt.Printf("Enter the %s (Press Enter to autogenerate the password): \n", passwordPrompt)
 	pass, err := term.ReadPassword(0)

--- a/internal/mediawiki/mediawiki.go
+++ b/internal/mediawiki/mediawiki.go
@@ -93,15 +93,16 @@ func promptUserPassword(userValue, passwordValue, userPrompt, passwordPrompt str
 		return "", "", err
 	}
 	if passwordValue != "" {
-		return username, "", err
+		return userValue, passwordValue, err
 	}
 	fmt.Printf("Enter the %s (Press Enter to autogenerate the password): \n", passwordPrompt)
 	pass, err := term.ReadPassword(0)
-	password := string(pass)
+	
 	if err != nil {
 		return "", "", err
 	}
-
+	password := string(pass)
+	
 	if password == "" {
 		return username, password, nil
 	}


### PR DESCRIPTION
Canasta-CLI subcommand wasn't setting the admin username properly, it came out empty.
The create subcommand run as (canasta create), allows to send some flags to it's subcommand such as:
-  "-a" (setting an admin username).
-  "-s" (setting a password).
It's possible setting those details by using:
- Run "canasta create", it will ask for the admin user and autogenerate a password that will be saved in the working path in an ".env" file.
- Run "canasta create -a admin", it will ask for a password or you can autogenerate one that will be saved in the working path in an ".env" file.
- Run "canasta create -s password", it will ask for an admin user of your choice and it won't save an ".env" file.