### PR TITLE
Resolve relative paths from working directory

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -74,6 +74,11 @@ func NewCmdCreate() *cobra.Command {
 				}
 			}
 
+			// Resolve relative database path to absolute (relative to working directory)
+			if databasePath != "" && !filepath.IsAbs(databasePath) {
+				databasePath = filepath.Join(workingDir, databasePath)
+			}
+
 			// Validate --admin is required when --database is not provided
 			if databasePath == "" && canastaInfo.AdminName == "" {
 				log.Fatal(fmt.Errorf("Error: --admin flag is required when --database is not provided"))


### PR DESCRIPTION
## Summary

When using `canasta create --database backup.sql` with a relative path, the CLI was looking for the file relative to the installation directory instead of the working directory where the command was run.

This PR resolves the `--database` path from the working directory, matching the behavior of `--envfile`.

Note: `--wiki-settings` and `--global-settings` already handle relative paths internally in their respective copy functions.

## Issues

Fixes #163

## Test plan

- [x] Verify `canasta create -d backup.sql` works when backup.sql is in the current directory
- [x] Verify `canasta create -d /absolute/path/backup.sql` still works