### PR TITLE
Improve compatibility with Docker Compose v2

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -57,7 +57,7 @@ func NewCmdCreate() *cobra.Command {
 	}
 
 	createCmd.Flags().StringVarP(&path, "path", "p", pwd, "Canasta directory")
-	createCmd.Flags().StringVarP(&orchestrator, "orchestrator", "o", "docker-compose", "Orchestrator to use for installation")
+	createCmd.Flags().StringVarP(&orchestrator, "orchestrator", "o", "compose", "Orchestrator to use for installation")
 	createCmd.Flags().StringVarP(&canastaInfo.Id, "id", "i", "", "Canasta instance ID")
 	createCmd.Flags().StringVarP(&canastaInfo.WikiName, "wiki", "w", "", "Name of wiki")
 	createCmd.Flags().StringVarP(&canastaInfo.DomainName, "domain-name", "n", "localhost", "Domain name")

--- a/cmd/import/importExisting.go
+++ b/cmd/import/importExisting.go
@@ -60,7 +60,7 @@ func NewCmdCreate() *cobra.Command {
 	}
 
 	importCmd.Flags().StringVarP(&path, "path", "p", pwd, "Canasta directory")
-	importCmd.Flags().StringVarP(&orchestrator, "orchestrator", "o", "docker-compose", "Orchestrator to use for installation")
+	importCmd.Flags().StringVarP(&orchestrator, "orchestrator", "o", "compose", "Orchestrator to use for installation")
 	importCmd.Flags().StringVarP(&canastaId, "id", "i", "", "Canasta instance ID")
 	importCmd.Flags().StringVarP(&domainName, "domain-name", "n", "localhost", "Domain name")
 	importCmd.Flags().StringVarP(&databasePath, "database", "d", "", "Path to the existing database dump")

--- a/cmd/restart/restart.go
+++ b/cmd/restart/restart.go
@@ -38,7 +38,7 @@ func NewCmdCreate() *cobra.Command {
 	}
 	restartCmd.Flags().StringVarP(&instance.Path, "path", "p", pwd, "Canasta installation directory")
 	restartCmd.Flags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
-	restartCmd.Flags().StringVarP(&instance.Orchestrator, "orchestrator", "o", "docker-compose", "Orchestrator to use for installation")
+	restartCmd.Flags().StringVarP(&instance.Orchestrator, "orchestrator", "o", "compose", "Orchestrator to use for installation")
 	restartCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Verbose Output")
 	return restartCmd
 }

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"path/filepath"
+
 	createCmd "github.com/CanastaWiki/Canasta-CLI-Go/cmd/create"
 	deleteCmd "github.com/CanastaWiki/Canasta-CLI-Go/cmd/delete"
 	extensionCmd "github.com/CanastaWiki/Canasta-CLI-Go/cmd/extension"
@@ -18,7 +20,6 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/orchestrators"
 	"github.com/spf13/cobra"
-	"path/filepath"
 )
 
 var (
@@ -41,7 +42,7 @@ var rootCmd = &cobra.Command{
 				logging.Fatal(err)
 			}
 			var orchestrator = config.Orchestrator{
-				Id:   "docker-compose",
+				Id:   "compose",
 				Path: OrchestratorPath}
 			err = config.AddOrchestrator(orchestrator)
 			if err != nil {
@@ -62,7 +63,7 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")
-	rootCmd.Flags().StringVarP(&OrchestratorPath, "docker-path", "d", "", "path to docker-compose")
+	rootCmd.Flags().StringVarP(&OrchestratorPath, "docker-path", "d", "", "path to docker")
 
 	rootCmd.AddCommand(createCmd.NewCmdCreate())
 	rootCmd.AddCommand(deleteCmd.NewCmdCreate())

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -39,7 +39,7 @@ func NewCmdCreate() *cobra.Command {
 	}
 	startCmd.Flags().StringVarP(&instance.Path, "path", "p", pwd, "Canasta installation directory")
 	startCmd.Flags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
-	startCmd.Flags().StringVarP(&instance.Orchestrator, "orchestrator", "o", "docker-compose", "Orchestrator to use for installation")
+	startCmd.Flags().StringVarP(&instance.Orchestrator, "orchestrator", "o", "compose", "Orchestrator to use for installation")
 	return startCmd
 }
 

--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -35,7 +35,7 @@ func NewCmdCreate() *cobra.Command {
 	}
 	stopCmd.Flags().StringVarP(&instance.Path, "path", "p", pwd, "Canasta installation directory")
 	stopCmd.Flags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
-	stopCmd.Flags().StringVarP(&instance.Orchestrator, "orchestrator", "o", "docker-compose", "Orchestrator to use for installation")
+	stopCmd.Flags().StringVarP(&instance.Orchestrator, "orchestrator", "o", "compose", "Orchestrator to use for installation")
 	return stopCmd
 }
 

