### PR TITLE
Move Canasta ID check to happen pre-password entry

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -92,9 +92,6 @@ func createCanasta(canastaInfo canasta.CanastaVariables, pwd, path, name, domain
 	defer func() {
 		done <- struct{}{}
 	}()
-	if _, err := config.GetDetails(canastaInfo.Id); err == nil {
-		log.Fatal(fmt.Errorf("Canasta installation with the ID already exist!"))
-	}
 	if err := farmsettings.CreateYaml(name, domain, &yamlPath); err != nil {
 		return err
 	}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -6,8 +6,10 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"log"
 
 	"github.com/CanastaWiki/Canasta-CLI-Go/internal/canasta"
+	"github.com/CanastaWiki/Canasta-CLI-Go/internal/config"
 	"golang.org/x/term"
 )
 
@@ -23,6 +25,9 @@ func PromptUser(name, yamlPath string, rootdbpass bool, wikidbpass bool, canasta
 	}
 	if canastaInfo.Id, err = promptForInput(canastaInfo.Id, "Canasta ID"); err != nil {
 		return name, canastaInfo, err
+	}
+	if _, err := config.GetDetails(canastaInfo.Id); err == nil {
+		log.Fatal(fmt.Errorf("Canasta installation with the ID already exist!"))
 	}
 	if canastaInfo.AdminName, canastaInfo.AdminPassword, err = promptForUserPassword(canastaInfo.AdminName, canastaInfo.AdminPassword); err != nil {
 		return name, canastaInfo, err

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -27,7 +27,7 @@ func PromptUser(name, yamlPath string, rootdbpass bool, wikidbpass bool, canasta
 		return name, canastaInfo, err
 	}
 	if _, err := config.GetDetails(canastaInfo.Id); err == nil {
-		log.Fatal(fmt.Errorf("Canasta installation with the ID already exist!"))
+		log.Fatal(fmt.Errorf("Canasta ID \"" + canastaInfo.Id + "\" already exist!"))
 	}
 	if canastaInfo.AdminName, canastaInfo.AdminPassword, err = promptForUserPassword(canastaInfo.AdminName, canastaInfo.AdminPassword); err != nil {
 		return name, canastaInfo, err


### PR DESCRIPTION
Canasta ID check should happen before asking the user for password and definitely before the start of create of operation.