### PR TITLE
Allow --build-from with only Canasta-DockerCompose

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -186,13 +186,22 @@ func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiI
 	// Determine the base image to use
 	var baseImage string
 	if buildFromPath != "" {
-		// Build Canasta (and optionally CanastaBase) from source
-		logging.Print("Building Canasta from local source...\n")
-		builtImage, err := imagebuild.BuildFromSource(buildFromPath)
-		if err != nil {
-			return fmt.Errorf("failed to build from source: %w", err)
+		// Check if local Canasta repo exists for building
+		canastaPath := filepath.Join(buildFromPath, "Canasta")
+		if _, err := os.Stat(canastaPath); err == nil {
+			// Build Canasta (and optionally CanastaBase) from source
+			logging.Print("Building Canasta from local source...\n")
+			builtImage, err := imagebuild.BuildFromSource(buildFromPath)
+			if err != nil {
+				return fmt.Errorf("failed to build from source: %w", err)
+			}
+			baseImage = builtImage
+		} else {
+			// No local Canasta repo, use registry image
+			// (buildFromPath may still have Canasta-DockerCompose for CloneStackRepo)
+			logging.Print("No local Canasta repo found, using registry image\n")
+			baseImage = canasta.GetImageWithTag(devTag)
 		}
-		baseImage = builtImage
 	} else {
 		// Use registry image with specified tag
 		baseImage = canasta.GetImageWithTag(devTag)


### PR DESCRIPTION
## Summary

When `--build-from` is specified but no local `Canasta/` repo exists, fall back to the registry image instead of failing. This allows using `--build-from` to test local `Canasta-DockerCompose/` changes without also building a custom Docker image.

## Test plan

- [x] `canasta create --build-from /path` with only `Canasta-DockerCompose/` present uses registry image and local DockerCompose
- [x] `canasta create --build-from /path` with both `Canasta/` and `Canasta-DockerCompose/` builds from source as before

Fixes #202