### PR TITLE
Only enable Vector skin by default

### DIFF
--- a/internal/mediawiki/mediawiki.go
+++ b/internal/mediawiki/mediawiki.go
@@ -63,7 +63,7 @@ func Install(path, orchestrator string, canastaInfo canasta.CanastaVariables) (c
 		}
 	}
 
-	command = fmt.Sprintf("php maintenance/install.php --dbserver=%s  --confpath=%s --scriptpath=%s	--server='https://%s' --dbuser='%s' --dbpass='%s' --pass='%s' '%s' '%s'",
+	command = fmt.Sprintf("php maintenance/install.php --skins='Vector' --dbserver=%s  --confpath=%s --scriptpath=%s	--server='https://%s' --dbuser='%s' --dbpass='%s' --pass='%s' '%s' '%s'",
 		dbServer, confPath, scriptPath, canastaInfo.DomainName, "root", envVariables["MYSQL_PASSWORD"], canastaInfo.AdminPassword, canastaInfo.WikiName, canastaInfo.AdminName)
 
 	output, err = orchestrators.ExecWithError(path, orchestrator, "web", command)


### PR DESCRIPTION
Partially fixes #85 

This patch makes it so the installer only enables the Vector skin, not all of the other installed skins. It isn't possible to get the installer to enable zero skins, but this is at least a bit of an improvement.