### PR TITLE
Allow dashes and underscores in canastaID

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -44,7 +44,7 @@ func NewCmdCreate() *cobra.Command {
 			if canastaInfo, err = canasta.GeneratePasswords(path, canastaInfo); err != nil {
 				log.Fatal(err)
 			}
-			validString := regexp.MustCompile(`^[a-zA-Z0-9]+$`)
+			validString := regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-_]*[a-zA-Z0-9])?$`)
 
 			if !validString.MatchString(canastaInfo.Id) {
 				log.Fatal(fmt.Errorf("Error: CanastaID should not contain spaces or non-ASCII characters, only alphanumeric characters are allowed"))


### PR DESCRIPTION
- Allow dashes and underscores in canastaID, except as a first or last character.