### PR TITLE
Allow root DB password and wiki DB username and password to be changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ sudo canasta create [flags]
 - `-f, --yamlfile`: Initial wiki yaml file for wiki farm setup.
 - `-k, --keep-config`: Keep the config files on installation failure.
 - `-r, --override`: Name of a file to copy to docker-compose.override.yml.
-- `--rootdbpass`: Prompt for the password for the root database user (default: "mediawiki").
-- `--wikidbuser`: The database user to use for normal operations (default: "root").
-- `--wikidbpass`: Prompt for the password for the database user to use for normal operations (default: "mediawiki").
+- `--rootdbpass`: Read root database user password from .root-db-password file or prompt for it if file does not exist (default password: "mediawiki").
+- `--wikidbuser`: The username of the wiki database user (default: "root").
+- `--wikidbpass`: Read wiki database user password from .wiki-db-password file or prompt for it if file does not exist (default password: "mediawiki").
 
 **YAML Format for Wiki Farm:**
 To create a wiki farm, you first need to create a YAML file with the following format:
@@ -83,6 +83,9 @@ sudo canasta add [flags]
 - `-i, --id`: Canasta instance ID.
 - `-o, --orchestrator`: Orchestrator to use for installation (default: "docker-compose").
 - `-d, --database`: Path to the existing database dump.
+- `-a, --admin`: Admin name of the new wiki.
+- `--wikidbuser`: The username of the wiki database user (default: "root").
+
 
 ### remove
 **Description:** Removes a wiki from a Canasta instance.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ sudo canasta create [flags]
 - `-s, --password`: Initial wiki admin password.
 - `-f, --yamlfile`: Initial wiki yaml file for wiki farm setup.
 - `-k, --keep-config`: Keep the config files on installation failure.
+- `-r, --override`: Name of a file to copy to docker-compose.override.yml.
+- `--rootdbpass`: Prompt for the password for the root database user (default: "mediawiki").
+- `--wikidbuser`: The database user to use for normal operations (default: "root").
+- `--wikidbpass`: Prompt for the password for the database user to use for normal operations (default: "mediawiki").
 
 **YAML Format for Wiki Farm:**
 To create a wiki farm, you first need to create a YAML file with the following format:

--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -59,7 +59,7 @@ func NewCmdCreate() *cobra.Command {
 	addCmd.Flags().StringVarP(&instance.Orchestrator, "orchestrator", "o", "docker-compose", "Orchestrator to use for installation")
 	addCmd.Flags().StringVarP(&databasePath, "database", "d", "", "Path to the existing database dump")
 	addCmd.Flags().StringVarP(&admin, "admin", "a", "", "Admin name of the new wiki")
-	addCmd.Flags().StringVar(&wikidbuser, "wikidbuser", "root", "The database user to use for normal operations (default: \"root\")")
+	addCmd.Flags().StringVar(&wikidbuser, "wikidbuser", "root", "The username of the wiki database user (default: \"root\")")
 	return addCmd
 }
 

