### PR TITLE
Fix chmod permissions issue in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -144,7 +144,7 @@ download_and_install() {
     exit 1
   fi
   echo "Download was successful; now installing Canasta CLI."
-  chmod u=rwx,g=xr,o=x canasta
+  sudo chmod u=rwx,g=xr,o=x canasta
   sudo mv canasta /usr/local/bin/canasta
   if [ $? -ne 0 ]; then
     echo "Installation failed. Please try again."


### PR DESCRIPTION
`chmod` in line 147 can fail when the install script isn't running as root because it's trying to change a file owned by a different user, the root user. 

Running `chmod` with `sudo` fixes this issue, as `sudo` allows `chmod` to run as root, the owner of the file `chmod` is changing.

Tested working on a fresh Kubuntu 25.10 livecd virtual machine with distribution-packaged Docker. 

Fixes: #132 