### PR TITLE
Fix MkDocs Material custom color scheme

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,9 @@
+[data-md-color-scheme="default"] {
+  --md-primary-fg-color: #666666;
+  --md-accent-fg-color: #ccff00;
+}
+
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color: #666666;
+  --md-accent-fg-color: #ccff00;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,14 +8,14 @@ theme:
   name: material
   palette:
     - scheme: default
-      primary: #666666
-      accent: #ccff00
+      primary: grey
+      accent: lime
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
     - scheme: slate
-      primary: #666666
-      accent: #ccff00
+      primary: grey
+      accent: lime
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
@@ -27,6 +27,9 @@ theme:
     - search.suggest
     - search.highlight
     - content.code.copy
+
+extra_css:
+  - stylesheets/extra.css
 
 plugins:
   - search


### PR DESCRIPTION
## Summary

- Add `docs/stylesheets/extra.css` with CSS custom properties for exact Canasta colors (`#666666` primary, `#ccff00` accent)
- Set palette `primary`/`accent` to closest named colors (`grey`/`lime`) as fallbacks
- Reference the stylesheet via `extra_css` in `mkdocs.yml`

Closes #193