### PR TITLE
Add public_assets support, update logo docs, and improve log documentation

### DIFF
--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -69,6 +69,10 @@ func Delete(instance config.Installation) error {
 		if err := orchestrators.CleanupImages(instance.Path, instance.Orchestrator, ""); err != nil {
 			logging.Print(fmt.Sprintf("Warning: could not clean up images: %v\n", err))
 		}
+		// Clean up public_assets from inside the container before stopping
+		if err := orchestrators.CleanupPublicAssets(instance.Path, instance.Orchestrator, ""); err != nil {
+			logging.Print(fmt.Sprintf("Warning: could not clean up public_assets: %v\n", err))
+		}
 	}
 
 	//Stopping and deleting Contianers and it's volumes

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -120,6 +120,15 @@ func RemoveWiki(instance config.Installation, wikiID string) error {
 		return err
 	}
 
+	// Remove the Public Assets (from inside container first to handle www-data ownership on Linux)
+	if containersRunning {
+		orchestrators.CleanupPublicAssets(instance.Path, instance.Orchestrator, wikiID)
+	}
+	err = canasta.RemovePublicAssets(instance.Path, wikiID)
+	if err != nil {
+		return err
+	}
+
 	//Rewrite the Caddyfile
 	err = canasta.RewriteCaddy(instance.Path)
 	if err != nil {

--- a/docs/guide/devmode.md
+++ b/docs/guide/devmode.md
@@ -369,32 +369,20 @@ When you re-enable dev mode (`canasta restart --dev`) after having disabled it:
 
 ## Log locations
 
-All commands should be run from the installation directory.
+For general log file locations (MediaWiki debug log, Apache error log, etc.), see [Troubleshooting: Log file locations](troubleshooting.md#log-file-locations).
 
-### Enabling the MediaWiki debug log
+### Xdebug log
 
-The MediaWiki debug log is the most useful log for debugging application issues. To enable it, add this to a settings file (e.g., `config/settings/global/Debug.php`):
-
-```php
-<?php
-$wgDebugLogFile = '/var/log/mediawiki/debug.log';
-```
-
-Then restart the container and tail the log:
+In dev mode, Xdebug writes connection attempts to its own log file:
 
 ```bash
-canasta restart -i myinstance
-docker compose exec web tail -f /var/log/mediawiki/debug.log
+docker compose exec web tail -f /var/log/mediawiki/php-xdebug.log
 ```
 
-### Log file locations
-
-| Log | Description | Command |
-|-----|-------------|---------|
-| MediaWiki debug | Application debug log (requires config above) | `docker compose exec web tail -f /var/log/mediawiki/debug.log` |
-| Apache error | PHP errors and Apache warnings | `docker compose exec web tail -f /var/log/apache2/error_log.current` |
-| Apache access | HTTP request log | `docker compose exec web tail -f /var/log/apache2/access_log.current` |
-| Xdebug | Debug connection attempts (dev mode only) | `docker compose exec web tail -f /var/log/mediawiki/php-xdebug.log` |
+This log is useful for diagnosing why breakpoints aren't being hit:
+- "Trigger value not found" — Cookie not set or not being sent
+- "Could not connect to debugging client" — IDE not listening
+- "Connecting to configured address" — Working correctly
 
 ---
 

--- a/docs/guide/devmode.md
+++ b/docs/guide/devmode.md
@@ -371,13 +371,30 @@ When you re-enable dev mode (`canasta restart --dev`) after having disabled it:
 
 All commands should be run from the installation directory.
 
+### Enabling the MediaWiki debug log
+
+The MediaWiki debug log is the most useful log for debugging application issues. To enable it, add this to a settings file (e.g., `config/settings/global/Debug.php`):
+
+```php
+<?php
+$wgDebugLogFile = '/var/log/mediawiki/debug.log';
+```
+
+Then restart the container and tail the log:
+
+```bash
+canasta restart -i myinstance
+docker compose exec web tail -f /var/log/mediawiki/debug.log
+```
+
+### Log file locations
+
 | Log | Description | Command |
 |-----|-------------|---------|
-| Xdebug | Debug connection attempts | `docker compose exec web tail -f /var/log/mediawiki/php-xdebug.log` |
-| PHP-FPM | PHP errors and warnings | `docker compose exec web tail -f /var/log/php8.1-fpm.log` |
-| MediaWiki debug | Application debug log | `docker compose exec web tail -f /var/log/mediawiki/debug.log` |
-
-**Note**: The MediaWiki debug log requires `$wgDebugLogFile = '/var/log/mediawiki/debug.log';` in your LocalSettings.php.
+| MediaWiki debug | Application debug log (requires config above) | `docker compose exec web tail -f /var/log/mediawiki/debug.log` |
+| Apache error | PHP errors and Apache warnings | `docker compose exec web tail -f /var/log/apache2/error_log.current` |
+| Apache access | HTTP request log | `docker compose exec web tail -f /var/log/apache2/access_log.current` |
+| Xdebug | Debug connection attempts (dev mode only) | `docker compose exec web tail -f /var/log/mediawiki/php-xdebug.log` |
 
 ---
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -6,6 +6,8 @@ This page covers common troubleshooting steps for Canasta installations.
 
 - [Checking container status](#checking-container-status)
 - [Viewing container logs](#viewing-container-logs)
+  - [Log file locations](#log-file-locations)
+  - [Enabling the MediaWiki debug log](#enabling-the-mediawiki-debug-log)
 - [Accessing the database](#accessing-the-database)
 - [Running commands inside containers](#running-commands-inside-containers)
 - [Common issues](#common-issues)
@@ -38,6 +40,31 @@ docker compose logs -f web
 To view logs from all containers:
 ```bash
 docker compose logs
+```
+
+### Log file locations
+
+For more detailed debugging, you can access log files inside the container:
+
+| Log | Description | Command |
+|-----|-------------|---------|
+| MediaWiki debug | Application debug log (see below) | `docker compose exec web tail -f /var/log/mediawiki/debug.log` |
+| Apache error | PHP errors and Apache warnings | `docker compose exec web tail -f /var/log/apache2/error_log.current` |
+| Apache access | HTTP request log | `docker compose exec web tail -f /var/log/apache2/access_log.current` |
+
+### Enabling the MediaWiki debug log
+
+The MediaWiki debug log is the most useful log for debugging application issues, but it requires explicit configuration. Add this to a settings file (e.g., `config/settings/global/Debug.php`):
+
+```php
+<?php
+$wgDebugLogFile = '/var/log/mediawiki/debug.log';
+```
+
+Then restart the container:
+
+```bash
+canasta restart -i myinstance
 ```
 
 ---

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -790,6 +790,27 @@ func RemoveImages(installPath, id string) error {
 	return nil
 }
 
+func RemovePublicAssets(installPath, id string) error {
+	// Prepare the file path
+	filePath := filepath.Join(installPath, "public_assets", id)
+
+	// Check if the file exists
+	if _, err := os.Stat(filePath); err == nil {
+		// If the file exists, remove it
+		err, output := execute.Run("", "rm", "-rf", filePath)
+		if err != nil {
+			return fmt.Errorf(output)
+		}
+	} else if os.IsNotExist(err) {
+		// File does not exist, do nothing
+		return nil
+	} else {
+		// File may or may not exist. See the specific error
+		return err
+	}
+	return nil
+}
+
 func MigrateToNewVersion(installPath string) error {
 	// Determine the path to the wikis.yaml file
 	yamlPath := filepath.Join(installPath, "config", "wikis.yaml")

--- a/internal/orchestrators/orchestrators.go
+++ b/internal/orchestrators/orchestrators.go
@@ -387,6 +387,21 @@ func CleanupImages(installPath, orchestrator, wikiID string) error {
 	return err
 }
 
+// CleanupPublicAssets removes public assets files from inside the container.
+// On Linux, files created by the container are owned by www-data (UID 33) which maps to
+// their container UID on the host and cannot be deleted without sudo.
+// If wikiID is empty, removes all public_assets (public_assets/*). Otherwise removes public_assets/{wikiID}.
+func CleanupPublicAssets(installPath, orchestrator, wikiID string) error {
+	var cleanupCmd string
+	if wikiID == "" {
+		cleanupCmd = "find /mediawiki/public_assets -mindepth 1 -delete"
+	} else {
+		cleanupCmd = fmt.Sprintf("rm -rf /mediawiki/public_assets/%s", wikiID)
+	}
+	_, err := ExecWithError(installPath, orchestrator, "web", cleanupCmd)
+	return err
+}
+
 func DeleteContainers(installPath, orchestrator string) (string, error) {
 	switch orchestrator {
 	case "compose":


### PR DESCRIPTION
## Summary

### Public assets directory support

Adds CLI support for the new `public_assets` directory:

- Add `CleanupPublicAssets()` function to remove files from inside container
- Add `RemovePublicAssets()` function to remove from host
- Update `remove` command to delete `public_assets/{wiki-id}/` when removing a wiki
- Update `delete` command to clean up all `public_assets/` when deleting installation

### Logo configuration documentation

Updated the "Configuring logos" section (general-concepts.md):

1. **Public assets directory** (now recommended) - Always publicly accessible, works for both public and private wikis
2. **Upload via MediaWiki** - Logo respects wiki permissions

Updated directory structure to include `public_assets/`.

### Log file documentation (devmode.md)

- Fixed inaccuracies about PHP-FPM vs Apache error logs
- Added MediaWiki debug log setup instructions
- Added Apache access log location

Fixes #206
Closes #208

## Related PRs

- CanastaWiki/CanastaBase#71
- CanastaWiki/Canasta-DockerCompose#87

## Test plan

- [x] Add a wiki with `canasta add`, verify `public_assets/{wiki-id}/` can be created
- [x] Remove a wiki with `canasta remove`, verify `public_assets/{wiki-id}/` is deleted
- [x] Delete installation with `canasta delete`, verify all `public_assets/` is cleaned up
- [x] Review updated documentation in `docs/guide/general-concepts.md`