### PR TITLE
Handle www-data file ownership in delete and remove commands

### DIFF
--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -53,6 +53,10 @@ func Delete(instance config.Installation) error {
 		return err
 	}
 
+	// Clean up mounted directories from inside the container before stopping
+	// This handles files owned by www-data that can't be deleted from the host on Linux
+	orchestrators.CleanupMountedDirs(instance.Path, instance.Orchestrator)
+
 	//Stopping and deleting Contianers and it's volumes
 	if _, err := orchestrators.DeleteContainers(instance.Path, instance.Orchestrator); err != nil {
 		return err

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 	"github.com/CanastaWiki/Canasta-CLI/internal/spinner"
 )
@@ -53,9 +54,17 @@ func Delete(instance config.Installation) error {
 		return err
 	}
 
-	// Clean up mounted directories from inside the container before stopping
-	// This handles files owned by www-data that can't be deleted from the host on Linux
-	orchestrators.CleanupMountedDirs(instance.Path, instance.Orchestrator)
+	// Ensure containers are running so we can clean up images from inside
+	// (needed on Linux where container-created files are owned by www-data)
+	if err := orchestrators.EnsureRunning(instance); err != nil {
+		fmt.Println("Warning: could not start containers for image cleanup.")
+		fmt.Println("Some image files may be orphaned and require manual removal with sudo.")
+	} else {
+		// Clean up images from inside the container before stopping
+		if err := orchestrators.CleanupImages(instance.Path, instance.Orchestrator, ""); err != nil {
+			logging.Print(fmt.Sprintf("Warning: could not clean up images: %v\n", err))
+		}
+	}
 
 	//Stopping and deleting Contianers and it's volumes
 	if _, err := orchestrators.DeleteContainers(instance.Path, instance.Orchestrator); err != nil {

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -56,10 +56,14 @@ func RemoveWiki(instance config.Installation, wikiID string) error {
 		return err
 	}
 
-	//Checking Running status
-	err = orchestrators.CheckRunningStatus(instance)
-	if err != nil {
-		return err
+	// Ensure containers are running (starts them if needed)
+	// Needed for database removal and image cleanup on Linux
+	containersRunning := true
+	if err = orchestrators.EnsureRunning(instance); err != nil {
+		containersRunning = false
+		fmt.Println("Warning: could not start containers.")
+		fmt.Println("Database may not be removed and some image files may be orphaned.")
+		fmt.Println("These may require manual removal.")
 	}
 
 	//Checking Wiki existence
@@ -87,10 +91,12 @@ func RemoveWiki(instance config.Installation, wikiID string) error {
 		return err
 	}
 
-	//Install the corresponding Database
-	err = mediawiki.RemoveDatabase(instance.Path, wikiID, instance.Orchestrator)
-	if err != nil {
-		return err
+	// Remove the corresponding Database (requires running container)
+	if containersRunning {
+		err = mediawiki.RemoveDatabase(instance.Path, wikiID, instance.Orchestrator)
+		if err != nil {
+			return err
+		}
 	}
 
 	//Remove the Localsettings
@@ -99,8 +105,10 @@ func RemoveWiki(instance config.Installation, wikiID string) error {
 		return err
 	}
 
-	//Remove the Images (from inside container first to handle www-data ownership on Linux)
-	orchestrators.CleanupWikiImages(instance.Path, instance.Orchestrator, wikiID)
+	// Remove the Images (from inside container first to handle www-data ownership on Linux)
+	if containersRunning {
+		orchestrators.CleanupImages(instance.Path, instance.Orchestrator, wikiID)
+	}
 	err = canasta.RemoveImages(instance.Path, wikiID)
 	if err != nil {
 		return err

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -99,7 +99,8 @@ func RemoveWiki(instance config.Installation, wikiID string) error {
 		return err
 	}
 
-	//Remove the Images
+	//Remove the Images (from inside container first to handle www-data ownership on Linux)
+	orchestrators.CleanupWikiImages(instance.Path, instance.Orchestrator, wikiID)
 	err = canasta.RemoveImages(instance.Path, wikiID)
 	if err != nil {
 		return err

--- a/internal/orchestrators/orchestrators.go
+++ b/internal/orchestrators/orchestrators.go
@@ -235,6 +235,14 @@ func CleanupMountedDirs(installPath, orchestrator string) error {
 	return nil
 }
 
+// CleanupWikiImages removes a specific wiki's images directory from inside the container.
+// This is necessary on Linux where container-created files retain their container UID.
+func CleanupWikiImages(installPath, orchestrator, wikiID string) error {
+	cleanupCmd := fmt.Sprintf("rm -rf /mediawiki/images/%s", wikiID)
+	_, err := ExecWithError(installPath, orchestrator, "web", cleanupCmd)
+	return err
+}
+
 func DeleteContainers(installPath, orchestrator string) (string, error) {
 	switch orchestrator {
 	case "compose":

--- a/internal/orchestrators/orchestrators.go
+++ b/internal/orchestrators/orchestrators.go
@@ -225,13 +225,14 @@ func StopAndStart(instance config.Installation) error {
 // their container UID on the host and cannot be deleted without sudo.
 // If wikiID is empty, removes all images (images/*). Otherwise removes images/{wikiID}.
 func CleanupImages(installPath, orchestrator, wikiID string) error {
-	var path string
+	var cleanupCmd string
 	if wikiID == "" {
-		path = "/mediawiki/images/*"
+		// Use find to delete all files including hidden files (dotfiles)
+		// The glob * doesn't match dotfiles like .htaccess
+		cleanupCmd = "find /mediawiki/images -mindepth 1 -delete"
 	} else {
-		path = fmt.Sprintf("/mediawiki/images/%s", wikiID)
+		cleanupCmd = fmt.Sprintf("rm -rf /mediawiki/images/%s", wikiID)
 	}
-	cleanupCmd := fmt.Sprintf("rm -rf %s", path)
 	_, err := ExecWithError(installPath, orchestrator, "web", cleanupCmd)
 	return err
 }


### PR DESCRIPTION
On Linux, files created by the container's www-data user retain that
ownership on the host. When running without sudo, the host-side rm -rf
cannot delete these files.

Fix by ensuring containers are running before cleanup operations:
- Add EnsureRunning() that starts containers if not running
- Add CleanupImages() to remove images from inside the container
- Update delete to start containers for image cleanup
- Update remove to start containers for database and image cleanup

Use 'find -delete' instead of 'rm -rf *' to also delete hidden files
like .htaccess and .gitignore (glob * doesn't match dotfiles).

If containers cannot be started, warn about potential orphaned files
(and database for remove) but continue with the operation. Manual
cleanup with sudo may be required in this case.

Note: On Linux, the recommended approach is to add your user to the
docker group and run Canasta commands without sudo.