--- a/install.sh
+++ b/install.sh
@@ -44,12 +44,16 @@ else
     echo "Docker appears to be installed at $loc but is not executable; please check permissions."
 fi
 
-if ! docker compose  version;
-then
-    echo "Docker Compose is not installed; please follow the guide at https://docs.docker.com/compose/install/ to install it.
-    Alternatively, set the Compose executable path in canasta CLI using \"canasta -d PATH\""
+# Canasta only supports Compose V2
+# Since July 2023 Compose V1 stopped receiving updates. It is also no longer available in new releases of Docker Desktop.
+if ! docker compose version >/dev/null 2>&1; then
+  echo "Docker Compose V2 is not installed"
+  echo "Please follow the guide at https://docs.docker.com/compose/install/ to install it."
+  echo "It is recommended to use the official Docker repositories."
+  echo "Alternatively, set the Compose executable path in canasta CLI using \"canasta -d PATH\" but note that Compose V1 is NOT supported."
+  exit 1
 else
-    echo "Checking for presence of Docker Compose... found."
+    echo "Checking for presence of Docker Compose V2... found."
 fi
 
 echo "Please make sure you have a working kubectl if you wish to use Kubernetes as an orchestrator."

--- a/install.sh
+++ b/install.sh
@@ -4,24 +4,9 @@
 
 # This script downloads and installs the Canasta command-line interface (CLI), which is
 # an executable called "canasta".
-# It also checks for the presence of Git, Docker and Docker Compose, and displays a
-# warning to the user if they are not correctly installed, although it installs the CLI
-# regardless.
 
-echo "Downloading Canasta CLI latest release..."
-canastaURL="https://github.com/CanastaWiki/Canasta-CLI/releases/latest/download/canasta"
-# The show-progress param was added to wget in version 1.16 (October 2014).
-wgetOptions=$(wget --help)
-if [[ $wgetOptions == *"show-progress"* ]]
-then
-  wget -q --show-progress $canastaURL
-else
-  wget -q $canastaURL
-fi
-
-echo "Download was successful; now installing Canasta CLI."
-chmod u=rwx,g=xr,o=x canasta
-sudo mv canasta /usr/local/bin/canasta
+# First it checks for the prerequisites of Git, Docker and Docker Compose, displaying a
+# warning to the user if they are not correctly installed; exiting the installer.
 
 # Check if Git is installed; exit if not.
 git --version 2>&1 >/dev/null
@@ -55,6 +40,21 @@ if ! docker compose version >/dev/null 2>&1; then
 else
     echo "Checking for presence of Docker Compose V2... found."
 fi
+
+echo "Downloading Canasta CLI latest release..."
+canastaURL="https://github.com/CanastaWiki/Canasta-CLI/releases/latest/download/canasta"
+# The show-progress param was added to wget in version 1.16 (October 2014).
+wgetOptions=$(wget --help)
+if [[ $wgetOptions == *"show-progress"* ]]
+then
+  wget -q --show-progress $canastaURL
+else
+  wget -q $canastaURL
+fi
+
+echo "Download was successful; now installing Canasta CLI."
+chmod u=rwx,g=xr,o=x canasta
+sudo mv canasta /usr/local/bin/canasta
 
 echo "Please make sure you have a working kubectl if you wish to use Kubernetes as an orchestrator."
 echo -e "\nUsage: sudo canasta [COMMAND] [ARGUMENTS...]"

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -21,7 +21,7 @@ type CanastaVariables struct {
 	AdminName     string
 }
 
