### PR TITLE
Allow modification to default composer installed extensions

### DIFF
--- a/internal/orchestrators/orchestrators.go
+++ b/internal/orchestrators/orchestrators.go
@@ -59,6 +59,29 @@ func CopyOverrideFile(path, orchestrator, sourceFilename, pwd string) error {
 	return nil
 }
 
+func CopyComposerFile(path, orchestrator, sourceFilename, pwd string) error {
+	logging.Print("Copying composer.local.json file\n")
+	switch orchestrator {
+	case "docker-compose":
+		if sourceFilename != "" {
+			if !strings.HasPrefix(sourceFilename, "/") {
+				sourceFilename = pwd + "/" + sourceFilename
+			}
+		} else {
+			sourceFilename = path + "/config/composer.local.default.json"
+		}
+		var composerFilename = path + "/config/composer.local.json"
+			logging.Print(fmt.Sprintf("Copying %s to %s\n", sourceFilename, composerFilename))
+		err, output := execute.Run("", "cp", sourceFilename, composerFilename)
+		if err != nil {
+			logging.Fatal(fmt.Errorf(output))
+		}
+	default:
+		logging.Fatal(fmt.Errorf("orchestrator: %s is not available", orchestrator))
+	}
+	return nil
+}
+
 func Start(path, orchestrator string) error {
 	logging.Print("Starting Canasta\n")
 	switch orchestrator {

--- a/internal/orchestrators/orchestrators.go
+++ b/internal/orchestrators/orchestrators.go
@@ -60,24 +60,29 @@ func CopyOverrideFile(path, orchestrator, sourceFilename, pwd string) error {
 }
 
 func CopyComposerFile(path, orchestrator, sourceFilename, pwd string) error {
-	logging.Print("Copying composer.local.json file\n")
-	switch orchestrator {
-	case "docker-compose":
-		if sourceFilename != "" {
+	if sourceFilename != "" {
+		logging.Print("Copying composer.local.json file\n")
+		switch orchestrator {
+		case "docker-compose":
 			if !strings.HasPrefix(sourceFilename, "/") {
 				sourceFilename = pwd + "/" + sourceFilename
 			}
-		} else {
-			sourceFilename = path + "/config/composer.local.default.json"
+			var composerFilename = path + "/config/composer.local.json"
+			var backupFilename = path + "/config/composer.local.default.json"
+			logging.Print(fmt.Sprintf("Moving %s to %s\n", composerFilename, backupFilename))
+			err, output := execute.Run("", "mv", composerFilename, backupFilename)
+			if err != nil {
+				logging.Fatal(fmt.Errorf(output))
+			} else {
+				logging.Print(fmt.Sprintf("Copying %s to %s\n", sourceFilename, composerFilename))
+				err, output := execute.Run("", "cp", sourceFilename, composerFilename)
+				if err != nil {
+					logging.Fatal(fmt.Errorf(output))
+				}
+			}
+		default:
+			logging.Fatal(fmt.Errorf("orchestrator: %s is not available", orchestrator))
 		}
-		var composerFilename = path + "/config/composer.local.json"
-			logging.Print(fmt.Sprintf("Copying %s to %s\n", sourceFilename, composerFilename))
-		err, output := execute.Run("", "cp", sourceFilename, composerFilename)
-		if err != nil {
-			logging.Fatal(fmt.Errorf(output))
-		}
-	default:
-		logging.Fatal(fmt.Errorf("orchestrator: %s is not available", orchestrator))
 	}
 	return nil
 }


### PR DESCRIPTION
Move composer installed extensions to volumed in composer.local.json file.
Add support for specifying an alternative composer.local.json file at create/import time.

Optionally extends CanastaWiki/Canasta#270 and CanastaWiki/Canasta-DockerCompose#47
Should only be merged if the other two pull requests are merged first.