### PR TITLE
Replace actions/upload-artifact v3 with v4 in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Build
       run: sh build.sh
     - name: Upload executable for job build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: executable
         path: ./Canasta-CLI-Go


### PR DESCRIPTION
v3 is no longer usable, after January 30:

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/