### PR TITLE
Document wiki display name configuration and $wgMetaNamespace behavior

### DIFF
--- a/docs/guide/general-concepts.md
+++ b/docs/guide/general-concepts.md
@@ -134,6 +134,29 @@ wikis:
 
 The `url` field uses `domain/path` format without the protocol. The Caddyfile is regenerated from this file whenever wikis are added or removed.
 
+#### Changing a wiki's display name
+
+The `name` field in `wikis.yaml` controls the wiki's display name (`$wgSitename` in MediaWiki). It defaults to the wiki ID if not set. The name is initially set with the `-t` (`--site-name`) flag of `canasta create` or `canasta add`:
+
+```bash
+canasta create -i myinstance -w docs -n example.com -a admin -t "Project Documentation"
+```
+
+To change it later, edit the `name` field directly in `config/wikis.yaml`:
+
+```yaml
+wikis:
+- id: docs
+  url: example.com/docs
+  name: Project Documentation
+```
+
+The change takes effect immediately — no restart is needed.
+
+Do not set `$wgSitename` in PHP settings files — it is configured automatically from `wikis.yaml`.
+
+`$wgMetaNamespace` provides an alias for the Project namespace (the `Project:` prefix always works as well). It is derived from the display name with spaces replaced by underscores. For example, a wiki named "Project Documentation" will get the alias `Project_Documentation:`. If you need a different alias, you can override `$wgMetaNamespace` in a per-wiki settings file (use underscores instead of spaces).
+
 ### Caddyfile, Caddyfile.custom, and Caddyfile.global
 
 Canasta uses [Caddy](https://caddyserver.com/) as its reverse proxy. The `config/Caddyfile` is auto-generated from `wikis.yaml` and is overwritten whenever wikis are added or removed — do not edit it directly.

--- a/internal/canasta/files/global-settings-README
+++ b/internal/canasta/files/global-settings-README
@@ -29,10 +29,11 @@ But plain names work fine:
 
 Do NOT set these here (they are configured automatically from wikis.yaml):
 
-- $wgDBname
-- $wgServer
-- $wgSitename
-- $wgMetaNamespace
+- $wgDBname — set to the wiki ID
+- $wgServer — set from the wiki's URL
+- $wgSitename — set from the wiki's "name" field (defaults to wiki ID)
+- $wgMetaNamespace — derived from display name with spaces replaced by underscores
+  (can be overridden in per-wiki settings)
 
 ## Per-Wiki Overrides
 

--- a/internal/canasta/files/wiki-settings-README
+++ b/internal/canasta/files/wiki-settings-README
@@ -26,12 +26,14 @@ But plain names work fine:
 
 ## Variables Set Automatically
 
-Do NOT set these here (they are configured automatically from wikis.yaml):
+Do NOT set these here unless you need to override the default:
 
-- $wgDBname
-- $wgServer
-- $wgSitename
-- $wgMetaNamespace
+- $wgDBname — set to the wiki ID (do NOT override)
+- $wgServer — set from the wiki's URL (do NOT override)
+- $wgSitename — set from the wiki's "name" field in wikis.yaml (do NOT override;
+  change the "name" field in wikis.yaml instead)
+- $wgMetaNamespace — derived from the display name with spaces replaced by
+  underscores; override here if you want a different Project namespace name
 
 ## Global Settings
 


### PR DESCRIPTION
## Summary

- Add section to `general-concepts.md` explaining how to set and change a wiki's display name via the `name` field in `wikis.yaml` and the `-t` (`--site-name`) flag
- Document that `$wgMetaNamespace` is set to the wiki ID and can be overridden in per-wiki settings files
- Update README templates (`global-settings-README`, `wiki-settings-README`) to explain what each auto-set variable does and clarify when overrides are allowed

Closes #216

## Test plan

- [ ] Verify `go build ./...` succeeds (README templates are embedded via `go:embed`)
- [ ] Review documentation for accuracy and clarity