### PR TITLE
Improve upgrade output and fix MW_SECRET_KEY handling during create

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -186,13 +186,22 @@ func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiI
 	// Determine the base image to use
 	var baseImage string
 	if buildFromPath != "" {
-		// Build Canasta (and optionally CanastaBase) from source
-		logging.Print("Building Canasta from local source...\n")
-		builtImage, err := imagebuild.BuildFromSource(buildFromPath)
-		if err != nil {
-			return fmt.Errorf("failed to build from source: %w", err)
+		// Check if local Canasta repo exists for building
+		canastaPath := filepath.Join(buildFromPath, "Canasta")
+		if _, err := os.Stat(canastaPath); err == nil {
+			// Build Canasta (and optionally CanastaBase) from source
+			logging.Print("Building Canasta from local source...\n")
+			builtImage, err := imagebuild.BuildFromSource(buildFromPath)
+			if err != nil {
+				return fmt.Errorf("failed to build from source: %w", err)
+			}
+			baseImage = builtImage
+		} else {
+			// No local Canasta repo, use registry image
+			// (buildFromPath may still have Canasta-DockerCompose for CloneStackRepo)
+			logging.Print("No local Canasta repo found, using registry image\n")
+			baseImage = canasta.GetImageWithTag(devTag)
 		}
-		baseImage = builtImage
 	} else {
 		// Use registry image with specified tag
 		baseImage = canasta.GetImageWithTag(devTag)

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -186,22 +186,13 @@ func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiI
 	// Determine the base image to use
 	var baseImage string
 	if buildFromPath != "" {
-		// Check if local Canasta repo exists for building
-		canastaPath := filepath.Join(buildFromPath, "Canasta")
-		if _, err := os.Stat(canastaPath); err == nil {
-			// Build Canasta (and optionally CanastaBase) from source
-			logging.Print("Building Canasta from local source...\n")
-			builtImage, err := imagebuild.BuildFromSource(buildFromPath)
-			if err != nil {
-				return fmt.Errorf("failed to build from source: %w", err)
-			}
-			baseImage = builtImage
-		} else {
-			// No local Canasta repo, use registry image
-			// (buildFromPath may still have Canasta-DockerCompose for CloneStackRepo)
-			logging.Print("No local Canasta repo found, using registry image\n")
-			baseImage = canasta.GetImageWithTag(devTag)
+		// Build Canasta (and optionally CanastaBase) from source
+		logging.Print("Building Canasta from local source...\n")
+		builtImage, err := imagebuild.BuildFromSource(buildFromPath)
+		if err != nil {
+			return fmt.Errorf("failed to build from source: %w", err)
 		}
+		baseImage = builtImage
 	} else {
 		// Use registry image with specified tag
 		baseImage = canasta.GetImageWithTag(devTag)

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -317,16 +317,23 @@ func generateSecretKey() (string, error) {
 	return hex.EncodeToString(bytes), nil
 }
 
-// GenerateAndSaveSecretKey generates a secret key and saves it to .env as MW_SECRET_KEY
-// This is used for all installations - both fresh installs and database imports
+// GenerateAndSaveSecretKey generates a secret key and saves it to .env as MW_SECRET_KEY,
+// unless MW_SECRET_KEY is already set (e.g. provided by the user via -e flag).
 func GenerateAndSaveSecretKey(installPath string) error {
+	envPath := installPath + "/.env"
+	envVars := GetEnvVariable(envPath)
+	if val, ok := envVars["MW_SECRET_KEY"]; ok && val != "" {
+		logging.Print("MW_SECRET_KEY already set in .env, skipping generation\n")
+		return nil
+	}
+
 	secretKey, err := generateSecretKey()
 	if err != nil {
 		return fmt.Errorf("failed to generate secret key: %w", err)
 	}
 
 	logging.Print("Generating MW_SECRET_KEY and saving to .env\n")
-	return SaveEnvVariable(installPath+"/.env", "MW_SECRET_KEY", secretKey)
+	return SaveEnvVariable(envPath, "MW_SECRET_KEY", secretKey)
 }
 
 func RewriteSettings(installPath string, WikiIDs []string) error {

--- a/internal/mediawiki/mediawiki.go
+++ b/internal/mediawiki/mediawiki.go
@@ -89,9 +89,11 @@ func Install(path, yamlPath, orchestrator string, canastaInfo canasta.CanastaVar
 			}
 		}
 
-		// Delete the installer-generated LocalSettings.php (not needed with new architecture).
-		// This runs for all wikis in the loop, but MW_SECRET_KEY extraction only happens for the
-		// first wiki (i == 0) since all wikis in a farm share the same secret key.
+		// Delete the installer-generated LocalSettings.php. The installer creates a LocalSettings.php
+		// for each wiki, but they are identical except for $wgSecretKey. We only need to extract the
+		// secret key from the first wiki's file (done above when i == 0), after which all these
+		// generated files are unnecessary—Canasta uses its own LocalSettings.php that reads
+		// MW_SECRET_KEY from the environment.
 		var rmOutput string
 		err, rmOutput = execute.Run(path, "rm", filepath.Join(path, "config", localSettingsFile))
 		if err != nil {

--- a/internal/mediawiki/mediawiki.go
+++ b/internal/mediawiki/mediawiki.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"time"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
@@ -28,7 +29,6 @@ func Install(path, yamlPath, orchestrator string, canastaInfo canasta.CanastaVar
 	var err error
 	logging.Print("Configuring MediaWiki Installation\n")
 	logging.Print("Running install.php\n")
-	settingsName := commonSettingsFile
 
 	command := "/wait-for-it.sh -t 60 db:3306"
 	output, err := orchestrators.ExecWithError(path, orchestrator, "web", command)
@@ -44,7 +44,8 @@ func Install(path, yamlPath, orchestrator string, canastaInfo canasta.CanastaVar
 		wikiID := WikiIDs[i]
 		domainName := domainNames[i]
 
-		command := fmt.Sprintf("php maintenance/install.php --skins='Vector' --dbserver=%s --dbname='%s' --confpath=%s --scriptpath=%s --server='https://%s' --installdbuser='%s' --installdbpass='%s' --dbuser='%s' --dbpass='%s' --pass='%s' '%s' '%s'",
+		// Unset MW_SECRET_KEY so CanastaDefaultSettings.php doesn't think wiki is already configured
+		command := fmt.Sprintf("env -u MW_SECRET_KEY php maintenance/install.php --skins='Vector' --dbserver=%s --dbname='%s' --confpath=%s --scriptpath=%s --server='https://%s' --installdbuser='%s' --installdbpass='%s' --dbuser='%s' --dbpass='%s' --pass='%s' '%s' '%s'",
 			dbServer, wikiID, confPath, scriptPath, domainName, "root", canastaInfo.RootDBPassword, canastaInfo.WikiDBUsername, canastaInfo.WikiDBPassword, canastaInfo.AdminPassword, wikiID, canastaInfo.AdminName)
 
 		output, err = orchestrators.ExecWithError(path, orchestrator, "web", command)
@@ -60,29 +61,44 @@ func Install(path, yamlPath, orchestrator string, canastaInfo canasta.CanastaVar
 		}
 
 		time.Sleep(time.Second)
+
+		// For the first wiki, ensure MW_SECRET_KEY is in .env
 		if i == 0 {
-			err, _ = execute.Run(path, "mv", filepath.Join(path, "config", localSettingsFile), filepath.Join(path, "config", localSettingsBackup))
-			if err != nil {
-				return canastaInfo, err
-			}
-		} else {
-			err, _ = execute.Run(path, "rm", filepath.Join(path, "config", localSettingsFile))
-			if err != nil {
-				return canastaInfo, err
+			envPath := filepath.Join(path, ".env")
+			envVars := canasta.GetEnvVariable(envPath)
+			if val, ok := envVars["MW_SECRET_KEY"]; ok && val != "" {
+				logging.Print("MW_SECRET_KEY already set in .env, skipping extraction\n")
+			} else {
+				localSettingsPath := filepath.Join(path, "config", localSettingsFile)
+				content, err := os.ReadFile(localSettingsPath)
+				if err != nil {
+					return canastaInfo, fmt.Errorf("failed to read LocalSettings.php: %w", err)
+				}
+
+				secretKeyRegex := regexp.MustCompile(`\$wgSecretKey\s*=\s*["']([a-f0-9]+)["']`)
+				matches := secretKeyRegex.FindSubmatch(content)
+				if matches == nil {
+					return canastaInfo, fmt.Errorf("could not find $wgSecretKey in LocalSettings.php")
+				}
+				secretKey := string(matches[1])
+
+				if err := canasta.SaveEnvVariable(envPath, "MW_SECRET_KEY", secretKey); err != nil {
+					return canastaInfo, fmt.Errorf("failed to save MW_SECRET_KEY to .env: %w", err)
+				}
+				logging.Print("Extracted MW_SECRET_KEY from LocalSettings.php to .env\n")
 			}
 		}
+
+		// Delete the installer-generated LocalSettings.php (not needed with new architecture)
+		err, _ = execute.Run(path, "rm", filepath.Join(path, "config", localSettingsFile))
+		if err != nil {
+			return canastaInfo, err
+		}
+
 		time.Sleep(time.Second)
 	}
 
-	if len(WikiIDs) == 1 {
-		settingsName = localSettingsFile
-	}
-
-	err, _ = execute.Run(path, "mv", filepath.Join(path, "config", localSettingsBackup), filepath.Join(path, "config", settingsName))
-	if err != nil {
-		return canastaInfo, err
-	}
-	return canastaInfo, err
+	return canastaInfo, nil
 }
 
 func InstallOne(installPath, id, domain, admin, adminPassword, dbuser, workingDir, orchestrator string) error {

--- a/internal/orchestrators/orchestrators.go
+++ b/internal/orchestrators/orchestrators.go
@@ -145,10 +145,9 @@ func Pull(installPath, orchestrator string) error {
 
 // ImageInfo holds information about a Docker image
 type ImageInfo struct {
-	Service   string
-	Image     string
-	ID        string
-	CreatedAt string
+	Service string
+	Image   string
+	ID      string
 }
 
 // ImageUpdateReport describes what changed during a pull
@@ -255,17 +254,28 @@ func getComposeImages(installPath string, compose config.Orchestrator) (map[stri
 			containerName := fields[0]
 			parts := strings.Split(containerName, "-")
 			var service string
-			if len(parts) >= 2 {
+			if len(parts) >= 3 {
 				// Modern format: project-service-1, extract service name
 				service = strings.Join(parts[1:len(parts)-1], "-")
+			} else if len(parts) == 2 {
+				// Edge case like project-1: use the first part as service name
+				service = parts[0]
 			} else {
 				// Try underscore format: project_service_1
 				parts = strings.Split(containerName, "_")
-				if len(parts) >= 2 {
+				if len(parts) >= 3 {
 					service = strings.Join(parts[1:len(parts)-1], "_")
+				} else if len(parts) == 2 {
+					// Edge case like project_1: use the first part as service name
+					service = parts[0]
 				} else {
 					service = containerName
 				}
+			}
+
+			// Skip entries with empty service names to avoid map key collisions
+			if service == "" {
+				continue
 			}
 
 			imageRepo := fields[1]


### PR DESCRIPTION
## Summary

- **Upgrade output**: Show files updated/removed from upstream, which container images changed, and a clear final summary distinguishing actual upgrades from already up-to-date installations
- **MW_SECRET_KEY**: Extract `$wgSecretKey` from installer-generated `LocalSettings.php` into `.env` and delete `LocalSettings.php` (new architecture); use `env -u MW_SECRET_KEY` so `install.php` runs regardless of environment state; respect user-provided key from `-e` flag

## Test plan

- [x] `canasta create -i test` creates instance with `MW_SECRET_KEY` in `.env` and no `config/LocalSettings.php`
- [x] `canasta create -i test -e custom.env` with `MW_SECRET_KEY` in `custom.env` preserves the user-provided key
- [x] `canasta create -i test -d dump.sql` with database import respects existing `MW_SECRET_KEY`
- [x] `canasta upgrade` on up-to-date instance shows clean output with no spurious messages
- [x] `canasta upgrade` after pushing upstream changes shows files updated and images changed
- [x] `canasta upgrade --dry-run` still shows expected preview output

Fixes #189