### PR TITLE
Use environment variables and new config directory structure

### DIFF
--- a/LocalSettingsTemplate.php
+++ b/LocalSettingsTemplate.php
@@ -1,8 +1,0 @@
-<?php
-// If not running MediaWiki, exit
-if ( !defined( 'MEDIAWIKI' ) ) {
-	exit;
-}
-#$wgServer = "http://localhost";
-#$wgSitename = ;
-#$wgMetaNamespace = ;

--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -130,7 +130,7 @@ func NewCmdCreate() *cobra.Command {
 	addCmd.Flags().StringVarP(&siteName, "site-name", "t", "", "Display name of the wiki (optional, defaults to wiki ID)")
 	addCmd.Flags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
 	addCmd.Flags().StringVarP(&databasePath, "database", "d", "", "Path to existing database dump (.sql or .sql.gz) to import instead of running install.php")
-	addCmd.Flags().StringVarP(&wikiSettingsPath, "wiki-settings", "l", "", "Path to per-wiki Settings.php to use instead of SettingsTemplate.php (only used with --database)")
+	addCmd.Flags().StringVarP(&wikiSettingsPath, "wiki-settings", "l", "", "Path to Settings.php to copy to config/settings/wikis/<wiki_id>/ (only used with --database)")
 	addCmd.Flags().StringVarP(&admin, "admin", "a", "", "Admin name of the new wiki")
 	addCmd.Flags().StringVarP(&adminPassword, "password", "s", "", "Admin password for the new wiki (if not provided, auto-generates and saves to config/admin-password_{wikiid})")
 	addCmd.Flags().StringVar(&wikidbuser, "wikidbuser", "root", "The username of the wiki database user (default: \"root\")")

--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -130,7 +130,7 @@ func NewCmdCreate() *cobra.Command {
 	addCmd.Flags().StringVarP(&siteName, "site-name", "t", "", "Display name of the wiki (optional, defaults to wiki ID)")
 	addCmd.Flags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
 	addCmd.Flags().StringVarP(&databasePath, "database", "d", "", "Path to existing database dump (.sql or .sql.gz) to import instead of running install.php")
-	addCmd.Flags().StringVarP(&wikiSettingsPath, "wiki-settings", "l", "", "Path to Settings.php to copy to config/settings/wikis/<wiki_id>/ (only used with --database)")
+	addCmd.Flags().StringVarP(&wikiSettingsPath, "wiki-settings", "l", "", "Path to per-wiki settings file to copy to config/settings/wikis/<wiki_id>/ (filename preserved)")
 	addCmd.Flags().StringVarP(&admin, "admin", "a", "", "Admin name of the new wiki")
 	addCmd.Flags().StringVarP(&adminPassword, "password", "s", "", "Admin password for the new wiki (if not provided, auto-generates and saves to config/admin-password_{wikiid})")
 	addCmd.Flags().StringVar(&wikidbuser, "wikidbuser", "root", "The username of the wiki database user (default: \"root\")")

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -152,7 +152,7 @@ func NewCmdCreate() *cobra.Command {
 	createCmd.Flags().StringVar(&devTag, "dev-tag", "latest", "Canasta image tag to use (e.g., latest, dev-branch)")
 	createCmd.Flags().StringVar(&buildFromPath, "build-from", "", "Build Canasta image from local source directory (expects Canasta/, optionally CanastaBase/)")
 	createCmd.Flags().StringVarP(&databasePath, "database", "d", "", "Path to existing database dump (.sql or .sql.gz) to import instead of running install.php")
-	createCmd.Flags().StringVarP(&wikiSettingsPath, "wiki-settings", "l", "", "Path to per-wiki Settings.php to use instead of SettingsTemplate.php (only used with --database)")
+	createCmd.Flags().StringVarP(&wikiSettingsPath, "wiki-settings", "l", "", "Path to Settings.php to copy to config/settings/wikis/<wiki_id>/ (only used with --database)")
 	createCmd.Flags().StringVarP(&globalSettingsPath, "global-settings", "g", "", "Path to global settings file to copy to config/settings/global/ (filename preserved)")
 
 	// Mark required flags

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -152,7 +152,7 @@ func NewCmdCreate() *cobra.Command {
 	createCmd.Flags().StringVar(&devTag, "dev-tag", "latest", "Canasta image tag to use (e.g., latest, dev-branch)")
 	createCmd.Flags().StringVar(&buildFromPath, "build-from", "", "Build Canasta image from local source directory (expects Canasta/, optionally CanastaBase/)")
 	createCmd.Flags().StringVarP(&databasePath, "database", "d", "", "Path to existing database dump (.sql or .sql.gz) to import instead of running install.php")
-	createCmd.Flags().StringVarP(&wikiSettingsPath, "wiki-settings", "l", "", "Path to Settings.php to copy to config/settings/wikis/<wiki_id>/ (only used with --database)")
+	createCmd.Flags().StringVarP(&wikiSettingsPath, "wiki-settings", "l", "", "Path to per-wiki settings file to copy to config/settings/wikis/<wiki_id>/ (filename preserved)")
 	createCmd.Flags().StringVarP(&globalSettingsPath, "global-settings", "g", "", "Path to global settings file to copy to config/settings/global/ (filename preserved)")
 
 	// Mark required flags

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -148,7 +148,7 @@ func NewCmdCreate() *cobra.Command {
 	createCmd.Flags().StringVar(&buildFromPath, "build-from", "", "Build Canasta image from local source directory (expects Canasta/, optionally CanastaBase/)")
 	createCmd.Flags().StringVarP(&databasePath, "database", "d", "", "Path to existing database dump (.sql or .sql.gz) to import instead of running install.php")
 	createCmd.Flags().StringVarP(&wikiSettingsPath, "wiki-settings", "l", "", "Path to per-wiki Settings.php to use instead of SettingsTemplate.php (only used with --database)")
-	createCmd.Flags().StringVarP(&globalSettingsPath, "global-settings", "g", "", "Path to global settings file to copy to config/settings/ (filename preserved)")
+	createCmd.Flags().StringVarP(&globalSettingsPath, "global-settings", "g", "", "Path to global settings file to copy to config/settings/global/ (filename preserved)")
 
 	// Mark required flags
 	createCmd.MarkFlagRequired("id")
@@ -258,6 +258,10 @@ func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiI
 		envVariables := canasta.GetEnvVariable(path + "/.env")
 		dbPassword := envVariables["MYSQL_PASSWORD"]
 		if err := orchestrators.ImportDatabase(wikiID, databasePath, dbPassword, tempInstance); err != nil {
+			return err
+		}
+		// Generate secret key and save to .env (DB password already in .env)
+		if err := canasta.GenerateAndSaveSecretKey(path); err != nil {
 			return err
 		}
 	} else {

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -84,9 +84,14 @@ func NewCmdCreate() *cobra.Command {
 				log.Fatal(fmt.Errorf("Error: --admin flag is required when --database is not provided"))
 			}
 
-			// Generate passwords only if not importing (when importing, we skip install.php)
+			// Always generate database passwords
+			if canastaInfo, err = canasta.GenerateDBPasswords(canastaInfo); err != nil {
+				log.Fatal(err)
+			}
+
+			// Generate admin password only if not importing (when importing, we skip install.php)
 			if databasePath == "" {
-				if canastaInfo, err = canasta.GeneratePasswords(workingDir, canastaInfo); err != nil {
+				if canastaInfo, err = canasta.GenerateAdminPassword(canastaInfo); err != nil {
 					log.Fatal(err)
 				}
 			}

--- a/internal/canasta/files/global-settings-README
+++ b/internal/canasta/files/global-settings-README
@@ -1,0 +1,43 @@
+# Global Settings Directory
+
+This directory contains PHP configuration files that apply to ALL wikis in your
+Canasta installation. Files are loaded automatically in alphabetical order.
+
+## File Naming Convention
+
+Use two-digit numeric prefixes (00-99) to control load order. For example:
+
+    00-first.php               # Loaded first
+    30-Vector.php              # Loaded early (default skin configuration)
+    50-extensions.php          # Loaded in the middle
+    90-CanastaFooterIcon.php   # Loaded late (footer icons)
+    99-final.php               # Loaded last (final overrides)
+
+## What to Configure Here
+
+- wfLoadExtension() / wfLoadSkin() calls
+- Default $wgLanguageCode, $wgDefaultSkin, etc.
+- Permission settings ($wgGroupPermissions)
+- Any setting that should be the same across all wikis
+
+## Variables Set Automatically
+
+Do NOT set these here (they are configured automatically from wikis.yaml):
+
+- $wgDBname
+- $wgServer
+- $wgSitename
+- $wgMetaNamespace
+
+## Per-Wiki Overrides
+
+For wiki-specific settings, add files to:
+
+    config/settings/wikis/<wiki_id>/
+
+Per-wiki settings are loaded AFTER global settings and can override them.
+
+## Notes
+
+- All .php files in this directory are loaded automatically
+- Files without the .php extension (like this README) are ignored

--- a/internal/canasta/files/wiki-settings-README
+++ b/internal/canasta/files/wiki-settings-README
@@ -1,0 +1,40 @@
+# Per-Wiki Settings Directory: {WIKI_ID}
+
+This directory contains PHP configuration files specific to this wiki.
+Files are loaded automatically in alphabetical order, AFTER global settings.
+
+## File Naming Convention
+
+Use two-digit numeric prefixes (00-99) to control load order. For example:
+
+    00-first.php   # Loaded first (within this wiki's directory)
+    50-logo.php    # Loaded in the middle
+    99-final.php   # Loaded last (final overrides)
+
+## What to Configure Here
+
+- Wiki-specific $wgLanguageCode
+- Wiki-specific $wgLogo
+- Wiki-specific extensions or skins (wfLoadExtension, wfLoadSkin)
+- Any setting that should differ from global defaults
+
+## Variables Set Automatically
+
+Do NOT set these here (they are configured automatically from wikis.yaml):
+
+- $wgDBname
+- $wgServer
+- $wgSitename
+- $wgMetaNamespace
+
+## Global Settings
+
+For settings that apply to ALL wikis, add files to:
+
+    config/settings/global/
+
+## Notes
+
+- All .php files in this directory are loaded automatically
+- Per-wiki settings override global settings with the same variable
+- Files without the .php extension (like this README) are ignored

--- a/internal/mediawiki/mediawiki.go
+++ b/internal/mediawiki/mediawiki.go
@@ -14,15 +14,21 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-const dbServer = "db"
-const confPath = "/mediawiki/config/"
-const scriptPath = "/w"
+const (
+	dbServer             = "db"
+	confPath             = "/mediawiki/config/"
+	scriptPath           = "/w"
+	localSettingsFile    = "LocalSettings.php"
+	commonSettingsFile   = "CommonSettings.php"
+	localSettingsBackup  = "LocalSettingsBackup.php"
+	commonSettingsBackup = "CommonSettingsBackup.php"
+)
 
 func Install(path, yamlPath, orchestrator string, canastaInfo canasta.CanastaVariables) (canasta.CanastaVariables, error) {
 	var err error
 	logging.Print("Configuring MediaWiki Installation\n")
 	logging.Print("Running install.php\n")
-	settingsName := "CommonSettings.php"
+	settingsName := commonSettingsFile
 
 	command := "/wait-for-it.sh -t 60 db:3306"
 	output, err := orchestrators.ExecWithError(path, orchestrator, "web", command)
@@ -55,12 +61,12 @@ func Install(path, yamlPath, orchestrator string, canastaInfo canasta.CanastaVar
 
 		time.Sleep(time.Second)
 		if i == 0 {
-			err, _ = execute.Run(path, "mv", filepath.Join(path, "config", "LocalSettings.php"), filepath.Join(path, "config", "LocalSettingsBackup.php"))
+			err, _ = execute.Run(path, "mv", filepath.Join(path, "config", localSettingsFile), filepath.Join(path, "config", localSettingsBackup))
 			if err != nil {
 				return canastaInfo, err
 			}
 		} else {
-			err, _ = execute.Run(path, "rm", filepath.Join(path, "config", "LocalSettings.php"))
+			err, _ = execute.Run(path, "rm", filepath.Join(path, "config", localSettingsFile))
 			if err != nil {
 				return canastaInfo, err
 			}
@@ -69,10 +75,10 @@ func Install(path, yamlPath, orchestrator string, canastaInfo canasta.CanastaVar
 	}
 
 	if len(WikiIDs) == 1 {
-		settingsName = "LocalSettings.php"
+		settingsName = localSettingsFile
 	}
 
-	err, _ = execute.Run(path, "mv", filepath.Join(path, "config", "LocalSettingsBackup.php"), filepath.Join(path, "config", settingsName))
+	err, _ = execute.Run(path, "mv", filepath.Join(path, "config", localSettingsBackup), filepath.Join(path, "config", settingsName))
 	if err != nil {
 		return canastaInfo, err
 	}
@@ -91,8 +97,8 @@ func InstallOne(installPath, id, domain, admin, adminPassword, dbuser, workingDi
 		return fmt.Errorf(output)
 	}
 
-	localExists, _ := fileExists(filepath.Join(installPath, "config", "LocalSettings.php"))
-	commonExists, _ := fileExists(filepath.Join(installPath, "config", "CommonSettings.php"))
+	localExists, _ := fileExists(filepath.Join(installPath, "config", localSettingsFile))
+	commonExists, _ := fileExists(filepath.Join(installPath, "config", commonSettingsFile))
 	wikisYamlExists, _ := fileExists(filepath.Join(installPath, "config", "wikis.yaml"))
 
 	if !localExists && !commonExists && !wikisYamlExists {
@@ -110,27 +116,27 @@ func InstallOne(installPath, id, domain, admin, adminPassword, dbuser, workingDi
 		// doesn't think the wiki is already configured
 	} else if commonExists {
 		// Farm already exists with CommonSettings.php - preserve it
-		originalSettingsFile = "CommonSettings.php"
+		originalSettingsFile = commonSettingsFile
 		// Backup the file
-		err, _ = execute.Run(installPath, "cp", filepath.Join(installPath, "config", "CommonSettings.php"), filepath.Join(installPath, "config", "CommonSettingsBackup.php"))
+		err, _ = execute.Run(installPath, "cp", filepath.Join(installPath, "config", commonSettingsFile), filepath.Join(installPath, "config", commonSettingsBackup))
 		if err != nil {
 			return err
 		}
 		// Remove the original so installer doesn't see it
-		err, _ = execute.Run(installPath, "rm", filepath.Join(installPath, "config", "CommonSettings.php"))
+		err, _ = execute.Run(installPath, "rm", filepath.Join(installPath, "config", commonSettingsFile))
 		if err != nil {
 			return err
 		}
 	} else if localExists {
 		// Converting from single wiki (LocalSettings.php) to farm
-		originalSettingsFile = "LocalSettings.php"
+		originalSettingsFile = localSettingsFile
 		// Backup the file
-		err, _ = execute.Run(installPath, "cp", filepath.Join(installPath, "config", "LocalSettings.php"), filepath.Join(installPath, "config", "LocalSettingsBackup.php"))
+		err, _ = execute.Run(installPath, "cp", filepath.Join(installPath, "config", localSettingsFile), filepath.Join(installPath, "config", localSettingsBackup))
 		if err != nil {
 			return err
 		}
 		// Remove the original so installer doesn't see it
-		err, _ = execute.Run(installPath, "rm", filepath.Join(installPath, "config", "LocalSettings.php"))
+		err, _ = execute.Run(installPath, "rm", filepath.Join(installPath, "config", localSettingsFile))
 		if err != nil {
 			return err
 		}
@@ -174,22 +180,22 @@ func InstallOne(installPath, id, domain, admin, adminPassword, dbuser, workingDi
 	// Restore the original settings file as CommonSettings.php (legacy architecture only)
 	if useNewArchitecture {
 		// New architecture: nothing to restore
-	} else if originalSettingsFile == "CommonSettings.php" {
+	} else if originalSettingsFile == commonSettingsFile {
 		// Farm already existed, restore CommonSettings.php from backup
-		err, _ = execute.Run(installPath, "mv", filepath.Join(installPath, "config", "CommonSettingsBackup.php"), filepath.Join(installPath, "config", "CommonSettings.php"))
+		err, _ = execute.Run(installPath, "mv", filepath.Join(installPath, "config", commonSettingsBackup), filepath.Join(installPath, "config", commonSettingsFile))
 		if err != nil {
 			return err
 		}
-	} else if originalSettingsFile == "LocalSettings.php" {
+	} else if originalSettingsFile == localSettingsFile {
 		// Converting single wiki to farm: rename backup to CommonSettings.php
-		err, _ = execute.Run(installPath, "mv", filepath.Join(installPath, "config", "LocalSettingsBackup.php"), filepath.Join(installPath, "config", "CommonSettings.php"))
+		err, _ = execute.Run(installPath, "mv", filepath.Join(installPath, "config", localSettingsBackup), filepath.Join(installPath, "config", commonSettingsFile))
 		if err != nil {
 			return err
 		}
 	}
 
 	// Always remove the newly generated LocalSettings.php (not needed in farm)
-	err, _ = execute.Run(installPath, "rm", filepath.Join(installPath, "config", "LocalSettings.php"))
+	err, _ = execute.Run(installPath, "rm", filepath.Join(installPath, "config", localSettingsFile))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- Replace `GenerateLocalSettings()` with `GenerateAndSaveSecretKey()`
- Save `MW_SECRET_KEY` to `.env` instead of creating `config/LocalSettings.php`
- Delete installer-generated `LocalSettings.php` after installation
- Remove `CommonSettings.php` vs `LocalSettings.php` distinction (all installations are wiki farms)
- Replace `SettingsTemplate.php` with generated README files
- Update directory paths:
  - Global settings: `config/settings/global/`
  - Per-wiki settings: `config/settings/wikis/<wiki_id>/`
- Remove unused `LocalSettingsTemplate.php`

**Fixes `canasta create --database` failing:** Previously, when importing a database dump with `--database`, the CLI skipped `install.php` (which normally generates `config/LocalSettings.php`), causing MediaWiki to fail with "There is no LocalSettings.php/CommonSettings.php file". This PR eliminates the need for `config/LocalSettings.php` entirely by using environment variables (`MW_SECRET_KEY`, `MYSQL_PASSWORD`) instead.

## Issues

Fixes #157, #158, #159

## Related PRs

- CanastaWiki/CanastaBase#59 - Environment variable support and directory structure
- CanastaWiki/Canasta#573 - Update BASE_IMAGE to canasta-base:1.0.8
- CanastaWiki/Canasta-DockerCompose#77 - Remove SettingsTemplate.php, add numeric prefixes to settings files

## Merge Order

1. **CanastaBase #59** - merge first
2. Wait for `canasta-base:1.0.8` image to build
3. **Canasta #573** - update BASE_IMAGE
4. Wait for `canasta:latest` image to build
5. **Canasta-DockerCompose #77**
6. **Canasta-CLI #161** (this PR) - merge last

## Test plan

- [x] Verify `canasta create -i test -w mywiki -n localhost --admin Admin` works (fresh wiki)
- [x] Verify `canasta create -i test -w mywiki -n localhost --database dump.sql` works (imported wiki)
- [x] Verify `MW_SECRET_KEY` is saved to `.env`
- [x] Verify `config/LocalSettings.php` is NOT created
- [x] Verify wiki settings are created in `config/settings/wikis/<wiki_id>/`
- [x] Verify README files are generated with correct content
- [x] Verify existing installations continue to work