### PR TITLE
Fix issue #59: add support for compose v2 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,15 +44,12 @@ else
     echo "Docker appears to be installed at $loc but is not executable; please check permissions."
 fi
 
-loc=$(which docker-compose)
-if [ -z $loc ]
+if ! docker compose  version;
 then
-    echo "Docker Compose is not installed; please follow the guide at https://docs.docker.com/compose/install/ to install it."
-elif [ -x $loc ]
-then
-    echo "Checking for presence of Docker Compose... found."
+    echo "Docker Compose is not installed; please follow the guide at https://docs.docker.com/compose/install/ to install it.
+    Alternatively, set the Compose executable path in canasta CLI using \"canasta -d PATH\""
 else
-    echo "Docker Compose appears to be installed at $loc but is not executable; please check permissions."
+    echo "Checking for presence of Docker Compose... found."
 fi
 
 echo "Please make sure you have a working kubectl if you wish to use Kubernetes as an orchestrator."

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"os/exec"
 	"os/user"
 	"path"
 	"syscall"
@@ -19,7 +18,12 @@ type Installation struct {
 	Id, Path, Orchestrator string
 }
 
+type Orchestrator struct {
+	Id, Path string
+}
+
 type Canasta struct {
+	Orchestrators map[string]Orchestrator
 	Installations map[string]Installation
 }
 
@@ -35,6 +39,14 @@ func Exists(canastaId string) bool {
 		logging.Fatal(err)
 	}
 	return existingInstallations.Installations[canastaId].Id != ""
