### PR TITLE
Implement automatic documentation generation for CLI commands using mkdocs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,66 @@
+# Documentation Deployment Workflow
+# Generates CLI documentation from Cobra commands and deploys to GitHub Pages
+
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install MkDocs
+        run: pip install mkdocs mkdocs-material
+
+      - name: Generate CLI Documentation
+        run: |
+          cd tools/docgen
+          go run main.go
+
+      - name: Build MkDocs Site
+        run: mkdocs build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'site'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,10 @@
 *.dll
 *.so
 *.dylib
+
+# YAML files (except mkdocs.yml)
 *.yaml
+!mkdocs.yml
 
 # Build output directory
 build/
@@ -23,3 +26,9 @@ build/
 *~
 .#*
 \#*#
+
+# MkDocs generated site
+site/
+
+# Auto-generated CLI documentation (regenerated on build)
+docs/cli/*.md

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -47,6 +47,11 @@ func Execute() {
 	}
 }
 
+// GetRootCmd returns the root command for documentation generation
+func GetRootCmd() *cobra.Command {
+	return rootCmd
+}
+
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")
 

--- a/docs/cli/.gitkeep
+++ b/docs/cli/.gitkeep
@@ -1,0 +1,2 @@
+# Placeholder for auto-generated CLI documentation
+# This directory contains generated Markdown files from Cobra commands

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,38 @@
+# Canasta CLI
+
+Welcome to the official documentation for **Canasta CLI**, the command-line interface tool for managing [Canasta](https://canasta.wiki/) MediaWiki installations.
+
+## What is Canasta CLI?
+
+Canasta CLI is a powerful tool that allows you to create, manage, and maintain multiple Canasta MediaWiki installations with ease. It supports Docker Compose orchestration and provides features for:
+
+- **Creating** new Canasta installations (single wikis or wiki farms)
+- **Managing** extensions and skins
+- **Backing up** and restoring with Restic
+- **Importing** and exporting wiki data
+- **Upgrading** existing installations
+
+## Supported Platforms
+
+| Platform | Architectures |
+|----------|--------------|
+| Linux | AMD64/x86-64, ARM64/AArch64 |
+| macOS | Intel (AMD64), Apple Silicon (ARM64) |
+| Windows | Use [WSL](https://docs.microsoft.com/en-us/windows/wsl/install) with Linux version |
+
+## Quick Start
+
+```bash
+# Install Canasta CLI
+curl -L https://github.com/CanastaWiki/Canasta-CLI/releases/latest/download/canasta-linux-amd64 -o canasta
+chmod +x canasta
+sudo mv canasta /usr/local/bin/
+
+# Create a new Canasta installation
+sudo canasta create -i my-wiki -w wiki1 -a admin -n localhost
+```
+
+## Next Steps
+
+- [Installation Guide](installation.md) - Detailed installation instructions
+- [CLI Reference](cli/canasta.md) - Complete command documentation

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,64 @@
+# Installation
+
+This guide covers how to install Canasta CLI on your system.
+
+## Prerequisites
+
+- **Docker** and **Docker Compose** must be installed and running
+- **Root/sudo access** for most operations
+
+## Quick Install (Linux/macOS)
+
+Run the automated installer:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/CanastaWiki/Canasta-CLI/main/install.sh | sudo bash
+```
+
+## Manual Installation
+
+### Linux (AMD64)
+
+```bash
+curl -L https://github.com/CanastaWiki/Canasta-CLI/releases/latest/download/canasta-linux-amd64 -o canasta
+chmod +x canasta
+sudo mv canasta /usr/local/bin/
+```
+
+### Linux (ARM64)
+
+```bash
+curl -L https://github.com/CanastaWiki/Canasta-CLI/releases/latest/download/canasta-linux-arm64 -o canasta
+chmod +x canasta
+sudo mv canasta /usr/local/bin/
+```
+
+### macOS (Intel)
+
+```bash
+curl -L https://github.com/CanastaWiki/Canasta-CLI/releases/latest/download/canasta-darwin-amd64 -o canasta
+chmod +x canasta
+sudo mv canasta /usr/local/bin/
+```
+
+### macOS (Apple Silicon)
+
+```bash
+curl -L https://github.com/CanastaWiki/Canasta-CLI/releases/latest/download/canasta-darwin-arm64 -o canasta
+chmod +x canasta
+sudo mv canasta /usr/local/bin/
+```
+
+### Windows
+
+Use [WSL (Windows Subsystem for Linux)](https://docs.microsoft.com/en-us/windows/wsl/install) and install the Linux version.
+
+## Verify Installation
+
+```bash
+canasta version
+```
+
+## Updating
+
+To update Canasta CLI, simply re-run the installation command or download the latest release.

--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,11 @@ require (
 )
 
 require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/term v0.6.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.1 h1:r/myEWzV9lfsM1tFLgDyu0atFtJ1fXn261LKYj/3DxU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -17,6 +18,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/schollz/progressbar/v3 v3.13.1 h1:o8rySDYiQ59Mwzy2FELeHY5ZARXZTVJC7iHD6PEFUiE=
 github.com/schollz/progressbar/v3 v3.13.1/go.mod h1:xvrbki8kfT1fzWzBT/UZd9L6GA+jdL7HAgq2RFnO6fQ=

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,88 @@
+site_name: Canasta CLI Documentation
+site_description: Official documentation for the Canasta CLI tool
+site_url: https://canastawiki.github.io/Canasta-CLI/
+repo_url: https://github.com/CanastaWiki/Canasta-CLI
+repo_name: CanastaWiki/Canasta-CLI
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.sections
+    - navigation.expand
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Installation: installation.md
+  - CLI Reference:
+    - Overview: cli/canasta.md
+    - Commands:
+      - create: cli/canasta_create.md
+      - delete: cli/canasta_delete.md
+      - add: cli/canasta_add.md
+      - remove: cli/canasta_remove.md
+      - start: cli/canasta_start.md
+      - stop: cli/canasta_stop.md
+      - restart: cli/canasta_restart.md
+      - list: cli/canasta_list.md
+      - import: cli/canasta_import.md
+      - export: cli/canasta_export.md
+      - upgrade: cli/canasta_upgrade.md
+      - version: cli/canasta_version.md
+    - extension:
+      - Overview: cli/canasta_extension.md
+      - list: cli/canasta_extension_list.md
+      - enable: cli/canasta_extension_enable.md
+      - disable: cli/canasta_extension_disable.md
+    - skin:
+      - Overview: cli/canasta_skin.md
+      - list: cli/canasta_skin_list.md
+      - enable: cli/canasta_skin_enable.md
+      - disable: cli/canasta_skin_disable.md
+    - maintenance:
+      - Overview: cli/canasta_maintenance.md
+      - update: cli/canasta_maintenance_update.md
+      - script: cli/canasta_maintenance_script.md
+    - restic:
+      - Overview: cli/canasta_restic.md
+      - init: cli/canasta_restic_init.md
+      - view: cli/canasta_restic_view.md
+      - take-snapshot: cli/canasta_restic_take-snapshot.md
+      - restore: cli/canasta_restic_restore.md
+      - forget: cli/canasta_restic_forget.md
+      - list: cli/canasta_restic_list.md
+      - check: cli/canasta_restic_check.md
+      - diff: cli/canasta_restic_diff.md
+      - unlock: cli/canasta_restic_unlock.md
+      - schedule: cli/canasta_restic_schedule.md

--- a/tools/docgen/main.go
+++ b/tools/docgen/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra/doc"
+
+	cmd "github.com/CanastaWiki/Canasta-CLI/cmd/root"
+)
+
+func main() {
+	// Get project root (two directories up from tools/docgen/)
+	projectRoot := filepath.Join("..", "..")
+	docsDir := filepath.Join(projectRoot, "docs", "cli")
+
+	// Create docs/cli directory if it doesn't exist
+	if err := os.MkdirAll(docsDir, 0755); err != nil {
+		log.Fatalf("Failed to create docs directory: %v", err)
+	}
+
+	// Get the root command from the CLI
+	rootCmd := cmd.GetRootCmd()
+	rootCmd.DisableAutoGenTag = true
+
+	// Custom link handler to create MkDocs-compatible links
+	linkHandler := func(name string) string {
+		base := strings.TrimSuffix(name, ".md")
+		return base + ".md"
+	}
+
+	// Custom file prepender to add MkDocs front matter
+	filePrepender := func(filename string) string {
+		name := filepath.Base(filename)
+		name = strings.TrimSuffix(name, ".md")
+		name = strings.ReplaceAll(name, "_", " ")
+		return ""
+	}
+
+	// Generate markdown documentation
+	err := doc.GenMarkdownTreeCustom(rootCmd, docsDir, filePrepender, linkHandler)
+	if err != nil {
+		log.Fatalf("Failed to generate documentation: %v", err)
+	}
+
+	log.Printf("Documentation generated successfully in %s", docsDir)
+}


### PR DESCRIPTION
This pull request introduces a complete documentation system for the Canasta CLI project, automating the generation and deployment of CLI documentation to GitHub Pages. It adds a MkDocs-based static site, a workflow for continuous deployment, and a Go-based tool for generating command documentation from the codebase. The changes also include user-facing documentation files and minor code adjustments to support doc generation.

**Documentation infrastructure and automation:**

* Added a GitHub Actions workflow `.github/workflows/docs.yml` to automatically generate CLI documentation using a Go tool and MkDocs, and deploy it to GitHub Pages on every push to `main` or manual trigger.
* Introduced `tools/docgen/main.go`, a Go program that generates Markdown documentation for all Cobra CLI commands, outputting them to `docs/cli/`.
* Added and configured `mkdocs.yml` for the documentation site, including navigation, theming, and search features.

**CLI code changes for documentation support:**

* Added `GetRootCmd()` to `cmd/root/root.go` to expose the root Cobra command for use by the documentation generator.
* Updated `go.mod` to add dependencies required for Markdown doc generation.

**User-facing documentation content:**

* Added `docs/index.md` and `docs/installation.md` to provide an introduction and installation guide for Canasta CLI. [[1]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R1-R38) [[2]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56R1-R64)
* Added a placeholder `.gitkeep` in `docs/cli/` to ensure the directory exists for generated files.