### PR TITLE
Remove sudo from install.sh message and README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Canasta CLI supports the following platforms:
 **Description:** Creates a Canasta installation. Enhanced to support wiki farm setup with the `-f` flag.
 
 **Usage:**
-sudo canasta create [flags]
+canasta create [flags]
 - `-p, --path`: Canasta directory.
 - `-o, --orchestrator`: Orchestrator to use for installation (default: "compose").
 - `-i, --id`: Canasta instance ID.
@@ -44,7 +44,7 @@ wikis:
 Then run the following:
 
 ```bash
-sudo canasta create -f [yamlfile] # Example: "wikis.yaml"
+canasta create -f [yamlfile] # Example: "wikis.yaml"
 ```
 
 ### extension
@@ -57,7 +57,7 @@ sudo canasta create -f [yamlfile] # Example: "wikis.yaml"
 
 **Usage:**
 ```bash
-sudo canasta extension [subcommand] [flags]
+canasta extension [subcommand] [flags]
 ```
 **Flags:**
 - `-i, --id`: Specifies the Canasta instance ID.
@@ -70,7 +70,7 @@ sudo canasta extension [subcommand] [flags]
 
 **Usage:**
 ```bash
-sudo canasta add [flags]
+canasta add [flags]
 ```
 **Flags:**
 - `-w, --wiki`: ID of the new wiki (required).
@@ -90,7 +90,7 @@ sudo canasta add [flags]
 
 **Usage:**
 ```bash
-sudo canasta remove [flags]
+canasta remove [flags]
 ```
 **Flags:**
 - `-w, --wiki`: ID of the wiki to be removed.

--- a/install.sh
+++ b/install.sh
@@ -238,7 +238,7 @@ main() {
   download_and_install
   if [ "$SKIP_CHECKS" = false ]; then
     echo "Please make sure you have a working kubectl if you wish to use Kubernetes as an orchestrator."
-    echo -e "\nUsage: sudo canasta [COMMAND] [ARGUMENTS...]"
+    echo -e "\nUsage: canasta [COMMAND] [ARGUMENTS...]"
   fi
 }
 main "$@"


### PR DESCRIPTION
## Summary

Closes #186

- Remove `sudo` from the post-install usage message in `install.sh`
- Remove `sudo` from all command examples in `README.md`

The CLI no longer requires sudo to run.

## Test plan

- [x] Run `install.sh` and verify the usage message shows `canasta` without `sudo`
- [x] Review README examples show `canasta` without `sudo`