### PR TITLE
Fix canasta add stripping port from URL before writing to wikis.yaml

### DIFF
--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -84,7 +84,7 @@ func NewCmdCreate() *cobra.Command {
 			if err != nil {
 				log.Fatal(fmt.Errorf("failed to parse URL: %w", err))
 			}
-			domainName = parsedUrl.Hostname()
+			domainName = parsedUrl.Host
 			wikiPath = strings.Trim(parsedUrl.Path, "/")
 
 			// Generate admin password if not provided


### PR DESCRIPTION
parsedUrl.Hostname() strips the port from the parsed URL, so a URL like "localhost:8443/wiki2" would be written to wikis.yaml as just "localhost/wiki2". Use parsedUrl.Host instead, which preserves the port, matching how canasta create handles domain names with ports.