+}
+
+func OrchestratorExists(orchestrator string) bool {
+	err := read(&existingInstallations)
+	if err != nil {
+		logging.Fatal(err)
+	}
+	return existingInstallations.Orchestrators[orchestrator].Path != ""
 }
 
 func ListAll() {
@@ -73,6 +85,22 @@ func Add(details Installation) error {
 	}
 	err := write(existingInstallations)
 	return err
+}
+
+func AddOrchestrator(details Orchestrator) error {
+	if details.Id != "docker-compose" {
+		return fmt.Errorf("orchestrator %s is not suported", details.Id)
+	}
+	existingInstallations.Orchestrators[details.Id] = details
+	err := write(existingInstallations)
+	return err
+}
+
+func GetOrchestrator(orchestrator string) Orchestrator {
+	if OrchestratorExists(orchestrator) {
+		return existingInstallations.Orchestrators[orchestrator]
+	}
+	return Orchestrator{}
 }
 
 func Delete(canastaID string) error {
@@ -149,17 +177,12 @@ func init() {
 	directory = GetConfigDir()
 	confFile = path.Join(directory, confFile)
 
-	_, err := exec.LookPath("docker-compose")
-	if err != nil {
-		log.Fatal(fmt.Errorf("docker-compose should be installed! (%s)", err))
-	}
-
 	// Checks for the conf.json file
-	_, err = os.Stat(confFile)
+	_, err := os.Stat(confFile)
 	if os.IsNotExist(err) {
 		// Creating conf.json
 		log.Print("Creating " + confFile)
-		err := write(Canasta{Installations: map[string]Installation{}})
+		err := write(Canasta{Installations: map[string]Installation{}, Orchestrators: map[string]Orchestrator{}})
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,6 +88,9 @@ func Add(details Installation) error {
 }
 
 func AddOrchestrator(details Orchestrator) error {
+	if existingInstallations.Orchestrators == nil {
+		existingInstallations.Orchestrators = map[string]Orchestrator{}
+	}
 	if details.Id != "docker-compose" {
 		return fmt.Errorf("orchestrator %s is not suported", details.Id)
 	}

--- a/internal/orchestrators/orchestrators.go
+++ b/internal/orchestrators/orchestrators.go
@@ -101,7 +101,7 @@ func DeleteContainers(path, orchestrator string) (string, error) {
 			err, output := execute.Run(path, compose.Path, "down", "-v")
 			return output, err
 		} else {
-			err, output := execute.Run(path, "docker", "down", "-v")
+			err, output := execute.Run(path, "docker", "compose", "down", "-v")
 			return output, err
 		}
 	default:

--- a/internal/orchestrators/orchestrators.go
+++ b/internal/orchestrators/orchestrators.go
@@ -4,14 +4,25 @@ import (
 	"fmt"
 	"os/exec"
 
+	"github.com/CanastaWiki/Canasta-CLI-Go/internal/config"
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/execute"
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/logging"
 )
 
 func CheckDependencies() {
-	_, err := exec.LookPath("docker-compose")
-	if err != nil {
-		logging.Fatal(fmt.Errorf("docker-compose should be installed! (%s)", err))
+	compose := config.GetOrchestrator("docker-compose")
+	if compose.Path != "" {
+		cmd := exec.Command(compose.Path, "version")
+		err := cmd.Run()
+		if err != nil {
+			logging.Fatal(fmt.Errorf("unable to execute compose (%s) \n", err))
+		}
+	} else {
+		cmd := exec.Command("docker", "compose", "version")
+		err := cmd.Run()
+		if err != nil {
+			logging.Fatal(fmt.Errorf("docker compose should be installed! (%s) \n", err))
+		}
 	}
 }
 
@@ -30,9 +41,17 @@ func Start(path, orchestrator string) error {
 	logging.Print("Starting Canasta\n")
 	switch orchestrator {
 	case "docker-compose":
-		err, output := execute.Run(path, "docker-compose", "up", "-d")
-		if err != nil {
-			return fmt.Errorf(output)
+		compose := config.GetOrchestrator("docker-compose")
+		if compose.Path != "" {
+			err, output := execute.Run(path, compose.Path, "up", "-d")
+			if err != nil {
+				return fmt.Errorf(output)
+			}
+		} else {
+			err, output := execute.Run(path, "docker", "compose", "up", "-d")
+			if err != nil {
+				return fmt.Errorf(output)
+			}
 		}
 	default:
 		logging.Fatal(fmt.Errorf("orchestrator: %s is not available", orchestrator))
@@ -44,9 +63,18 @@ func Stop(path, orchestrator string) error {
 	logging.Print("Stopping the containers\n")
 	switch orchestrator {
 	case "docker-compose":
-		err, output := execute.Run(path, "docker-compose", "down")
-		if err != nil {
-			return fmt.Errorf(output)
+		compose := config.GetOrchestrator("docker-compose")
+		if compose.Path != "" {
+			err, output := execute.Run(path, compose.Path, "down")
+			if err != nil {
+				return fmt.Errorf(output)
+
+			}
+		} else {
+			err, output := execute.Run(path, "docker", "compose", "down")
+			if err != nil {
+				return fmt.Errorf(output)
+			}
 		}
 	default:
 		logging.Fatal(fmt.Errorf("orchestrator: %s is not available", orchestrator))
@@ -67,8 +95,15 @@ func StopAndStart(path, orchestrator string) error {
 func DeleteContainers(path, orchestrator string) (string, error) {
 	switch orchestrator {
 	case "docker-compose":
-		err, output := execute.Run(path, "docker-compose", "down", "-v")
-		return output, err
+		compose := config.GetOrchestrator("docker-compose")
+		if compose.Path != "" {
+
+			err, output := execute.Run(path, compose.Path, "down", "-v")
+			return output, err
+		} else {
+			err, output := execute.Run(path, "docker", "down", "-v")
+			return output, err
+		}
 	default:
 		logging.Fatal(fmt.Errorf("orchestrator: %s is not available", orchestrator))
 	}
@@ -87,11 +122,21 @@ func ExecWithError(path, orchestrator, container, command string) (string, error
 
 	switch orchestrator {
 	case "docker-compose":
-		cmd := exec.Command("docker-compose", "exec", "-T", container, "/bin/bash", "-c", command)
-		if path != "" {
-			cmd.Dir = path
+		compose := config.GetOrchestrator("docker-compose")
+		if compose.Path != "" {
+
+			cmd := exec.Command(compose.Path, "exec", "-T", container, "/bin/bash", "-c", command)
+			if path != "" {
+				cmd.Dir = path
+			}
+			outputByte, err = cmd.CombinedOutput()
+		} else {
+			cmd := exec.Command("docker", "compose", "exec", "-T", container, "/bin/bash", "-c", command)
+			if path != "" {
+				cmd.Dir = path
+			}
+			outputByte, err = cmd.CombinedOutput()
 		}
-		outputByte, err = cmd.CombinedOutput()
 	default:
 		logging.Fatal(fmt.Errorf("orchestrator: %s is not available", orchestrator))
 	}


### PR DESCRIPTION

This PR addresses issue #59 by adding support for Docker [Compose v2](https://docs.docker.com/compose/compose-v2/), as well as an option to specify the path to the compose binary, as discussed in issue #21.

## Changes:
- Implemented support for Docker Compose v2, the CLI now uses the `docker compose` command.
- Added a new option to allow users to specify the path to the compose executable with the `-d` or `docker-path` flag.
- `docker-compose` is no longer supported. However, users can now supply the path to the executable as described above to continue using the `docker-compose` binary
## Testing
I have tested the changes by 
1. Running on a standard installation with `docker compose`
2. Running using by using a compose executable specified by the `-d` flag
3. Running with an existing config from the previous CLI installation

![VirtualBoxVM_04-12-23(23-19-922)](https://user-images.githubusercontent.com/96643110/231662770-6b4e7dc4-91f7-4ee9-947e-105ba9d2778d.png)

Structure of the new config file 
``` json
{
        "Orchestrators": {
                "docker-compose": {
                        "Id": "docker-compose",
                        "Path": "/home/d3bug/gsoc/docker-compose-linux-x86_64"
                }
        },
        "Installations": {
                "testID": {
                        "Id": "testID",
                        "Path": "/home/d3bug/gsoc/main/Canasta-CLI/testID",
                        "Orchestrator": "docker-compose"
                }
        }
}
```
