### PR TITLE
Add support for AArch64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,54 +5,81 @@ name: Go build
 
 on:
   push:
-    branches:
-      - main
+    branches: [ main ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64   # aarch64
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.19
-    - name: Build
-      run: sh build.sh
-    - name: Upload executable for job build
-      uses: actions/upload-artifact@v4
-      with:
-        name: executable
-        path: ./Canasta-CLI-Go
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.19'
+
+      - name: Build (${{ matrix.goos }}-${{ matrix.goarch }})
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: 0
+        run: |
+          sh build.sh
+
+      - name: Collect artifact
+        run: |
+          mkdir -p dist
+          # If build.sh outputs ./Canasta-CLI-Go, rename it into dist with OS/ARCH suffix
+          mv ./Canasta-CLI-Go "dist/canasta-${{ matrix.goos }}-${{ matrix.goarch }}"
+        shell: bash
+
+      - name: Upload artifact (${{ matrix.goos }}-${{ matrix.goarch }})
+        uses: actions/upload-artifact@v4
+        with:
+          name: executable-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/canasta-${{ matrix.goos }}-${{ matrix.goarch }}
+
   release:
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - name: Download executable
-      uses: actions/download-artifact@v4
-      with:
-        name: executable
-    - name: Rename executable
-      run: mv Canasta-CLI-Go canasta
-    - name: Generate Version Tag
-      id: generate
-      run: |
-        latest_version_raw="$(curl -s https://api.github.com/repos/${{ github.repository }}/releases | grep -m 1 "html_url" | rev | cut -d/  -f1 | rev  )"
-        latest_version="${latest_version_raw%??}"
-        major_version=$(echo $latest_version | cut -d. -f1 | cut -dv -f2)
-        minor_version=$(echo $latest_version | cut -d. -f2)
-        patch_version=$(echo $latest_version | cut -d. -f3)
-        minor_version=$(expr $minor_version + 1)
-        new_version=$(echo "v$major_version.$minor_version.$patch_version")
-        echo $new_version
-        echo "new_version=$new_version" >> $GITHUB_OUTPUT
-    - name: Publish
-      uses: softprops/action-gh-release@v1
-      id: publish
-      with:
-        draft: false
-        tag_name: ${{ steps.generate.outputs.new_version }}
-        fail_on_unmatched_files: true
-        generate_release_notes: true
-        append_body: true
-        files: canasta
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: executable-*
+          merge-multiple: true
+          path: dist
+
+      - name: List files
+        run: ls -la dist
+
+      - name: Generate Version Tag
+        id: generate
+        run: |
+          latest_version_raw="$(curl -s https://api.github.com/repos/${{ github.repository }}/releases | grep -m 1 "html_url" | rev | cut -d/  -f1 | rev )"
+          latest_version="${latest_version_raw%??}"
+          major_version=$(echo $latest_version | cut -d. -f1 | cut -dv -f2)
+          minor_version=$(echo $latest_version | cut -d. -f2)
+          patch_version=$(echo $latest_version | cut -d. -f3)
+          minor_version=$(expr $minor_version + 1)
+          new_version=$(echo "v$major_version.$minor_version.$patch_version")
+          echo "new_version=$new_version" >> $GITHUB_OUTPUT
+
+      - name: Publish
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: false
+          tag_name: ${{ steps.generate.outputs.new_version }}
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+          append_body: true
+          files: |
+            dist/canasta-linux-amd64
+            dist/canasta-linux-arm64


### PR DESCRIPTION
The only issue is that the install script will need to be changed to not just use an executable named `canasta`. It will be a different file name depending on the architecture.