### PR TITLE
Added "canasta elasticsearch index" command

### DIFF
--- a/cmd/elasticsearch/elasticsearch.go
+++ b/cmd/elasticsearch/elasticsearch.go
@@ -1,0 +1,32 @@
+package elasticsearch
+
+import (
+	"log"
+	"os"
+
+	"github.com/CanastaWiki/Canasta-CLI-Go/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var (
+	instance config.Installation
+	pwd      string
+	err      error
+)
+
+func NewCmdCreate() *cobra.Command {
+	elasticsearchCmd := &cobra.Command{
+		Use:   "elasticsearch",
+		Short: "Manage Elasticsearch indices and clusters for Canasta",
+	}
+
+	elasticsearchCmd.AddCommand(indexCmdCreate())
+	if pwd, err = os.Getwd(); err != nil {
+		log.Fatal(err)
+	}
+
+	elasticsearchCmd.PersistentFlags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
+	elasticsearchCmd.PersistentFlags().StringVarP(&instance.Path, "path", "p", pwd, "Canasta installation directory")
+
+	return elasticsearchCmd
+}

--- a/cmd/elasticsearch/index.go
+++ b/cmd/elasticsearch/index.go
@@ -1,0 +1,34 @@
+package elasticsearch
+
+import (
+	"fmt"
+
+	"github.com/CanastaWiki/Canasta-CLI-Go/internal/canasta"
+	"github.com/CanastaWiki/Canasta-CLI-Go/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI-Go/internal/orchestrators"
+	"github.com/spf13/cobra"
+)
+
+// indexCmd represents the index command
+func indexCmdCreate() *cobra.Command {
+	var updateCmd = &cobra.Command{
+		Use:   "index",
+		Short: "Initialize search index for Canasta instance",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			instance, err = canasta.CheckCanastaId(instance)
+			return err
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			initializeIndex(instance)
+		},
+	}
+	return updateCmd
+}
+
+func initializeIndex(instance config.Installation) {
+	fmt.Println("Running search index initialization process...")
+	orchestrators.Exec(instance.Path, instance.Orchestrator, "web", "php extensions/CirrusSearch/maintenance/UpdateSearchIndexConfig.php --startOver")
+	orchestrators.Exec(instance.Path, instance.Orchestrator, "web", "php extensions/CirrusSearch/maintenance/ForceSearchIndex.php --skipLinks --indexOnSkip")
+	orchestrators.Exec(instance.Path, instance.Orchestrator, "web", "php extensions/CirrusSearch/maintenance/ForceSearchIndex.php --skipParse")
+	fmt.Println("Search index initialization completed")
+}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	createCmd "github.com/CanastaWiki/Canasta-CLI-Go/cmd/create"
 	deleteCmd "github.com/CanastaWiki/Canasta-CLI-Go/cmd/delete"
+	elasticCmd "github.com/CanastaWiki/Canasta-CLI-Go/cmd/elasticsearch"
 	extensionCmd "github.com/CanastaWiki/Canasta-CLI-Go/cmd/extension"
 	importCmd "github.com/CanastaWiki/Canasta-CLI-Go/cmd/import"
 	listCmd "github.com/CanastaWiki/Canasta-CLI-Go/cmd/list"
@@ -57,5 +58,6 @@ func init() {
 	rootCmd.AddCommand(startCmd.NewCmdCreate())
 	rootCmd.AddCommand(stopCmd.NewCmdCreate())
 	rootCmd.AddCommand(versionCmd.NewCmdCreate())
+	rootCmd.AddCommand(elasticCmd.NewCmdCreate())
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
 }


### PR DESCRIPTION
Fixes #41 
## Summary
This PR adds the canasta elasticsearch index command to the Canasta CLI, which allows users to easily initialize the search index for a Canasta instance. This new command will make it more convenient for users to set up and manage the Elasticsearch indices and clusters associated with their Canasta installations.

## Changes
Create a new elasticsearch package for managing Elasticsearch indices and clusters for Canasta.
Add indexCmdCreate() function in the elasticsearch package to create a new Cobra command for initializing the search index for a Canasta instance.
Add initializeIndex() function in the elasticsearch package to perform the actual index initialization process.
Add NewCmdCreate() function in the elasticsearch package to create a new Cobra command for managing Elasticsearch.
Update the root CLI command to include the new elasticsearch package and its commands.

## Test
Test the new command by following these steps:

Check out this branch and build the CLI tool.
Use an existing Canasta instance
Run the canasta elasticsearch index command with the appropriate flags
Verify that the search index initialization process completes successfully and the Elasticsearch indices and clusters are configured correctly.
![Screenshot from 2023-03-26 20-07-56](https://user-images.githubusercontent.com/116774313/227831303-1d4cb8df-50d3-400b-a104-a8eca7f46322.png)

Please let me know if you have any questions or concerns about the changes in this PR.