### PR TITLE
Add Caddy access logging to generated Caddyfile

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -277,6 +277,9 @@ func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiI
 	if err := canasta.CreateCaddyfileGlobal(path); err != nil {
 		return err
 	}
+	if _, err := canasta.EnsureObservabilityCredentials(path); err != nil {
+		return err
+	}
 	if err := canasta.RewriteCaddy(path); err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/CanastaWiki/Canasta-CLI
 
-go 1.18
+go 1.24.0
 
 require (
 	github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f
@@ -13,8 +13,9 @@ require (
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
-	golang.org/x/sys v0.6.0 // indirect
-	golang.org/x/term v0.6.0 // indirect
+	golang.org/x/crypto v0.48.0 // indirect
+	golang.org/x/sys v0.41.0 // indirect
+	golang.org/x/term v0.40.0 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -29,11 +29,17 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
+golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.6.0 h1:clScbb1cHjoCkyRbWwBEUZ5H/tIFu5TAXIqaZD0Gcjw=
 golang.org/x/term v0.6.0/go.mod h1:m6U89DPEgQRMq3DNkDClhWw02AUbt2daBVO4cn4Hv9U=
+golang.org/x/term v0.40.0 h1:36e4zGLqU4yhjlmxEaagx2KuYbJq3EwY8K943ZsHcvg=
+golang.org/x/term v0.40.0/go.mod h1:w2P8uVp06p2iyKKuvXIm7N/y0UCRt3UfJTfZ7oOpglM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -19,6 +19,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 	"github.com/sethvargo/go-password/password"
+	"golang.org/x/crypto/bcrypt"
 )
 
 type CanastaVariables struct {
@@ -360,6 +361,67 @@ func removeDuplicates(slice []string) []string {
 	return list
 }
 
+// ContainsProfile checks if a comma-separated profile string contains the given profile name.
+func ContainsProfile(profiles, target string) bool {
+	for _, p := range strings.Split(profiles, ",") {
+		if strings.TrimSpace(p) == target {
+			return true
+		}
+	}
+	return false
+}
+
+// EnsureObservabilityCredentials checks if COMPOSE_PROFILES contains "observable" in .env.
+// If active, it ensures OS_USER, OS_PASSWORD, and OS_PASSWORD_HASH are set.
+// Returns true if the observable profile is active.
+func EnsureObservabilityCredentials(installPath string) (bool, error) {
+	envPath := installPath + "/.env"
+	envVars, err := GetEnvVariable(envPath)
+	if err != nil {
+		return false, err
+	}
+
+	if !ContainsProfile(envVars["COMPOSE_PROFILES"], "observable") {
+		return false, nil
+	}
+
+	// Set OS_USER to "admin" if not present
+	if envVars["OS_USER"] == "" {
+		if err := SaveEnvVariable(envPath, "OS_USER", "admin"); err != nil {
+			return true, fmt.Errorf("failed to save OS_USER: %w", err)
+		}
+		fmt.Println("Set OS_USER=admin in .env")
+	}
+
+	// Generate OS_PASSWORD if not present
+	if envVars["OS_PASSWORD"] == "" {
+		pw, err := GeneratePassword("OpenSearch")
+		if err != nil {
+			return true, fmt.Errorf("failed to generate OS_PASSWORD: %w", err)
+		}
+		if err := SaveEnvVariable(envPath, "OS_PASSWORD", pw); err != nil {
+			return true, fmt.Errorf("failed to save OS_PASSWORD: %w", err)
+		}
+		fmt.Println("Generated OS_PASSWORD and saved to .env")
+		// Re-read so we can hash it below
+		envVars["OS_PASSWORD"] = pw
+	}
+
+	// Compute bcrypt hash of OS_PASSWORD and save as OS_PASSWORD_HASH if not present
+	if envVars["OS_PASSWORD_HASH"] == "" {
+		hash, err := bcrypt.GenerateFromPassword([]byte(envVars["OS_PASSWORD"]), bcrypt.DefaultCost)
+		if err != nil {
+			return true, fmt.Errorf("failed to hash OS_PASSWORD: %w", err)
+		}
+		if err := SaveEnvVariable(envPath, "OS_PASSWORD_HASH", string(hash)); err != nil {
+			return true, fmt.Errorf("failed to save OS_PASSWORD_HASH: %w", err)
+		}
+		fmt.Println("Generated OS_PASSWORD_HASH and saved to .env")
+	}
+
+	return true, nil
+}
+
 func RewriteCaddy(installPath string) error {
 	_, ServerNames, _, err := farmsettings.ReadWikisYaml(installPath + "/config/wikis.yaml")
 	if err != nil {
@@ -374,6 +436,14 @@ func RewriteCaddy(installPath string) error {
 		return err
 	}
 	httpOnly := strings.ToLower(envVars["CADDY_AUTO_HTTPS"]) == "off"
+
+	// Check if observable profile is active
+	observable := ContainsProfile(envVars["COMPOSE_PROFILES"], "observable")
+	if observable {
+		if envVars["OS_USER"] == "" || envVars["OS_PASSWORD_HASH"] == "" {
+			return fmt.Errorf("observable profile is active but OS_USER or OS_PASSWORD_HASH is missing from .env; run 'canasta upgrade' to generate credentials")
+		}
+	}
 
 	// Remove duplicates from ServerNames
 	ServerNames = removeDuplicates(ServerNames)
@@ -430,7 +500,22 @@ func RewriteCaddy(installPath string) error {
 	// Write site block
 	writeLine(siteAddress.String() + " {")
 	writeLine("    import /etc/caddy/Caddyfile.site")
-	writeLine("    reverse_proxy varnish:80")
+	writeLine("")
+	if observable {
+		writeLine("    handle /opensearch/* {")
+		writeLine("        basicauth {")
+		writeLine("            " + envVars["OS_USER"] + " " + envVars["OS_PASSWORD_HASH"])
+		writeLine("        }")
+		writeLine("        reverse_proxy opensearch-dashboards:5601")
+		writeLine("    }")
+		writeLine("")
+		writeLine("    handle {")
+		writeLine("        reverse_proxy varnish:80")
+		writeLine("    }")
+	} else {
+		writeLine("    reverse_proxy varnish:80")
+	}
+	writeLine("")
 	writeLine("    log {")
 	writeLine("        output file /var/log/caddy/access.log")
 	writeLine("    }")

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -431,6 +431,9 @@ func RewriteCaddy(installPath string) error {
 	writeLine(siteAddress.String() + " {")
 	writeLine("    import /etc/caddy/Caddyfile.site")
 	writeLine("    reverse_proxy varnish:80")
+	writeLine("    log {")
+	writeLine("        output file /var/log/caddy/access.log")
+	writeLine("    }")
 	writeLine("}")
 
 	if writeErr != nil {

--- a/internal/canasta/canasta_test.go
+++ b/internal/canasta/canasta_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"golang.org/x/crypto/bcrypt"
 )
 
 func TestGetEnvVariable(t *testing.T) {
@@ -217,5 +219,188 @@ func TestGenerateSecretKey(t *testing.T) {
 	}
 	if key == key2 {
 		t.Error("expected different keys on successive calls")
+	}
+}
+
+func TestContainsProfile(t *testing.T) {
+	tests := []struct {
+		name     string
+		profiles string
+		target   string
+		want     bool
+	}{
+		{"exact match", "observable", "observable", true},
+		{"in list", "web,observable,worker", "observable", true},
+		{"first in list", "observable,worker", "observable", true},
+		{"last in list", "web,observable", "observable", true},
+		{"not present", "web,worker", "observable", false},
+		{"empty string", "", "observable", false},
+		{"partial match should not match", "observable-extra", "observable", false},
+		{"with whitespace", "web, observable , worker", "observable", true},
+		{"single non-matching", "web", "observable", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ContainsProfile(tt.profiles, tt.target)
+			if got != tt.want {
+				t.Errorf("ContainsProfile(%q, %q) = %v, want %v", tt.profiles, tt.target, got, tt.want)
+			}
+		})
+	}
+}
+
+// setupTestInstall creates a minimal installation directory with .env and wikis.yaml
+func setupTestInstall(t *testing.T, envContent, wikisYaml string) string {
+	t.Helper()
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "config")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(envContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "wikis.yaml"), []byte(wikisYaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestEnsureObservabilityCredentials_NotObservable(t *testing.T) {
+	dir := setupTestInstall(t, "COMPOSE_PROFILES=web\n", "wikis:\n  - id: main\n    url: example.com\n")
+
+	active, err := EnsureObservabilityCredentials(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if active {
+		t.Error("expected active=false when observable profile is not set")
+	}
+
+	// Verify no OS_ variables were added
+	vars, _ := GetEnvVariable(filepath.Join(dir, ".env"))
+	if vars["OS_USER"] != "" {
+		t.Error("OS_USER should not be set")
+	}
+}
+
+func TestEnsureObservabilityCredentials_GeneratesCredentials(t *testing.T) {
+	dir := setupTestInstall(t, "COMPOSE_PROFILES=observable\n", "wikis:\n  - id: main\n    url: example.com\n")
+
+	active, err := EnsureObservabilityCredentials(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !active {
+		t.Error("expected active=true when observable profile is set")
+	}
+
+	vars, _ := GetEnvVariable(filepath.Join(dir, ".env"))
+	if vars["OS_USER"] != "admin" {
+		t.Errorf("OS_USER = %q, want \"admin\"", vars["OS_USER"])
+	}
+	if len(vars["OS_PASSWORD"]) != 30 {
+		t.Errorf("OS_PASSWORD length = %d, want 30", len(vars["OS_PASSWORD"]))
+	}
+	if !strings.HasPrefix(vars["OS_PASSWORD_HASH"], "$2a$") {
+		t.Errorf("OS_PASSWORD_HASH should be a bcrypt hash, got %q", vars["OS_PASSWORD_HASH"])
+	}
+
+	// Verify the hash matches the password
+	err = bcrypt.CompareHashAndPassword([]byte(vars["OS_PASSWORD_HASH"]), []byte(vars["OS_PASSWORD"]))
+	if err != nil {
+		t.Errorf("bcrypt hash does not match password: %v", err)
+	}
+}
+
+func TestEnsureObservabilityCredentials_PreservesExisting(t *testing.T) {
+	envContent := "COMPOSE_PROFILES=observable\nOS_USER=customuser\nOS_PASSWORD=custompass\nOS_PASSWORD_HASH=$2a$10$existinghash\n"
+	dir := setupTestInstall(t, envContent, "wikis:\n  - id: main\n    url: example.com\n")
+
+	active, err := EnsureObservabilityCredentials(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !active {
+		t.Error("expected active=true")
+	}
+
+	vars, _ := GetEnvVariable(filepath.Join(dir, ".env"))
+	if vars["OS_USER"] != "customuser" {
+		t.Errorf("OS_USER = %q, want \"customuser\"", vars["OS_USER"])
+	}
+	if vars["OS_PASSWORD"] != "custompass" {
+		t.Errorf("OS_PASSWORD = %q, want \"custompass\"", vars["OS_PASSWORD"])
+	}
+	if vars["OS_PASSWORD_HASH"] != "$2a$10$existinghash" {
+		t.Errorf("OS_PASSWORD_HASH = %q, want \"$2a$10$existinghash\"", vars["OS_PASSWORD_HASH"])
+	}
+}
+
+func TestRewriteCaddy_WithObservable(t *testing.T) {
+	hash := "$2a$10$testhashvalue"
+	envContent := "COMPOSE_PROFILES=observable\nOS_USER=admin\nOS_PASSWORD_HASH=" + hash + "\n"
+	dir := setupTestInstall(t, envContent, "wikis:\n  - id: main\n    url: example.com\n")
+
+	if err := RewriteCaddy(dir); err != nil {
+		t.Fatalf("RewriteCaddy() error = %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "config", "Caddyfile"))
+	if err != nil {
+		t.Fatalf("failed to read Caddyfile: %v", err)
+	}
+	caddy := string(content)
+
+	// Should contain opensearch handle block
+	if !strings.Contains(caddy, "handle /opensearch/*") {
+		t.Error("Caddyfile should contain 'handle /opensearch/*'")
+	}
+	if !strings.Contains(caddy, "basicauth") {
+		t.Error("Caddyfile should contain 'basicauth'")
+	}
+	if !strings.Contains(caddy, "admin "+hash) {
+		t.Errorf("Caddyfile should contain 'admin %s'", hash)
+	}
+	if !strings.Contains(caddy, "reverse_proxy opensearch-dashboards:5601") {
+		t.Error("Caddyfile should contain 'reverse_proxy opensearch-dashboards:5601'")
+	}
+	// Varnish should be in a handle block
+	if !strings.Contains(caddy, "handle {") {
+		t.Error("Caddyfile should contain 'handle {' for varnish")
+	}
+	if !strings.Contains(caddy, "reverse_proxy varnish:80") {
+		t.Error("Caddyfile should contain 'reverse_proxy varnish:80'")
+	}
+}
+
+func TestRewriteCaddy_WithoutObservable(t *testing.T) {
+	envContent := "COMPOSE_PROFILES=web\n"
+	dir := setupTestInstall(t, envContent, "wikis:\n  - id: main\n    url: example.com\n")
+
+	if err := RewriteCaddy(dir); err != nil {
+		t.Fatalf("RewriteCaddy() error = %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "config", "Caddyfile"))
+	if err != nil {
+		t.Fatalf("failed to read Caddyfile: %v", err)
+	}
+	caddy := string(content)
+
+	// Should NOT contain opensearch references
+	if strings.Contains(caddy, "opensearch") {
+		t.Error("Caddyfile should not contain opensearch references when profile is not active")
+	}
+	if strings.Contains(caddy, "basicauth") {
+		t.Error("Caddyfile should not contain basicauth when profile is not active")
+	}
+	// Should have bare reverse_proxy (not wrapped in handle)
+	if strings.Contains(caddy, "handle {") {
+		t.Error("Caddyfile should not use handle blocks when observable is not active")
+	}
+	if !strings.Contains(caddy, "reverse_proxy varnish:80") {
+		t.Error("Caddyfile should contain 'reverse_proxy varnish:80'")
 	}
 }


### PR DESCRIPTION
## Summary

- Add `log` block to CLI-generated Caddyfile
- Logs access requests to `/var/log/caddy/access.log`

Companion to CanastaWiki/Canasta-DockerCompose#74

Fixes #213