### PR TITLE
Merge self-update into upgrade command

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -213,7 +213,8 @@ func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiI
 	}
 
 	// Clone the stack repository first to create the installation directory
-	if err := canasta.CloneStackRepo(orchestrator, canastaInfo.Id, &path, buildFromPath); err != nil {
+	localStack, err := canasta.CloneStackRepo(orchestrator, canastaInfo.Id, &path, buildFromPath)
+	if err != nil {
 		return err
 	}
 
@@ -307,7 +308,7 @@ func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiI
 		}
 	}
 
-	instance := config.Installation{Id: canastaInfo.Id, Path: path, Orchestrator: orchestrator, DevMode: devModeEnabled}
+	instance := config.Installation{Id: canastaInfo.Id, Path: path, Orchestrator: orchestrator, DevMode: devModeEnabled, LocalStack: localStack}
 	if err := config.Add(instance); err != nil {
 		return err
 	}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -12,7 +12,6 @@ import (
 	removeCmd "github.com/CanastaWiki/Canasta-CLI/cmd/remove"
 	restartCmd "github.com/CanastaWiki/Canasta-CLI/cmd/restart"
 	resticCmd "github.com/CanastaWiki/Canasta-CLI/cmd/restic"
-	selfupdateCmd "github.com/CanastaWiki/Canasta-CLI/cmd/selfupdate"
 	skinCmd "github.com/CanastaWiki/Canasta-CLI/cmd/skin"
 	startCmd "github.com/CanastaWiki/Canasta-CLI/cmd/start"
 	stopCmd "github.com/CanastaWiki/Canasta-CLI/cmd/stop"
@@ -74,7 +73,6 @@ func init() {
 	rootCmd.AddCommand(versionCmd.NewCmdCreate())
 	rootCmd.AddCommand(addCmd.NewCmdCreate())
 	rootCmd.AddCommand(removeCmd.NewCmdCreate())
-	rootCmd.AddCommand(selfupdateCmd.NewCmdCreate())
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
 
 	// Add config file location to help output

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -191,26 +191,28 @@ func Upgrade(instance config.Installation, dryRun bool) error {
 		return nil
 	}
 
-	// Restart the containers
-	if err = orchestrators.StopAndStart(instance); err != nil {
-		return err
-	}
-
-	// Touch LocalSettings.php to flush cache
-	fmt.Print("Running 'touch LocalSettings.php' to flush cache\n")
-	_, err = orchestrators.ExecWithError(instance.Path, instance.Orchestrator, "web", "touch LocalSettings.php")
-	if err != nil {
-		return err
-	}
-
-	// Print summary
-	fmt.Println()
+	// Only restart if something changed
 	if repoChanged || migrationsNeeded || imagesUpdated {
+		// Restart the containers
+		if err = orchestrators.StopAndStart(instance); err != nil {
+			return err
+		}
+
+		// Touch LocalSettings.php to flush cache
+		fmt.Print("Running 'touch LocalSettings.php' to flush cache\n")
+		_, err = orchestrators.ExecWithError(instance.Path, instance.Orchestrator, "web", "touch LocalSettings.php")
+		if err != nil {
+			return err
+		}
+
+		fmt.Println()
 		fmt.Println("Canasta upgraded successfully!")
 	} else if instance.LocalStack || isLocalBuild {
+		fmt.Println()
 		fmt.Println("This is a local development instance. To update, recreate the instance.")
 	} else {
-		fmt.Println("Installation was already up to date. Containers restarted.")
+		fmt.Println()
+		fmt.Println("Installation is already up to date.")
 	}
 
 	return nil

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -151,7 +151,7 @@ func Upgrade(instance config.Installation, dryRun bool) error {
 	if !dryRun {
 		if isLocalBuild {
 			fmt.Println("Skipping image pull: this instance uses a locally-built image (--build-from).")
-			fmt.Println("To update, rebuild the image and recreate the instance.")
+			fmt.Println("To update, recreate the instance.")
 		} else {
 			fmt.Println("Pulling Canasta container images...")
 			report, err := orchestrators.PullWithReport(instance.Path, instance.Orchestrator)

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -194,6 +194,7 @@ func Upgrade(instance config.Installation, dryRun bool) error {
 	// Only restart if something changed
 	if repoChanged || migrationsNeeded || imagesUpdated {
 		// Restart the containers
+		fmt.Println("Restarting containers...")
 		if err = orchestrators.StopAndStart(instance); err != nil {
 			return err
 		}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -55,12 +55,6 @@ canasta version
 
 The CLI automatically updates itself when you run `canasta upgrade`. This ensures you always have the latest CLI version when upgrading your Canasta instances.
 
-To manually update the CLI without upgrading any instances, re-run the installation command:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/CanastaWiki/Canasta-CLI/main/install.sh | sudo bash
-```
-
 ## Uninstall
 
 First, delete any Canasta installations using `canasta delete` for each one.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -53,13 +53,13 @@ canasta version
 
 ## Updating
 
-To update to the latest version:
+The CLI automatically updates itself when you run `canasta upgrade`. This ensures you always have the latest CLI version when upgrading your Canasta instances.
+
+To manually update the CLI without upgrading any instances, re-run the installation command:
 
 ```bash
-canasta self-update
+curl -fsSL https://raw.githubusercontent.com/CanastaWiki/Canasta-CLI/main/install.sh | sudo bash
 ```
-
-Alternatively, re-run the installation command.
 
 ## Uninstall
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type Installation struct {
 	Path         string `json:"path"`
 	Orchestrator string `json:"orchestrator"`
 	DevMode      bool   `json:"devMode,omitempty"`
+	LocalStack   bool   `json:"localStack,omitempty"`
 }
 
 type Orchestrator struct {

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -37,7 +37,8 @@ func CheckAndUpdate() (bool, error) {
 	}
 
 	if currentVersion == "" {
-		fmt.Println("Warning: running a dev build; proceeding with update to latest release.")
+		fmt.Println("Skipping CLI update: running a dev build.")
+		return true, nil
 	} else if currentVersion == latestVersion {
 		fmt.Printf("CLI is up to date (%s)\n", currentVersion)
 		return true, nil

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,7 +73,6 @@ nav:
       - export: cli/canasta_export.md
       - upgrade: cli/canasta_upgrade.md
       - version: cli/canasta_version.md
-      - self-update: cli/canasta_self-update.md
     - extension:
       - Overview: cli/canasta_extension.md
       - list: cli/canasta_extension_list.md


### PR DESCRIPTION
## Summary

- Merge `canasta self-update` functionality into `canasta upgrade`
- CLI automatically updates itself before upgrading instances
- Dev builds skip CLI update automatically
- Add `--skip-cli-update` flag to bypass CLI update if needed
- Remove standalone `self-update` command
- Track local Canasta-DockerCompose usage in conf.json (`LocalStack` field)
- Skip git fetch and image pull for local development instances

Fixes #209
Closes #173

## How it works

### CLI Self-Update
1. `canasta upgrade` checks GitHub for the latest CLI release
2. If a newer version exists, downloads and installs it
3. Uses `syscall.Exec()` to re-exec with the new binary, preserving arguments
4. New binary continues with the instance upgrade
5. Dev builds skip this step automatically

### Local Development Instances
- Instances created with `--build-from` using local Canasta-DockerCompose are tracked via `LocalStack: true` in conf.json
- Upgrade skips git fetch for these instances (no remote to fetch from)
- Upgrade skips image pull for locally-built images (`canasta:local`)
- Clear messaging directs users to recreate the instance to update

## Test plan

- [x] Build and run `canasta upgrade -i <instance>` with an outdated CLI
- [x] Verify CLI updates and continues with instance upgrade seamlessly
- [x] Test `canasta upgrade --skip-cli-update` skips CLI update
- [x] Test `canasta upgrade --all` updates CLI once then upgrades all instances
- [x] Verify `canasta self-update` no longer exists
- [x] Test dev build skips CLI update with message
- [x] Create instance with `--build-from` (local Canasta-DockerCompose)
- [x] Verify conf.json has `localStack: true`
- [x] Verify upgrade skips git fetch and image pull for local instance