### PR TITLE
Remove unnecessary CleanupPublicAssets container cleanup

### DIFF
--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -69,10 +69,6 @@ func Delete(instance config.Installation) error {
 		if err := orchestrators.CleanupImages(instance.Path, instance.Orchestrator, ""); err != nil {
 			logging.Print(fmt.Sprintf("Warning: could not clean up images: %v\n", err))
 		}
-		// Clean up public_assets from inside the container before stopping
-		if err := orchestrators.CleanupPublicAssets(instance.Path, instance.Orchestrator, ""); err != nil {
-			logging.Print(fmt.Sprintf("Warning: could not clean up public_assets: %v\n", err))
-		}
 	}
 
 	//Stopping and deleting Contianers and it's volumes

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -120,10 +120,7 @@ func RemoveWiki(instance config.Installation, wikiID string) error {
 		return err
 	}
 
-	// Remove the Public Assets (from inside container first to handle www-data ownership on Linux)
-	if containersRunning {
-		orchestrators.CleanupPublicAssets(instance.Path, instance.Orchestrator, wikiID)
-	}
+	// Remove the Public Assets
 	err = canasta.RemovePublicAssets(instance.Path, wikiID)
 	if err != nil {
 		return err

--- a/internal/orchestrators/orchestrators.go
+++ b/internal/orchestrators/orchestrators.go
@@ -387,21 +387,6 @@ func CleanupImages(installPath, orchestrator, wikiID string) error {
 	return err
 }
 
-// CleanupPublicAssets removes public assets files from inside the container.
-// On Linux, files created by the container are owned by www-data (UID 33) which maps to
-// their container UID on the host and cannot be deleted without sudo.
-// If wikiID is empty, removes all public_assets (public_assets/*). Otherwise removes public_assets/{wikiID}.
-func CleanupPublicAssets(installPath, orchestrator, wikiID string) error {
-	var cleanupCmd string
-	if wikiID == "" {
-		cleanupCmd = "find /mediawiki/public_assets -mindepth 1 -delete"
-	} else {
-		cleanupCmd = fmt.Sprintf("rm -rf /mediawiki/public_assets/%s", wikiID)
-	}
-	_, err := ExecWithError(installPath, orchestrator, "web", cleanupCmd)
-	return err
-}
-
 func DeleteContainers(installPath, orchestrator string) (string, error) {
 	switch orchestrator {
 	case "compose":


### PR DESCRIPTION
## Summary

- Remove `CleanupPublicAssets` function from orchestrators
- Remove calls from `delete.go` and `remove.go`
- No longer needed since CanastaWiki/CanastaBase#74 sets public_assets ownership to host user

Fixes #211