--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -25,6 +25,7 @@ func NewCmdCreate() *cobra.Command {
 	var databasePath string
 	var url string
 	var admin string
+	var wikidbuser string
 
 	addCmd := &cobra.Command{
 		Use:   "add",
@@ -36,7 +37,7 @@ func NewCmdCreate() *cobra.Command {
 				log.Fatal(err)
 			}
 			fmt.Printf("Adding wiki '%s' to Canasta instance '%s'...\n", wikiName, instance.Id)
-			err = AddWiki(wikiName, domainName, wikiPath, siteName, databasePath, admin, instance)
+			err = AddWiki(wikiName, domainName, wikiPath, siteName, databasePath, admin, wikidbuser, instance)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -58,11 +59,12 @@ func NewCmdCreate() *cobra.Command {
 	addCmd.Flags().StringVarP(&instance.Orchestrator, "orchestrator", "o", "docker-compose", "Orchestrator to use for installation")
 	addCmd.Flags().StringVarP(&databasePath, "database", "d", "", "Path to the existing database dump")
 	addCmd.Flags().StringVarP(&admin, "admin", "a", "", "Admin name of the new wiki")
+	addCmd.Flags().StringVar(&wikidbuser, "wikidbuser", "root", "The database user to use for normal operations (default: \"root\")")
 	return addCmd
 }
 
 // addWiki accepts the Canasta instance ID, the name, domain and path of the new wiki, and the initial admin info, then creates a new wiki in the instance.
-func AddWiki(name, domain, wikipath, siteName, databasePath, admin string, instance config.Installation) error {
+func AddWiki(name, domain, wikipath, siteName, databasePath, admin, wikidbuser string, instance config.Installation) error {
 	var err error
 
 	//Checking Installation existence
@@ -121,7 +123,7 @@ func AddWiki(name, domain, wikipath, siteName, databasePath, admin string, insta
 		return err
 	}
 
-	err = mediawiki.InstallOne(instance.Path, name, domain, wikipath, admin,instance.Orchestrator)
+	err = mediawiki.InstallOne(instance.Path, name, domain, admin, wikidbuser, instance.Orchestrator)
 	if err != nil {
 		return err
 	}

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -93,6 +93,9 @@ func createCanasta(canastaInfo canasta.CanastaVariables, pwd, path, name, domain
 	if err := canasta.CopyYaml(yamlPath, path); err != nil {
 		return err
 	}
+	if err := canasta.GetPasswords(path, canastaInfo); err != nil {
+		return err
+	}
 	if err := canasta.CopyEnv("", path, pwd, canastaInfo.RootDBPassword); err != nil {
 		return err
 	}

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -28,13 +28,15 @@ func NewCmdCreate() *cobra.Command {
 		keepConfig   bool
 		canastaInfo  canasta.CanastaVariables
 		override     string
+		rootdbpass   bool
+		wikidbpass   bool
 	)
 	createCmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a Canasta installation",
 		Long:  "Creates a Canasta installation using an orchestrator of your choice.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if name, canastaInfo, err = prompt.PromptUser(name, yamlPath, canastaInfo); err != nil {
+			if name, canastaInfo, err = prompt.PromptUser(name, yamlPath, rootdbpass, wikidbpass, canastaInfo); err != nil {
 				log.Fatal(err)
 			}
 			fmt.Println("Creating Canasta installation '" + canastaInfo.Id + "'...")
@@ -71,6 +73,9 @@ func NewCmdCreate() *cobra.Command {
 	createCmd.Flags().StringVarP(&yamlPath, "yamlfile", "f", "", "Initial wiki yaml file")
 	createCmd.Flags().BoolVarP(&keepConfig, "keep-config", "k", false, "Keep the config files on installation failure")
 	createCmd.Flags().StringVarP(&override, "override", "r", "", "Name of a file to copy to docker-compose.override.yml")
+	createCmd.Flags().BoolVar(&rootdbpass, "rootdbpass", false, "Prompt for the password for the root database user (default: \"mediawiki\")")
+	createCmd.Flags().StringVar(&canastaInfo.WikiDBUsername, "wikidbuser", "root", "The database user to use for normal operations (default: \"root\")")
+	createCmd.Flags().BoolVar(&wikidbpass, "wikidbpass", false, "Prompt for the password for the database user to use for normal operations (default: \"mediawiki\")")
 	return createCmd
 }
 
@@ -88,7 +93,7 @@ func createCanasta(canastaInfo canasta.CanastaVariables, pwd, path, name, domain
 	if err := canasta.CopyYaml(yamlPath, path); err != nil {
 		return err
 	}
-	if err := canasta.CopyEnv("", path, pwd); err != nil {
+	if err := canasta.CopyEnv("", path, pwd, canastaInfo.RootDBPassword); err != nil {
 		return err
 	}
 	if err := canasta.CopySettings(path); err != nil {

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -39,7 +39,7 @@ func NewCmdCreate() *cobra.Command {
 			if name, canastaInfo, err = prompt.PromptUser(name, yamlPath, rootdbpass, wikidbpass, canastaInfo); err != nil {
 				log.Fatal(err)
 			}
-			if canastaInfo, err = mediawiki.GeneratePasswords(path, canastaInfo); err != nil {
+			if canastaInfo, err = canasta.GeneratePasswords(path, canastaInfo); err != nil {
 				log.Fatal(err)
 			}
 			fmt.Println("Creating Canasta installation '" + canastaInfo.Id + "'...")

--- a/cmd/import/importExisting.go
+++ b/cmd/import/importExisting.go
@@ -80,7 +80,7 @@ func importCanasta(pwd, canastaId, domainName, path, orchestrator, databasePath,
 	if err := canasta.CloneStackRepo(orchestrator, canastaId, &path); err != nil {
 		return err
 	}
-	if err := canasta.CopyEnv(envPath, path, pwd); err != nil {
+	if err := canasta.CopyEnv(envPath, path, pwd, ""); err != nil {
 		return err
 	}
 	if err := canasta.CopyDatabase(databasePath, path, pwd); err != nil {

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -17,9 +17,12 @@ import (
 )
 
 type CanastaVariables struct {
-	Id            string
-	AdminPassword string
-	AdminName     string
+	Id             string
+	AdminPassword  string
+	AdminName      string
+	RootDBPassword string
+	WikiDBUsername string
+	WikiDBPassword string
 }
 
 // CloneStackRepo() accepts the orchestrator from the CLI,
@@ -36,7 +39,7 @@ func CloneStackRepo(orchestrator, canastaId string, path *string) error {
 // if envPath is passed as argument,
 // copies the file located at envPath to the installation directory
 // else copies .env.example to .env in the installation directory
-func CopyEnv(envPath, path, pwd string) error {
+func CopyEnv(envPath, path, pwd, rootDBpass string) error {
 	yamlPath := path + "/config/wikis.yaml"
 
 	if envPath == "" {
@@ -58,6 +61,11 @@ func CopyEnv(envPath, path, pwd string) error {
 	}
 	if err := SaveEnvVariable(path+"/.env", "MW_SITE_FQDN", domainNames[0]); err != nil {
 		return err
+	}
+	if rootDBpass != "" {
+		if err := SaveEnvVariable(path+"/.env", "MYSQL_ROOT_PASSWORD", rootDBpass); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -309,13 +309,13 @@ func GetOrGenerateAndSavePassword(pwd, path, prompt, filename string) (string, e
 		fmt.Printf("Retrieved %s password from %s/%s\n", prompt, path, filename)
 		return pwd, nil
 	}
-	pwd, err = password.Generate(12, 2, 4, false, true)
+	pwd, err = password.Generate(30, 4, 6, false, true)
 	if err != nil {
 		return "", err
 	}
 	// dollar signs in the root DB password break the installer
 	// https://phabricator.wikimedia.org/T355013
-	strings.ReplaceAll(pwd, "$", "#")
+	pwd = strings.ReplaceAll(pwd, "$", "#")
 	fmt.Printf("Saving %s password to %s/%s\n", prompt, path, filename)
 	file, err := os.Create(path + "/" + filename)
 	if err != nil {

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -64,7 +64,8 @@ func CopyEnv(envPath, path, pwd, rootDBpass string) error {
 		return err
 	}
 	if rootDBpass != "" {
-		if err := SaveEnvVariable(path+"/.env", "MYSQL_PASSWORD", rootDBpass); err != nil {
+		pass := "\"" + strings.ReplaceAll(rootDBpass, "\"", "\\\"") + "\""
+		if err := SaveEnvVariable(path+"/.env", "MYSQL_PASSWORD", pass); err != nil {
 			return err
 		}
 	}

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -63,7 +63,7 @@ func CopyEnv(envPath, path, pwd, rootDBpass string) error {
 		return err
 	}
 	if rootDBpass != "" {
-		if err := SaveEnvVariable(path+"/.env", "MYSQL_ROOT_PASSWORD", rootDBpass); err != nil {
+		if err := SaveEnvVariable(path+"/.env", "MYSQL_PASSWORD", rootDBpass); err != nil {
 			return err
 		}
 	}

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -14,7 +14,6 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/git"
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/orchestrators"
-	"github.com/sethvargo/go-password/password"
 )
 
 type CanastaVariables struct {
@@ -35,46 +34,6 @@ func CloneStackRepo(orchestrator, canastaId string, path *string) error {
 	repo := orchestrators.GetRepoLink(orchestrator)
 	err := git.Clone(repo, *path)
 	return err
-}
-
-func GetPasswords(path string, canastaInfo CanastaVariables) error {
-	var err error
-
-	canastaInfo.AdminPassword, err = GetAndSavePassword(canastaInfo.AdminPassword, path, "admin", ".admin-password")
-	if err != nil {
-		return err
-	}
-
-	canastaInfo.RootDBPassword, err = GetAndSavePassword(canastaInfo.RootDBPassword, path, "root database", ".root-db-password")
-	if err != nil {
-		return err
-	}
-
-	canastaInfo.WikiDBPassword, err = GetAndSavePassword(canastaInfo.WikiDBPassword, path, "wiki database", ".wiki-db-password")
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func GetAndSavePassword(pwd, path, prompt, filename string) (string, error) {
-	var err error
-	if pwd != "" {
-		return pwd, nil
-	}
-	pwd, err = password.Generate(12, 2, 4, false, true)
-	if err != nil {
-		return "", err
-	}
-	fmt.Printf("Saving %s password to %s/%s\n", prompt, path, filename)
-	file, err := os.Create(path + "/" + filename)
-	if err != nil {
-		return "", err
-	}
-	defer file.Close()
-	_, err = file.WriteString(pwd)
-	return pwd, err
 }
 
 // if envPath is passed as argument,

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -288,9 +288,13 @@ func GeneratePasswords(path string, canastaInfo CanastaVariables) (CanastaVariab
 		return canastaInfo, err
 	}
 
-	canastaInfo.WikiDBPassword, err = GetOrGenerateAndSavePassword(canastaInfo.WikiDBPassword, path, "wiki database", ".wiki-db-password")
-	if err != nil {
-		return canastaInfo, err
+	if (canastaInfo.WikiDBUsername == "root") {
+		canastaInfo.WikiDBPassword = canastaInfo.RootDBPassword
+	} else {
+		canastaInfo.WikiDBPassword, err = GetOrGenerateAndSavePassword(canastaInfo.WikiDBPassword, path, "wiki database", ".wiki-db-password")
+		if err != nil {
+			return canastaInfo, err
+		}
 	}
 
 	return canastaInfo, nil

--- a/internal/mediawiki/mediawiki.go
+++ b/internal/mediawiki/mediawiki.go
@@ -14,7 +14,6 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/farmsettings"
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/orchestrators"
-	"github.com/sethvargo/go-password/password"
 )
 
 const dbServer = "db"
@@ -31,21 +30,6 @@ func Install(path, yamlPath, orchestrator string, canastaInfo canasta.CanastaVar
 	output, err := orchestrators.ExecWithError(path, orchestrator, "web", command)
 	if err != nil {
 		return canastaInfo, fmt.Errorf(output)
-	}
-
-	canastaInfo.AdminPassword, err = GetAndSavePassword(canastaInfo.AdminPassword, path, "admin", ".admin-password")
-	if err != nil {
-		return canastaInfo, err
-	}
-
-	canastaInfo.RootDBPassword, err = GetAndSavePassword(canastaInfo.RootDBPassword, path, "root database", ".root-db-password")
-	if err != nil {
-		return canastaInfo, err
-	}
-
-	canastaInfo.WikiDBPassword, err = GetAndSavePassword(canastaInfo.WikiDBPassword, path, "wiki database", ".wiki-db-password")
-	if err != nil {
-		return canastaInfo, err
 	}
 
 	fmt.Printf("Saving adminname to %s/.admin\n", path)
@@ -98,25 +82,6 @@ func Install(path, yamlPath, orchestrator string, canastaInfo canasta.CanastaVar
 		return canastaInfo, err
 	}
 	return canastaInfo, err
-}
-
-func GetAndSavePassword(pwd, path, prompt, filename string) (string, error) {
-	var err error
-	if pwd != "" {
-		return pwd, nil
-	}
-	pwd, err = password.Generate(12, 2, 4, false, true)
-	if err != nil {
-		return "", err
-	}
-	fmt.Printf("Saving %s password to %s/%s\n", prompt, path, filename)
-	file, err := os.Create(path + "/" + filename)
-	if err != nil {
-		return "", err
-	}
-	defer file.Close()
-	_, err = file.WriteString(pwd)
-	return pwd, err
 }
 
 func InstallOne(path, name, domain, admin, dbuser, orchestrator string) error {

--- a/internal/mediawiki/mediawiki.go
+++ b/internal/mediawiki/mediawiki.go
@@ -14,6 +14,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/farmsettings"
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/orchestrators"
+	"github.com/sethvargo/go-password/password"
 )
 
 const dbServer = "db"
@@ -161,6 +162,50 @@ func InstallOne(path, name, domain, admin, dbuser, orchestrator string) error {
 	}
 
 	return err
+}
+
+func GeneratePasswords(path string, canastaInfo canasta.CanastaVariables) (canasta.CanastaVariables, error) {
+	var err error
+
+	canastaInfo.AdminPassword, err = GenerateAndSavePassword(canastaInfo.AdminPassword, path, "admin", ".admin-password")
+	if err != nil {
+		return canastaInfo, err
+	}
+
+	canastaInfo.RootDBPassword, err = GenerateAndSavePassword(canastaInfo.RootDBPassword, path, "root database", ".root-db-password")
+	if err != nil {
+		return canastaInfo, err
+	}
+
+	canastaInfo.WikiDBPassword, err = GenerateAndSavePassword(canastaInfo.WikiDBPassword, path, "wiki database", ".wiki-db-password")
+	if err != nil {
+		return canastaInfo, err
+	}
+
+	return canastaInfo, nil
+}
+
+func GenerateAndSavePassword(pwd, path, prompt, filename string) (string, error) {
+	var err error
+	if pwd != "" {
+		return pwd, nil
+	}
+	if pwd, err = GetPasswordFromFile(path, filename); err == nil {
+		fmt.Printf("Retrieved %s password from %s/%s\n", prompt, path, filename)
+		return pwd, nil
+	}
+	pwd, err = password.Generate(12, 2, 4, false, true)
+	if err != nil {
+		return "", err
+	}
+	fmt.Printf("Saving %s password to %s/%s\n", prompt, path, filename)
+	file, err := os.Create(path + "/" + filename)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	_, err = file.WriteString(pwd)
+	return pwd, err
 }
 
 func GetPasswordFromFile(path, filename string) (string, error) {

--- a/internal/mediawiki/mediawiki.go
+++ b/internal/mediawiki/mediawiki.go
@@ -14,6 +14,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/farmsettings"
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/orchestrators"
+	"github.com/sethvargo/go-password/password"
 )
 
 const dbServer = "db"
@@ -24,7 +25,6 @@ func Install(path, yamlPath, orchestrator string, canastaInfo canasta.CanastaVar
 	var err error
 	logging.Print("Configuring MediaWiki Installation\n")
 	logging.Print("Running install.php\n")
-	envVariables := canasta.GetEnvVariable(path + "/.env")
 	settingsName := "CommonSettings.php"
 
 	command := "/wait-for-it.sh -t 60 db:3306"
@@ -100,12 +100,12 @@ func Install(path, yamlPath, orchestrator string, canastaInfo canasta.CanastaVar
 	return canastaInfo, err
 }
 
-func GetAndSavePassword(password, path, prompt, filename string, canastaInfo canasta.CanastaVariables) (string, error) {
+func GetAndSavePassword(pwd, path, prompt, filename string, canastaInfo canasta.CanastaVariables) (string, error) {
 	var err error
-	if password != "" {
-		return password, nil
+	if pwd != "" {
+		return pwd, nil
 	}
-	password, err = password.Generate(12, 2, 4, false, true)
+	pwd, err = password.Generate(12, 2, 4, false, true)
 	if err != nil {
 		return "", err
 	}
@@ -115,8 +115,8 @@ func GetAndSavePassword(password, path, prompt, filename string, canastaInfo can
 		return "", err
 	}
 	defer file.Close()
-	_, err = file.WriteString(password)
-	return password, err
+	_, err = file.WriteString(pwd)
+	return pwd, err
 }
 
 func InstallOne(path, name, domain, wikipath, admin, orchestrator string) error {

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -112,7 +112,7 @@ func promptForUserPassword(username, password string) (string, string, error) {
 }
 
 func getAndConfirmPassword(username string) (string, string, error) {
-	fmt.Print("Enter the admin password (Press Enter to autogenerate the password): \n")
+	fmt.Print("Enter the admin password (Press Enter to get saved password or, if one does not exist, autogenerate a password): \n")
 	password, err := getPasswordInput()
 	if err != nil {
 		return "", "", err
@@ -140,7 +140,7 @@ func promptForDBPassword(whichpass string, passflag bool) (string, error) {
 }
 
 func getAndConfirmDBPassword(whichpass string) (string, error) {
-	fmt.Printf("Enter the %s database password (Press Enter to autogenerate the password): \n", whichpass)
+	fmt.Printf("Enter the %s database password (Press Enter to get saved password or, if one does not exist, autogenerate a password): \n", whichpass)
 	password, err := getPasswordInput()
 	if err != nil {
 		return "", err

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -140,7 +140,7 @@ func promptForDBPassword(whichpass string, passflag bool) (string, error) {
 }
 
 func getAndConfirmDBPassword(whichpass string) (string, error) {
-	fmt.Print("Enter the %s database password (Press Enter to autogenerate the password): \n", whichpass)
+	fmt.Printf("Enter the %s database password (Press Enter to autogenerate the password): \n", whichpass)
 	password, err := getPasswordInput()
 	if err != nil {
 		return "", err
@@ -148,7 +148,7 @@ func getAndConfirmDBPassword(whichpass string) (string, error) {
 	if password == "" {
 		return "", nil
 	}
-	fmt.Print("Re-enter the %s database password: \n", whichpass)
+	fmt.Printf("Re-enter the %s database password: \n", whichpass)
 	confirmedPassword, err := getPasswordInput()
 	if err != nil || password != confirmedPassword {
 		return "", fmt.Errorf("Passwords do not match, please try again.")


### PR DESCRIPTION
Currently the root DB password is hardcoded to "mediawiki" and the wiki DB user is hardcoded to be the root DB user. This patch allows the root DB password to be set or generated. It allows a separate DB user to be set as the wiki user, also with a password that can be set or generated. As is currently done with the wiki admin password, if the user does not enter a password when prompted, a password is generated and saved to a file.