### PR TITLE
Add --wiki/--all flags and streaming output to maintenance commands

### DIFF
--- a/cmd/maintenanceUpdate/maintenance.go
+++ b/cmd/maintenanceUpdate/maintenance.go
@@ -10,6 +10,8 @@ import (
 
 var (
 	instance config.Installation
+	wiki     string
+	all      bool
 	err      error
 )
 
@@ -32,5 +34,7 @@ runJobs.php, and SMW rebuildData.php) or execute arbitrary maintenance scripts.`
 	maintenanceCmd.AddCommand(scriptCmdCreate())
 
 	maintenanceCmd.PersistentFlags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
+	maintenanceCmd.PersistentFlags().StringVarP(&wiki, "wiki", "w", "", "Wiki ID to run maintenance on")
+	maintenanceCmd.PersistentFlags().BoolVar(&all, "all", false, "Run for all wikis in the farm")
 	return maintenanceCmd
 }

--- a/cmd/maintenanceUpdate/maintenanceUpdate.go
+++ b/cmd/maintenanceUpdate/maintenanceUpdate.go
@@ -2,12 +2,21 @@ package maintenance
 
 import (
 	"fmt"
+	"log"
+	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
+)
+
+var (
+	skipJobs bool
+	skipSMW  bool
 )
 
 func updateCmdCreate() *cobra.Command {
@@ -17,23 +26,98 @@ func updateCmdCreate() *cobra.Command {
 		Short: "Run maintenance update jobs",
 		Long: `Run the standard MediaWiki maintenance update sequence: update.php,
 runJobs.php, and Semantic MediaWiki's rebuildData.php. This is typically
-needed after upgrading MediaWiki or enabling new extensions.`,
-		Example: `  canasta maintenance update -i myinstance`,
+needed after upgrading MediaWiki or enabling new extensions.
+
+By default, all three scripts are run. Use --skip-jobs to skip runJobs.php
+and --skip-smw to skip rebuildData.php.
+
+In a wiki farm, use --wiki to target a specific wiki, or --all to run
+maintenance on every wiki. If there is only one wiki, it is selected
+automatically.`,
+		Example: `  canasta maintenance update -i myinstance
+  canasta maintenance update -i myinstance --wiki=docs
+  canasta maintenance update -i myinstance --all
+  canasta maintenance update -i myinstance --skip-jobs --skip-smw`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			instance, err = canasta.CheckCanastaId(instance)
 			return err
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			runMaintenanceUpdate(instance)
+			if wiki != "" && all {
+				log.Fatal("cannot use --wiki with --all")
+			}
+			if all {
+				wikiIDs := getWikiIDs(instance)
+				for _, id := range wikiIDs {
+					runMaintenanceUpdate(instance, id)
+				}
+			} else if wiki != "" {
+				runMaintenanceUpdate(instance, wiki)
+			} else {
+				wikiIDs := getWikiIDs(instance)
+				if len(wikiIDs) == 1 {
+					runMaintenanceUpdate(instance, wikiIDs[0])
+				} else {
+					log.Fatal("multiple wikis found; use --wiki=<id> or --all")
+				}
+			}
 		},
 	}
+
+	updateCmd.Flags().BoolVar(&skipJobs, "skip-jobs", false, "Skip running runJobs.php")
+	updateCmd.Flags().BoolVar(&skipSMW, "skip-smw", false, "Skip running Semantic MediaWiki rebuildData.php")
 
 	return updateCmd
 }
 