-// CloneStackRepo accept the orchestrator from the cli and pass the corresponding reopository link
+// CloneStackRepo accept the orchestrator from the cli and pass the corresponding repository link
 // and clones the repo to a new folder in the specified path
 func CloneStackRepo(orchestrator, canastaId string, path *string) error {
 	*path += "/" + canastaId

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,7 +91,7 @@ func AddOrchestrator(details Orchestrator) error {
 	if existingInstallations.Orchestrators == nil {
 		existingInstallations.Orchestrators = map[string]Orchestrator{}
 	}
-	if details.Id != "docker-compose" {
+	if details.Id != "compose" {
 		return fmt.Errorf("orchestrator %s is not suported", details.Id)
 	}
 	existingInstallations.Orchestrators[details.Id] = details

--- a/internal/orchestrators/orchestrators.go
+++ b/internal/orchestrators/orchestrators.go
@@ -11,7 +11,7 @@ import (
 )
 
 func CheckDependencies() {
-	compose := config.GetOrchestrator("docker-compose")
+	compose := config.GetOrchestrator("compose")
 	if compose.Path != "" {
 		cmd := exec.Command(compose.Path, "version")
 		err := cmd.Run()
@@ -30,7 +30,7 @@ func CheckDependencies() {
 func GetRepoLink(orchestrator string) string {
 	var repo string
 	switch orchestrator {
-	case "docker-compose":
+	case "compose":
 		repo = "https://github.com/CanastaWiki/Canasta-DockerCompose.git"
 	default:
 		logging.Fatal(fmt.Errorf("orchestrator: %s is not available", orchestrator))
@@ -42,7 +42,7 @@ func CopyOverrideFile(path, orchestrator, sourceFilename, pwd string) error {
 	if sourceFilename != "" {
 		logging.Print("Copying override file\n")
 		switch orchestrator {
-		case "docker-compose":
+		case "compose":
 			if !strings.HasPrefix(sourceFilename, "/") {
 				sourceFilename = pwd + "/" + sourceFilename
 			}
@@ -62,8 +62,8 @@ func CopyOverrideFile(path, orchestrator, sourceFilename, pwd string) error {
 func Start(path, orchestrator string) error {
 	logging.Print("Starting Canasta\n")
 	switch orchestrator {
-	case "docker-compose":
-		compose := config.GetOrchestrator("docker-compose")
+	case "compose":
+		compose := config.GetOrchestrator("compose")
 		if compose.Path != "" {
 			err, output := execute.Run(path, compose.Path, "up", "-d")
 			if err != nil {
@@ -84,8 +84,8 @@ func Start(path, orchestrator string) error {
 func Stop(path, orchestrator string) error {
 	logging.Print("Stopping the containers\n")
 	switch orchestrator {
-	case "docker-compose":
-		compose := config.GetOrchestrator("docker-compose")
+	case "compose":
+		compose := config.GetOrchestrator("compose")
 		if compose.Path != "" {
 			err, output := execute.Run(path, compose.Path, "down")
 			if err != nil {
@@ -116,8 +116,8 @@ func StopAndStart(path, orchestrator string) error {
 
 func DeleteContainers(path, orchestrator string) (string, error) {
 	switch orchestrator {
-	case "docker-compose":
-		compose := config.GetOrchestrator("docker-compose")
+	case "compose":
+		compose := config.GetOrchestrator("compose")
 		if compose.Path != "" {
 
 			err, output := execute.Run(path, compose.Path, "down", "-v")
@@ -143,8 +143,8 @@ func ExecWithError(path, orchestrator, container, command string) (string, error
 	var err error
 
 	switch orchestrator {
-	case "docker-compose":
-		compose := config.GetOrchestrator("docker-compose")
+	case "compose":
+		compose := config.GetOrchestrator("compose")
 		if compose.Path != "" {
 
 			cmd := exec.Command(compose.Path, "exec", "-T", container, "/bin/bash", "-c", command)


### PR DESCRIPTION
To improve how the Canasta CLI checks for dependencies during the installation of the canasta binary, I made the checks come first in the install.sh script. If any dependencies are not met, the script exits with instructions.

Only if the checks are satisfied will the binary be placed on the system.

To avoid confusion with the now deprecated 'docker-compose' binary (docker compose is now a plugin vs. a standalone binary), I renamed the "Docker Compose" orchestrator for Canasta to just 'compose' in the Go files.