### PR TITLE
Enable Restic repository URL configuration through env to support destinations like Azure

### DIFF
--- a/cmd/restic/init.go
+++ b/cmd/restic/init.go
@@ -27,7 +27,7 @@ func initCmdCreate() *cobra.Command {
 }
 
 func initRestic() {
-	fmt.Println("Initializing Restic repo in S3")
+	fmt.Println("Initializing Restic repo")
 	commandArgs = append(commandArgs, "init")
 	err, output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
 	if err != nil {

--- a/cmd/restic/restic.go
+++ b/cmd/restic/restic.go
@@ -38,7 +38,8 @@ func NewCmdCreate() *cobra.Command {
 			}
 			envPath := instance.Path + "/.env"
 			EnvVariables := canasta.GetEnvVariable(envPath)
-			commandArgs = append(make([]string, 0), "sudo", "docker", "run", "--rm", "-i", "--env-file", envPath, "restic/restic", "-r", "s3:"+EnvVariables["AWS_S3_API"]+"/"+EnvVariables["AWS_S3_BUCKET"])
+			repoURL := getRepoURL(EnvVariables)
+			commandArgs = append(make([]string, 0), "sudo", "docker", "run", "--rm", "-i", "--env-file", envPath, "restic/restic", "-r", repoURL)
 
 			return nil
 		},
@@ -58,6 +59,16 @@ func NewCmdCreate() *cobra.Command {
 	resticCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Verbose Output")
 	return resticCmd
 
+}
+
+func getRepoURL(env map[string]string) string {
+	if val, ok := env["RESTIC_REPOSITORY"]; ok && val != "" {
+		return val
+	}
+	if val, ok := env["RESTIC_REPO"]; ok && val != "" {
+		return val
+	}
+	return "s3:" + env["AWS_S3_API"] + "/" + env["AWS_S3_BUCKET"]
 }
 
 func checkCurrentSnapshotFolder(currentSnapshotFolder string) {

--- a/cmd/restic/restoreSnapshot.go
+++ b/cmd/restic/restoreSnapshot.go
@@ -51,7 +51,8 @@ func restoreSnapshot(snapshotId string, skipBeforeSnapshot bool) {
 	checkCurrentSnapshotFolder(currentSnapshotFolder)
 
 	logging.Print("Restoring snapshot to /currentsnapshot")
-	command := fmt.Sprintf("docker run --rm -i --env-file %s/.env -v %s:/currentsnapshot restic/restic -r s3:%s/%s restore %s --target /currentsnapshot", instance.Path, currentSnapshotFolder, EnvVariables["AWS_S3_API"], EnvVariables["AWS_S3_BUCKET"], snapshotId)
+	repoURL := getRepoURL(EnvVariables)
+	command := fmt.Sprintf("docker run --rm -i --env-file %s/.env -v %s:/currentsnapshot restic/restic -r %s restore %s --target /currentsnapshot", instance.Path, currentSnapshotFolder, repoURL, snapshotId)
 	commandArgs := strings.Fields(command)
 	err, output := execute.Run("", "sudo", commandArgs...)
 	if err != nil {

--- a/cmd/restic/takeSnapshot.go
+++ b/cmd/restic/takeSnapshot.go
@@ -46,7 +46,8 @@ func takeSnapshot(tag string) {
 	logging.Print("Copy folders and files completed.")
 
 	hostname, _ := os.Hostname()
-	err, output = execute.Run(instance.Path, "sudo", "docker", "run", "--rm", "-i", "--env-file", envPath, "-v", currentSnapshotFolder+":/currentsnapshot/", "restic/restic", "-r", "s3:"+EnvVariables["AWS_S3_API"]+"/"+EnvVariables["AWS_S3_BUCKET"], "--tag", fmt.Sprintf("%s__on__%s", tag, hostname), "backup", "/currentsnapshot")
+	repoURL := getRepoURL(EnvVariables)
+	err, output = execute.Run(instance.Path, "sudo", "docker", "run", "--rm", "-i", "--env-file", envPath, "-v", currentSnapshotFolder+":/currentsnapshot/", "restic/restic", "-r", repoURL, "--tag", fmt.Sprintf("%s__on__%s", tag, hostname), "backup", "/currentsnapshot")
 	if err != nil {
 		logging.Fatal(fmt.Errorf(output))
 	}


### PR DESCRIPTION
Enable Restic repository URL configuration through env to support destinations like Azure

Implements #151 