### PR TITLE
Make --id flag optional when running from an instance directory

### DIFF
--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -64,6 +64,12 @@ func NewCmdCreate() *cobra.Command {
 	var adminPassword string
 	var wikidbuser string
 
+	workingDir, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	instance.Path = workingDir
+
 	addCmd := &cobra.Command{
 		Use:   "add",
 		Short: "Add a new wiki to a Canasta instance",
@@ -96,11 +102,6 @@ func NewCmdCreate() *cobra.Command {
 				fmt.Printf("Generated admin password for wiki '%s'\n", wikiID)
 			}
 
-			workingDir, err := os.Getwd()
-			if err != nil {
-				log.Fatal(err)
-			}
-
 			fmt.Printf("Adding wiki '%s' to Canasta instance '%s'...\n", wikiID, instance.Id)
 			err = AddWiki(instance, wikiID, siteName, domainName, wikiPath, databasePath, admin, adminPassword, wikidbuser, workingDir)
 			if err != nil {
@@ -123,7 +124,6 @@ func NewCmdCreate() *cobra.Command {
 	// Mark required flags
 	addCmd.MarkFlagRequired("wiki")
 	addCmd.MarkFlagRequired("url")
-	addCmd.MarkFlagRequired("id")
 	addCmd.MarkFlagRequired("admin")
 
 	return addCmd

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -2,6 +2,8 @@ package start
 
 import (
 	"fmt"
+	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -14,6 +16,12 @@ import (
 var instance config.Installation
 
 func NewCmdCreate() *cobra.Command {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	instance.Path = workingDir
+
 	var deleteCmd = &cobra.Command{
 		Use:   "delete",
 		Short: "Delete a Canasta installation",

--- a/cmd/extension/extension.go
+++ b/cmd/extension/extension.go
@@ -1,6 +1,9 @@
 package extension
 
 import (
+	"log"
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
@@ -19,6 +22,12 @@ var (
 )
 
 func NewCmdCreate() *cobra.Command {
+	workingDir, wdErr := os.Getwd()
+	if wdErr != nil {
+		log.Fatal(wdErr)
+	}
+	instance.Path = workingDir
+
 	extensionCmd = &cobra.Command{
 		Use:   "extension",
 		Short: "Manage Canasta extensions",

--- a/cmd/maintenanceUpdate/maintenance.go
+++ b/cmd/maintenanceUpdate/maintenance.go
@@ -1,6 +1,9 @@
 package maintenance
 
 import (
+	"log"
+	"os"
+
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
 	"github.com/spf13/cobra"
 )
@@ -11,6 +14,12 @@ var (
 )
 
 func NewCmdCreate() *cobra.Command {
+	workingDir, wdErr := os.Getwd()
+	if wdErr != nil {
+		log.Fatal(wdErr)
+	}
+	instance.Path = workingDir
+
 	maintenanceCmd := &cobra.Command{
 		Use:   "maintenance",
 		Short: "Use to run update and other maintenance scripts",

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -21,6 +21,12 @@ func NewCmdCreate() *cobra.Command {
 	var instance config.Installation
 	var wikiID string
 
+	workingDir, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	instance.Path = workingDir
+
 	addCmd := &cobra.Command{
 		Use:   "remove",
 		Short: "Remove a wiki from a Canasta instance",

--- a/cmd/restart/restart.go
+++ b/cmd/restart/restart.go
@@ -3,6 +3,7 @@ package restart
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -18,6 +19,13 @@ func NewCmdCreate() *cobra.Command {
 	var verbose bool
 	var devModeFlag bool
 	var noDevFlag bool
+
+	workingDir, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	instance.Path = workingDir
+
 	var restartCmd = &cobra.Command{
 		Use:   "restart",
 		Short: "Restart the Canasta installation",

--- a/cmd/restic/restic.go
+++ b/cmd/restic/restic.go
@@ -1,6 +1,7 @@
 package restic
 
 import (
+	"log"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -20,6 +21,12 @@ var (
 )
 
 func NewCmdCreate() *cobra.Command {
+	workingDir, wdErr := os.Getwd()
+	if wdErr != nil {
+		log.Fatal(wdErr)
+	}
+	instance.Path = workingDir
+
 	resticCmd = &cobra.Command{
 		Use:   "restic",
 		Short: "Use restic to backup and restore Canasta",

--- a/cmd/skin/skin.go
+++ b/cmd/skin/skin.go
@@ -1,6 +1,9 @@
 package skin
 
 import (
+	"log"
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
@@ -19,6 +22,12 @@ var (
 )
 
 func NewCmdCreate() *cobra.Command {
+	workingDir, wdErr := os.Getwd()
+	if wdErr != nil {
+		log.Fatal(wdErr)
+	}
+	instance.Path = workingDir
+
 	skinCmd = &cobra.Command{
 		Use:   "skin",
 		Short: "Manage Canasta skins",

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -2,6 +2,8 @@ package start
 
 import (
 	"fmt"
+	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -19,6 +21,12 @@ var (
 )
 
 func NewCmdCreate() *cobra.Command {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	instance.Path = workingDir
+
 	var startCmd = &cobra.Command{
 		Use:   "start",
 		Short: "Start the Canasta installation",

--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -3,6 +3,7 @@ package stop
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -13,6 +14,12 @@ import (
 
 func NewCmdCreate() *cobra.Command {
 	var instance config.Installation
+	workingDir, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	instance.Path = workingDir
+
 	var stopCmd = &cobra.Command{
 		Use:   "stop",
 		Short: "Shuts down the Canasta installation",

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -2,6 +2,8 @@ package upgrade
 
 import (
 	"fmt"
+	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -14,6 +16,12 @@ import (
 var instance config.Installation
 
 func NewCmdCreate() *cobra.Command {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	instance.Path = workingDir
+
 	var upgradeCmd = &cobra.Command{
 		Use:   "upgrade",
 		Short: "Upgrade a Canasta installation to the latest version",


### PR DESCRIPTION
All commands that operate on an existing Canasta instance now resolve the instance from the current working directory when --id is not provided. This uses the existing CheckCanastaId() fallback which looks up the instance path in the config registry.

Commands that also accept the instance ID as a positional argument (start, stop, restart, upgrade, delete) retain that behavior.

The create command is unchanged since it always requires --id to name the new installation.

How it works:

  1. The change sets instance.Path to the working directory.  
  2. CheckCanastaId() (internal/canasta/canasta.go:524) checks: if instance.Id  
  is empty (no -i flag), it calls config.GetCanastaID(instance.Path) at line 531
  3. GetCanastaID() (internal/config/config.go:116) iterates through all        
  installations stored in conf.json and matches by path:                        
```
  for _, installations := range existingInstallations.Installations {           
      if installations.Path == installPath {                                    
          return installations.Id, nil                                          
      }                                                                         
  }                                                                             

```
So it looks up the working directory in the config registry (.../canasta/conf.json), which stores the path for every installation created with canasta create. If your current directory matches a registered installation path, it returns that installation's ID.

Before #146 was merged, all these commands had a --path flag that defaulted to the working directory:                          
                                                                                
startCmd.Flags().StringVarP(&instance.Path, "path", "p", workingDir, "Canasta installation directory")                                                      
                                                                                
That flag's default value silently set instance.Path to the working directory, which made CheckCanastaId() work without -i. When that PR removed --path, it inadvertently broke the path-based lookup because nothing was setting instance.Path anymore.This change restores that behavior by setting instance.Path = workingDir directly, without re-introducing the --path flag.  
