### PR TITLE
Update settings file references after DockerCompose rename

### DIFF
--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -398,13 +398,9 @@ func createCaddyfileCustom(installPath string, dryRun bool) (bool, error) {
 
 // fixVectorDefaultSkin ensures Vector.php includes $wgDefaultSkin if it exists
 func fixVectorDefaultSkin(installPath string, dryRun bool) (bool, error) {
-	// Check both names: legacy "Vector.php" and current "30-Vector.php" (after git pull)
 	vectorPath := filepath.Join(installPath, "config", "settings", "global", "Vector.php")
 	if _, err := os.Stat(vectorPath); err != nil {
-		vectorPath = filepath.Join(installPath, "config", "settings", "global", "30-Vector.php")
-		if _, err := os.Stat(vectorPath); err != nil {
-			return false, nil // Neither file exists, nothing to fix
-		}
+		return false, nil // File doesn't exist, nothing to fix
 	}
 
 	content, err := os.ReadFile(vectorPath)

--- a/docs/guide/general-concepts.md
+++ b/docs/guide/general-concepts.md
@@ -122,7 +122,7 @@ See the [Caddy documentation](https://caddyserver.com/docs/caddyfile/directives)
 
 ### Settings
 
-Settings files are PHP files placed in the settings directories and loaded in alphabetical order:
+Settings files are PHP files placed in the settings directories and loaded in lexicographic order:
 
 - **Global settings** (`config/settings/global/*.php`) — loaded for every wiki
 - **Per-wiki settings** (`config/settings/wikis/{wiki-id}/*.php`) — loaded only for that wiki

--- a/internal/canasta/files/global-settings-README
+++ b/internal/canasta/files/global-settings-README
@@ -1,17 +1,22 @@
 # Global Settings Directory
 
 This directory contains PHP configuration files that apply to ALL wikis in your
-Canasta installation. Files are loaded automatically in alphabetical order.
+Canasta installation. Files are loaded automatically in lexicographic order.
 
-## File Naming Convention
+## Load Order
 
-Use two-digit numeric prefixes (00-99) to control load order. For example:
+All .php files in this directory are loaded automatically in lexicographic order.
+You can optionally use numeric prefixes to control load order:
 
-    00-first.php               # Loaded first
-    30-Vector.php              # Loaded early (default skin configuration)
-    50-extensions.php          # Loaded in the middle
-    90-CanastaFooterIcon.php   # Loaded late (footer icons)
-    99-final.php               # Loaded last (final overrides)
+    10-MySkin.php
+    50-Extensions.php
+    90-Footer.php
+
+But plain names work fine:
+
+    Vector.php
+    CanastaFooterIcon.php
+    MyExtensions.php
 
 ## What to Configure Here
 

--- a/internal/canasta/files/wiki-settings-README
+++ b/internal/canasta/files/wiki-settings-README
@@ -1,15 +1,21 @@
 # Per-Wiki Settings Directory: {WIKI_ID}
 
 This directory contains PHP configuration files specific to this wiki.
-Files are loaded automatically in alphabetical order, AFTER global settings.
+Files are loaded automatically in lexicographic order, AFTER global settings.
 
-## File Naming Convention
+## Load Order
 
-Use two-digit numeric prefixes (00-99) to control load order. For example:
+All .php files in this directory are loaded automatically in lexicographic order.
+You can optionally use numeric prefixes to control load order:
 
-    00-first.php   # Loaded first (within this wiki's directory)
+    10-first.php   # Loaded first (within this wiki's directory)
     50-logo.php    # Loaded in the middle
-    99-final.php   # Loaded last (final overrides)
+    90-final.php   # Loaded last (final overrides)
+
+But plain names work fine:
+
+    Logo.php
+    Permissions.php
 
 ## What to Configure Here
 


### PR DESCRIPTION
## Summary

- Remove legacy `30-Vector.php` fallback from `fixVectorDefaultSkin` in upgrade
- Change "alphabetical" to "lexicographic" in docs and README templates
- Make numeric prefixes optional in settings README files

Closes #191
See also CanastaWiki/Canasta-DockerCompose#82