-func runMaintenanceUpdate(instance config.Installation) {
-	fmt.Println("Running maintenance jobs")
-	orchestrators.Exec(instance.Path, instance.Orchestrator, "web", "php maintenance/update.php && php maintenance/runJobs.php && php canasta-extensions/SemanticMediaWiki/maintenance/rebuildData.php")
-	fmt.Println("Completed running maintenance jobs")
+func getWikiIDs(instance config.Installation) []string {
+	yamlPath := filepath.Join(instance.Path, "config", "wikis.yaml")
+	ids, _, _, err := farmsettings.ReadWikisYaml(yamlPath)
+	if err != nil {
+		log.Fatalf("failed to read wikis.yaml: %v", err)
+	}
+	return ids
+}
 
+func runMaintenanceUpdate(instance config.Installation, wikiID string) {
+	wikiFlag := ""
+	if wikiID != "" {
+		wikiFlag = " --wiki=" + wikiID
+	}
+	wikiMsg := ""
+	if wikiID != "" {
+		wikiMsg = " for wiki '" + wikiID + "'"
+	}
+
+	fmt.Printf("Running update.php%s...\n", wikiMsg)
+	if err := orchestrators.ExecStreaming(instance.Path, instance.Orchestrator, "web",
+		"php maintenance/update.php"+wikiFlag); err != nil {
+		log.Fatalf("update.php failed%s: %v", wikiMsg, err)
+	}
+
+	if !skipJobs {
+		fmt.Printf("Running runJobs.php%s...\n", wikiMsg)
+		if err := orchestrators.ExecStreaming(instance.Path, instance.Orchestrator, "web",
+			"php maintenance/runJobs.php"+wikiFlag); err != nil {
+			log.Fatalf("runJobs.php failed%s: %v", wikiMsg, err)
+		}
+	}
+
+	if !skipSMW {
+		smwCheck := fmt.Sprintf(
+			`php maintenance/eval.php%s --expression="echo defined('SMW_VERSION') ? 'yes' : 'no';"`,
+			wikiFlag)
+		smwOutput, smwErr := orchestrators.ExecWithError(instance.Path, instance.Orchestrator, "web", smwCheck)
+		if smwErr != nil || !strings.Contains(smwOutput, "yes") {
+			fmt.Printf("Semantic MediaWiki not enabled%s, skipping rebuildData.php\n", wikiMsg)
+		} else {
+			fmt.Printf("Running rebuildData.php%s...\n", wikiMsg)
+			if err := orchestrators.ExecStreaming(instance.Path, instance.Orchestrator, "web",
+				"php extensions/SemanticMediaWiki/maintenance/rebuildData.php"+wikiFlag); err != nil {
+				log.Fatalf("rebuildData.php failed%s: %v", wikiMsg, err)
+			}
+		}
+	}
+
+	fmt.Printf("Completed maintenance%s\n", wikiMsg)
 }

--- a/cmd/maintenanceUpdate/maintenanceUpdate.go
+++ b/cmd/maintenanceUpdate/maintenanceUpdate.go
@@ -91,7 +91,7 @@ func runMaintenanceUpdate(instance config.Installation, wikiID string) {
 
 	fmt.Printf("Running update.php%s...\n", wikiMsg)
 	if err := orchestrators.ExecStreaming(instance.Path, instance.Orchestrator, "web",
-		"php maintenance/update.php"+wikiFlag); err != nil {
+		"php maintenance/update.php --quick"+wikiFlag); err != nil {
 		log.Fatalf("update.php failed%s: %v", wikiMsg, err)
 	}
 

--- a/docs/guide/general-concepts.md
+++ b/docs/guide/general-concepts.md
@@ -10,6 +10,7 @@ This page covers foundational concepts that apply to all Canasta installations, 
 - [Importing an existing wiki](#importing-an-existing-wiki)
 - [Maintenance scripts](#maintenance-scripts)
   - [Automatic maintenance](#automatic-maintenance)
+  - [Running the update sequence](#running-the-update-sequence)
   - [Running scripts manually](#running-scripts-manually)
 - [conf.json](#confjson)
 - [Running on non-standard ports](#running-on-non-standard-ports)
@@ -160,12 +161,42 @@ You generally do not need to run maintenance scripts manually:
 - **`update.php`** runs automatically during container startup. If you need to run it, simply restart the installation with `canasta restart`.
 - **`runJobs.php`** runs automatically in the background for the entire life of the container.
 
+### Running the update sequence
+
+Use `canasta maintenance update` to run the standard update sequence: `update.php`, `runJobs.php`, and (if Semantic MediaWiki is installed) `rebuildData.php`. Each script runs separately with its output streamed in real time.
+
+```bash
+canasta maintenance update -i myinstance
+```
+
+In a wiki farm, use `--wiki` to target a specific wiki or `--all` to run on every wiki:
+
+```bash
+canasta maintenance update -i myinstance --wiki=docs
+canasta maintenance update -i myinstance --all
+```
+
+If the installation has only one wiki, it is selected automatically. If there are multiple wikis and neither `--wiki` nor `--all` is specified, the command will error with guidance.
+
+Use `--skip-jobs` and `--skip-smw` to skip individual steps:
+
+```bash
+# Run only update.php
+canasta maintenance update -i myinstance --skip-jobs --skip-smw
+```
+
 ### Running scripts manually
 
-To run a maintenance script, use `canasta maintenance script`. Wrap the script name and any arguments in quotes so they are passed as a single argument:
+To run an arbitrary maintenance script, use `canasta maintenance script`. Wrap the script name and any arguments in quotes so they are passed as a single argument:
 
 ```bash
 canasta maintenance script "createAndPromote.php WikiSysop MyPassword --bureaucrat --sysop" -i myinstance
+```
+
+Use `--wiki` to target a specific wiki in a farm:
+
+```bash
+canasta maintenance script "rebuildrecentchanges.php" -i myinstance --wiki=docs
 ```
 
 See the [CLI Reference](../cli/canasta_maintenance.md) for more details.


### PR DESCRIPTION
## Summary

Closes #182

- Add `--wiki` / `-w` and `--all` persistent flags to the `maintenance` parent command, available to both `update` and `script` subcommands
- Add `ExecStreaming()` to orchestrators that pipes container stdout/stderr directly to the terminal for real-time output
- Split `maintenance update` into separate per-script invocations with `--skip-jobs` and `--skip-smw` flags
- Auto-detect Semantic MediaWiki before running `rebuildData.php`
- Auto-select wiki when only one exists; error with guidance when multiple wikis exist and no flag is given

## Test plan

- [x] `canasta maintenance update -i <id>` on a single-wiki farm auto-selects the wiki and streams output
- [x] `canasta maintenance update -i <id> --wiki=<id>` runs for that specific wiki
- [x] `canasta maintenance update -i <id> --all` runs for all wikis
- [x] `canasta maintenance update -i <id>` on a multi-wiki farm without `--wiki`/`--all` errors with guidance
- [x] `canasta maintenance update --skip-jobs --skip-smw` runs only `update.php`
- [x] `canasta maintenance script "rebuildrecentchanges.php" --wiki=<id>` passes `--wiki` through
- [x] Output streams in real-time instead of appearing all at once at the end