### PR TITLE
Append port to default domain in wikis.yaml

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -69,6 +69,20 @@ func NewCmdCreate() *cobra.Command {
 				log.Fatal(err)
 			}
 
+			// If no domain was explicitly provided and an env file specifies a
+			// non-standard HTTPS port, append the port to the default domain
+			// so that wikis.yaml is generated with the correct URL.
+			if !cmd.Flags().Changed("domain-name") && envFile != "" {
+				envFilePath := envFile
+				if !filepath.IsAbs(envFilePath) {
+					envFilePath = filepath.Join(workingDir, envFilePath)
+				}
+				envVars := canasta.GetEnvVariable(envFilePath)
+				if port, ok := envVars["HTTPS_PORT"]; ok && port != "443" && port != "" {
+					domain = domain + ":" + port
+				}
+			}
+
 			description := "Creating Canasta installation '" + canastaInfo.Id + "'..."
 			if devModeFlag {
 				description = "Creating Canasta installation '" + canastaInfo.Id + "' with dev mode..."


### PR DESCRIPTION
For the "canasta create" command, if an env file with a non-standard port is provided but no domain is provided, rather than writing the default of "localhost" to wikis.yaml, append the specified port to "localhost". For example, if the file `envfile` contains:

```
  HTTPS_PORT=8443
  HTTP_PORT=8080
```

then the command:

```
  canasta create -i farm -w test -e envfile -a admin
```

will generate the following farm/config/wikis.yaml file:

```
  wikis:
  - id: test
     url: localhost:8443
     name: test
```