### PR TITLE
Fix missing return value in runMigration

### DIFF
--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -195,7 +195,7 @@ func runMigration(installPath string, dryRun bool) (bool, error) {
 	// Step 4: Create Caddyfile.custom and update Caddyfile with import directive
 	caddyChanged, err := createCaddyfileCustom(installPath, dryRun)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if caddyChanged {
 		changed = true


### PR DESCRIPTION
## Summary
- Fix compile error in `cmd/upgrade/upgrade.go:198` where `return err` should be `return false, err`

## Context
This was introduced in PR #179 (Caddyfile.custom migration step). The `runMigration` function returns `(bool, error)` but the error check after `createCaddyfileCustom` was only returning the error.

This is blocking the CI build and needs to be merged before a new release can be cut.