### PR TITLE
Wait for database to be ready before importing

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -243,6 +243,13 @@ func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiI
 	// If database path is provided, import the database instead of running install.php
 	if databasePath != "" {
 		logging.Print("Importing database instead of running install.php\n")
+
+		// Wait for database to be ready
+		command := "/wait-for-it.sh -t 60 db:3306"
+		if _, err := orchestrators.ExecWithError(path, orchestrator, "web", command); err != nil {
+			return fmt.Errorf("database not ready: %w", err)
+		}
+
 		envVariables := canasta.GetEnvVariable(path + "/.env")
 		dbPassword := envVariables["MYSQL_PASSWORD"]
 		if err := orchestrators.ImportDatabase(wikiID, databasePath, dbPassword, tempInstance); err != nil {


### PR DESCRIPTION
## Summary

When using `canasta create --database` to import an existing database dump, the import may fail because the CLI attempts to connect to MySQL immediately after starting containers, without waiting for MySQL to be ready.

This PR adds a `wait-for-it.sh` call before importing the database, matching the behavior in `mediawiki.Install()`.

## Issues

Fixes #162

## Test plan

- [x] Verify `canasta create --database dump.sql` waits for MySQL before importing
- [x] Verify import succeeds on first attempt (no race condition)