### PR TITLE
Replace git pull with selective fetch+checkout in upgrade

### DIFF
--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -116,7 +116,8 @@ func Upgrade(instance config.Installation, dryRun bool) error {
 	}
 
 	fmt.Println("Checking for repo changes...")
-	if err = git.FetchAndCheckout(instance.Path, dryRun); err != nil {
+	repoChanged, err := git.FetchAndCheckout(instance.Path, dryRun)
+	if err != nil {
 		return err
 	}
 
@@ -127,30 +128,39 @@ func Upgrade(instance config.Installation, dryRun bool) error {
 	}
 
 	// Run migration steps (before restart so config is correct when containers come up)
-	if err = runMigration(instance.Path, dryRun); err != nil {
+	migrationsNeeded, err := runMigration(instance.Path, dryRun)
+	if err != nil {
 		return err
 	}
 
-	if !dryRun {
-		// Restart the containers
-		if err = orchestrators.StopAndStart(instance); err != nil {
-			return err
+	if dryRun {
+		fmt.Println()
+		if repoChanged || migrationsNeeded {
+			fmt.Println("Run 'canasta upgrade' to apply these changes.")
+		} else {
+			fmt.Println("Installation is up to date. No upgrade needed.")
 		}
-
-		// Touch LocalSettings.php to flush cache
-		fmt.Print("Running 'touch LocalSettings.php' to flush cache\n")
-		_, err = orchestrators.ExecWithError(instance.Path, instance.Orchestrator, "web", "touch LocalSettings.php")
-		if err != nil {
-			return err
-		}
-		fmt.Print("Canasta Upgraded!\n")
+		return nil
 	}
+
+	// Restart the containers
+	if err = orchestrators.StopAndStart(instance); err != nil {
+		return err
+	}
+
+	// Touch LocalSettings.php to flush cache
+	fmt.Print("Running 'touch LocalSettings.php' to flush cache\n")
+	_, err = orchestrators.ExecWithError(instance.Path, instance.Orchestrator, "web", "touch LocalSettings.php")
+	if err != nil {
+		return err
+	}
+	fmt.Print("Canasta Upgraded!\n")
 
 	return nil
 }
 
 // runMigration orchestrates all migration steps
-func runMigration(installPath string, dryRun bool) error {
+func runMigration(installPath string, dryRun bool) (bool, error) {
 	fmt.Println("Checking for config migrations...")
 
 	changed := false
@@ -158,7 +168,7 @@ func runMigration(installPath string, dryRun bool) error {
 	// Step 1: Extract or generate MW_SECRET_KEY
 	keyChanged, err := extractSecretKey(installPath, dryRun)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if keyChanged {
 		changed = true
@@ -167,7 +177,7 @@ func runMigration(installPath string, dryRun bool) error {
 	// Step 2: Migrate directory structure
 	dirChanged, err := migrateDirectoryStructure(installPath, dryRun)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if dirChanged {
 		changed = true
@@ -176,7 +186,7 @@ func runMigration(installPath string, dryRun bool) error {
 	// Step 3: Fix Vector.php default skin
 	vectorChanged, err := fixVectorDefaultSkin(installPath, dryRun)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if vectorChanged {
 		changed = true
@@ -185,12 +195,12 @@ func runMigration(installPath string, dryRun bool) error {
 	if !changed {
 		fmt.Println("No config migrations needed.")
 	} else if dryRun {
-		fmt.Println("Run 'canasta upgrade' without --dry-run to apply these changes.")
+		fmt.Println("Config migrations would be applied.")
 	} else {
 		fmt.Println("Migrations applied.")
 	}
 
-	return nil
+	return changed, nil
 }
 
 // extractSecretKey extracts $wgSecretKey from PHP config files into .env as MW_SECRET_KEY,

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -115,13 +115,12 @@ func Upgrade(instance config.Installation, dryRun bool) error {
 		fmt.Println("Dry run mode - showing what would change without applying")
 	}
 
-	if !dryRun {
-		fmt.Print("Pulling the latest changes\n")
-		// Pull the latest changes from GitHub
-		if err = git.FetchAndCheckout(instance.Path); err != nil {
-			return err
-		}
+	fmt.Println("Checking for repo changes...")
+	if err = git.FetchAndCheckout(instance.Path, dryRun); err != nil {
+		return err
+	}
 
+	if !dryRun {
 		if err = orchestrators.Pull(instance.Path, instance.Orchestrator); err != nil {
 			return err
 		}

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -183,7 +183,7 @@ func runMigration(installPath string, dryRun bool) error {
 	}
 
 	if !changed {
-		fmt.Println("No migrations needed.")
+		fmt.Println("No config migrations needed.")
 	} else if dryRun {
 		fmt.Println("Run 'canasta upgrade' without --dry-run to apply these changes.")
 	} else {

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -118,7 +118,7 @@ func Upgrade(instance config.Installation, dryRun bool) error {
 	if !dryRun {
 		fmt.Print("Pulling the latest changes\n")
 		// Pull the latest changes from GitHub
-		if err = git.Pull(instance.Path); err != nil {
+		if err = git.FetchAndCheckout(instance.Path); err != nil {
 			return err
 		}
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -2,6 +2,8 @@ package git
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/execute"
@@ -100,9 +102,24 @@ func FetchAndCheckout(path string, dryRun bool) error {
 				fmt.Printf("  %s\n", file)
 			}
 		}
-		if len(skippedFiles) > 0 {
-			fmt.Println("Files that differ from upstream but will be preserved locally (if they exist):")
-			for _, file := range skippedFiles {
+		var preservedFiles []string
+		var absentFiles []string
+		for _, file := range skippedFiles {
+			if _, err := os.Stat(filepath.Join(path, file)); err == nil {
+				preservedFiles = append(preservedFiles, file)
+			} else {
+				absentFiles = append(absentFiles, file)
+			}
+		}
+		if len(preservedFiles) > 0 {
+			fmt.Println("Files that differ from upstream but will be preserved locally:")
+			for _, file := range preservedFiles {
+				fmt.Printf("  %s\n", file)
+			}
+		}
+		if len(absentFiles) > 0 {
+			fmt.Println("Files absent locally that will not be restored from upstream:")
+			for _, file := range absentFiles {
 				fmt.Printf("  %s\n", file)
 			}
 		}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -140,13 +140,13 @@ func FetchAndCheckout(path string, dryRun bool) error {
 			}
 		}
 		if len(preservedFiles) > 0 {
-			fmt.Println("Files with local modifications that will be preserved:")
+			fmt.Println("Files with local modifications that would be preserved:")
 			for _, file := range preservedFiles {
 				fmt.Printf("  %s\n", file)
 			}
 		}
 		if len(absentFiles) > 0 {
-			fmt.Println("Files absent locally that will not be restored from upstream:")
+			fmt.Println("Files absent locally that would not be restored from upstream:")
 			for _, file := range absentFiles {
 				fmt.Printf("  %s\n", file)
 			}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -166,11 +166,10 @@ func FetchAndCheckout(path string, dryRun bool) (bool, error) {
 	}
 
 	// Remove files that were deleted in origin/main
-	if len(filesToRemove) > 0 {
-		args := append([]string{"rm", "--"}, filesToRemove...)
-		err, output = execute.Run(path, "git", args...)
-		if err != nil {
-			return false, fmt.Errorf(output)
+	for _, file := range filesToRemove {
+		filePath := filepath.Join(path, file)
+		if err := os.Remove(filePath); err != nil && !os.IsNotExist(err) {
+			return false, fmt.Errorf("failed to remove %s: %w", file, err)
 		}
 	}
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -101,7 +101,7 @@ func FetchAndCheckout(path string, dryRun bool) error {
 			}
 		}
 		if len(skippedFiles) > 0 {
-			fmt.Println("Files that differ from upstream but will be preserved locally:")
+			fmt.Println("Files that differ from upstream but will be preserved locally (if they exist):")
 			for _, file := range skippedFiles {
 				fmt.Printf("  %s\n", file)
 			}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -173,6 +173,13 @@ func FetchAndCheckout(path string, dryRun bool) (bool, error) {
 		}
 	}
 
+	// Move HEAD and index to origin/main so future diffs reflect the updated state.
+	// Working tree is left as-is (denylist files keep their local changes).
+	err, output = execute.Run(path, "git", "reset", "origin/main")
+	if err != nil {
+		return false, fmt.Errorf(output)
+	}
+
 	return true, nil
 }
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -2,9 +2,21 @@ package git
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/execute"
 )
+
+// skipPaths are files/directories that should never be overwritten during upgrade.
+// Users may modify or delete these locally.
+var skipPaths = []string{
+	"my.cnf",
+	"docker-compose.override.yml",
+	"config/settings/",
+	"config/Caddyfile.custom",
+	"config/composer.local.json",
+	"config/default.vcl",
+}
 
 func Clone(repo, path string) error {
 	err, output := execute.Run("", "git", "clone", repo, path)
@@ -13,6 +25,7 @@ func Clone(repo, path string) error {
 	}
 	return nil
 }
+
 func Cloneb(repo, path string, branch string) error {
 	err, output := execute.Run("", "git", "clone", "-b", branch, repo, path)
 	if err != nil {
@@ -21,10 +34,58 @@ func Cloneb(repo, path string, branch string) error {
 	return nil
 }
 
-func Pull(path string) error {
-	err, output := execute.Run(path, "git", "pull", "origin", "main")
+// FetchAndCheckout fetches from origin and selectively checks out files from
+// origin/main, skipping user-modifiable files listed in skipPaths. This avoids
+// merge conflicts when local commits diverge from upstream and preserves any
+// files the user has customized or deleted.
+func FetchAndCheckout(path string) error {
+	// Fetch latest from origin
+	err, output := execute.Run(path, "git", "fetch", "origin")
+	if err != nil {
+		return fmt.Errorf(output)
+	}
+
+	// Get list of files that differ between local and upstream
+	err, output = execute.Run(path, "git", "diff", "--name-only", "HEAD", "origin/main")
+	if err != nil {
+		return fmt.Errorf(output)
+	}
+
+	// Filter out denied paths
+	var filesToUpdate []string
+	for _, file := range strings.Split(strings.TrimSpace(output), "\n") {
+		if file == "" {
+			continue
+		}
+		if !isSkipped(file) {
+			filesToUpdate = append(filesToUpdate, file)
+		}
+	}
+
+	if len(filesToUpdate) == 0 {
+		return nil
+	}
+
+	// Checkout only the safe files from origin/main
+	args := append([]string{"checkout", "origin/main", "--"}, filesToUpdate...)
+	err, output = execute.Run(path, "git", args...)
 	if err != nil {
 		return fmt.Errorf(output)
 	}
 	return nil
+}
+
+// isSkipped returns true if the file matches any entry in skipPaths.
+// Directory entries (ending in /) match any file under that path.
+func isSkipped(file string) bool {
+	for _, skip := range skipPaths {
+		if strings.HasSuffix(skip, "/") {
+			if strings.HasPrefix(file, skip) {
+				return true
+			}
+		} else if file == skip {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/orchestrators/orchestrators.go
+++ b/internal/orchestrators/orchestrators.go
@@ -127,12 +127,12 @@ func Pull(installPath, orchestrator string) error {
 	case "compose":
 		compose := config.GetOrchestrator("compose")
 		if compose.Path != "" {
-			err, output := execute.Run(installPath, compose.Path, "pull")
+			err, output := execute.Run(installPath, compose.Path, "pull", "--ignore-buildable")
 			if err != nil {
 				return fmt.Errorf(output)
 			}
 		} else {
-			err, output := execute.Run(installPath, "docker", "compose", "pull")
+			err, output := execute.Run(installPath, "docker", "compose", "pull", "--ignore-buildable")
 			if err != nil {
 				return fmt.Errorf(output)
 			}

--- a/internal/orchestrators/orchestrators.go
+++ b/internal/orchestrators/orchestrators.go
@@ -127,12 +127,12 @@ func Pull(installPath, orchestrator string) error {
 	case "compose":
 		compose := config.GetOrchestrator("compose")
 		if compose.Path != "" {
-			err, output := execute.Run(installPath, compose.Path, "pull", "--ignore-buildable")
+			err, output := execute.Run(installPath, compose.Path, "pull", "--ignore-buildable", "--ignore-pull-failures")
 			if err != nil {
 				return fmt.Errorf(output)
 			}
 		} else {
-			err, output := execute.Run(installPath, "docker", "compose", "pull", "--ignore-buildable")
+			err, output := execute.Run(installPath, "docker", "compose", "pull", "--ignore-buildable", "--ignore-pull-failures")
 			if err != nil {
 				return fmt.Errorf(output)
 			}


### PR DESCRIPTION
## Summary

- Replaces `git pull origin main` with `git fetch` + selective `git checkout` to avoid merge conflicts when the installation directory has diverged from upstream
- Introduces a denylist of user-modifiable files (`my.cnf`, `docker-compose.override.yml`, `config/settings/`, etc.) that are never overwritten during upgrade
- New upstream files are automatically picked up without needing an allowlist

Fixes #180

## Test plan

- [x] `canasta upgrade` on a clean installation updates upstream files
- [x] `canasta upgrade` on an installation with divergent local commits succeeds without conflict
- [x] `canasta upgrade` on an installation with deleted settings files succeeds without restoring them
- [x] `canasta upgrade` on an installation with modified `my.cnf` or `docker-compose.override.yml` leaves them untouched
- [x] `canasta upgrade --dry-run` still works (skips the fetch/checkout entirely)
- [x] `go build ./...` succeeds