### PR TITLE
Fix all golangci-lint warnings

### DIFF
--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -148,8 +148,8 @@ an existing database dump instead of running the installer.`,
 	addCmd.Flags().StringVar(&wikidbuser, "wikidbuser", "root", "The username of the wiki database user (default: \"root\")")
 
 	// Mark required flags (admin is validated at runtime based on whether --database is provided)
-	addCmd.MarkFlagRequired("wiki")
-	addCmd.MarkFlagRequired("url")
+	_ = addCmd.MarkFlagRequired("wiki")
+	_ = addCmd.MarkFlagRequired("url")
 
 	return addCmd
 }

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -173,7 +173,7 @@ instead of running the installer, or enable development mode with Xdebug.`,
 	createCmd.Flags().StringVarP(&globalSettingsPath, "global-settings", "g", "", "Path to global settings file to copy to config/settings/global/ (filename preserved)")
 
 	// Mark required flags
-	createCmd.MarkFlagRequired("id")
+	_ = createCmd.MarkFlagRequired("id")
 
 	return createCmd
 }

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -81,7 +81,7 @@ Use a .gz extension on the output path to get a gzip-compressed dump.`,
 	exportCmd.Flags().StringVarP(&wikiID, "wiki", "w", "", "ID of the wiki to export")
 	exportCmd.Flags().StringVarP(&outputPath, "file", "f", "", "Output file path (default: <wikiID>.sql)")
 
-	exportCmd.MarkFlagRequired("wiki")
+	_ = exportCmd.MarkFlagRequired("wiki")
 
 	return exportCmd
 }

--- a/cmd/import/import.go
+++ b/cmd/import/import.go
@@ -87,8 +87,8 @@ To create a new wiki from a database dump, use the --database flag with
 	importCmd.Flags().StringVarP(&databasePath, "database", "d", "", "Path to SQL dump file (.sql or .sql.gz)")
 	importCmd.Flags().StringVarP(&settingsPath, "wiki-settings", "l", "", "Path to per-wiki Settings.php to replace the existing one")
 
-	importCmd.MarkFlagRequired("wiki")
-	importCmd.MarkFlagRequired("database")
+	_ = importCmd.MarkFlagRequired("wiki")
+	_ = importCmd.MarkFlagRequired("database")
 
 	return importCmd
 }

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -122,7 +122,7 @@ func RemoveWiki(instance config.Installation, wikiID string) error {
 	// Remove the Images (from inside container first to handle www-data ownership on Linux)
 	if containersRunning {
 		cleanupCmd := fmt.Sprintf("rm -rf /mediawiki/images/%s", wikiID)
-		orch.ExecWithError(instance.Path, "web", cleanupCmd)
+		_, _ = orch.ExecWithError(instance.Path, "web", cleanupCmd)
 	}
 	err = canasta.RemoveImages(instance.Path, wikiID)
 	if err != nil {

--- a/cmd/restic/check.go
+++ b/cmd/restic/check.go
@@ -29,7 +29,7 @@ func check() {
 	commandArgs = append(commandArgs, "check")
 	err, output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
 	if err != nil {
-		logging.Fatal(fmt.Errorf(output))
+		logging.Fatal(fmt.Errorf("%s", output))
 	} else {
 		fmt.Print(output)
 	}

--- a/cmd/restic/diff.go
+++ b/cmd/restic/diff.go
@@ -29,8 +29,8 @@ modified files.`,
 	}
 	diffCmd.Flags().StringVar(&tag1, "tag1", "", "Restic snapshot ID (required)")
 	diffCmd.Flags().StringVar(&tag2, "tag2", "", "Restic snapshot ID (required)")
-	diffCmd.MarkFlagRequired("tag1")
-	diffCmd.MarkFlagRequired("tag2")
+	_ = diffCmd.MarkFlagRequired("tag1")
+	_ = diffCmd.MarkFlagRequired("tag2")
 	return diffCmd
 }
 
@@ -38,7 +38,7 @@ func diff() {
 	commandArgs = append(commandArgs, "diff", tag1, tag2)
 	err, output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
 	if err != nil {
-		logging.Fatal(fmt.Errorf(output))
+		logging.Fatal(fmt.Errorf("%s", output))
 	} else {
 		fmt.Print(output)
 	}

--- a/cmd/restic/forgetSnapshots.go
+++ b/cmd/restic/forgetSnapshots.go
@@ -35,7 +35,7 @@ func forgetSnapshot() {
 	commandArgs = append(commandArgs, "forget", tag)
 	err, output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
 	if err != nil {
-		logging.Fatal(fmt.Errorf(output))
+		logging.Fatal(fmt.Errorf("%s", output))
 	} else {
 		fmt.Print(output)
 	}

--- a/cmd/restic/init.go
+++ b/cmd/restic/init.go
@@ -35,7 +35,7 @@ func initRestic() {
 	commandArgs = append(commandArgs, "init")
 	err, output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
 	if err != nil {
-		logging.Fatal(fmt.Errorf(output))
+		logging.Fatal(fmt.Errorf("%s", output))
 	} else {
 		fmt.Print(output)
 	}

--- a/cmd/restic/listFiles.go
+++ b/cmd/restic/listFiles.go
@@ -35,7 +35,7 @@ func listFiles() {
 	commandArgs = append(commandArgs, "ls", tag)
 	err, output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
 	if err != nil {
-		logging.Fatal(fmt.Errorf(output))
+		logging.Fatal(fmt.Errorf("%s", output))
 	} else {
 		fmt.Print(output)
 	}

--- a/cmd/restic/restoreSnapshot.go
+++ b/cmd/restic/restoreSnapshot.go
@@ -42,7 +42,7 @@ specified snapshot.`,
 
 	restoreSnapshotCmd.Flags().StringVarP(&snapshotId, "snapshot-id", "s", "", "Restic snapshot ID (required)")
 	restoreSnapshotCmd.Flags().BoolVarP(&skipBeforeSnapshot, "skip-before-restore-snapshot", "r", false, "Skips taking snapshot before restore")
-	restoreSnapshotCmd.MarkFlagRequired("snapshot-id")
+	_ = restoreSnapshotCmd.MarkFlagRequired("snapshot-id")
 	return restoreSnapshotCmd
 }
 
@@ -65,7 +65,7 @@ func restoreSnapshot(snapshotId string, skipBeforeSnapshot bool) {
 	commandArgs := strings.Fields(command)
 	err, output := execute.Run("", "sudo", commandArgs...)
 	if err != nil {
-		logging.Fatal(fmt.Errorf(output))
+		logging.Fatal(fmt.Errorf("%s", output))
 	}
 	logging.Print("Copying files....")
 	folders := [...]string{"/config", "/extensions", "/images", "/skins"}

--- a/cmd/restic/takeSnapshot.go
+++ b/cmd/restic/takeSnapshot.go
@@ -51,7 +51,7 @@ func takeSnapshot(tag string) {
 
 	err, output := execute.Run(instance.Path, "sudo", "cp", "--preserve=links,mode,ownership,timestamps", "-r", "config", "extensions", "images", "skins", currentSnapshotFolder)
 	if err != nil {
-		logging.Fatal(fmt.Errorf(output))
+		logging.Fatal(fmt.Errorf("%s", output))
 	}
 	logging.Print("Copy folders and files completed.")
 
@@ -59,7 +59,7 @@ func takeSnapshot(tag string) {
 	repoURL := getRepoURL(EnvVariables)
 	err, output = execute.Run(instance.Path, "sudo", "docker", "run", "--rm", "-i", "--env-file", envPath, "-v", currentSnapshotFolder+":/currentsnapshot/", "restic/restic", "-r", repoURL, "--tag", fmt.Sprintf("%s__on__%s", tag, hostname), "backup", "/currentsnapshot")
 	if err != nil {
-		logging.Fatal(fmt.Errorf(output))
+		logging.Fatal(fmt.Errorf("%s", output))
 	}
 	fmt.Print(output)
 	fmt.Println("Completed running restic backup")

--- a/cmd/restic/unlock.go
+++ b/cmd/restic/unlock.go
@@ -28,7 +28,7 @@ func unlock() {
 	commandArgs = append(commandArgs, "unlock")
 	err, output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
 	if err != nil {
-		logging.Fatal(fmt.Errorf(output))
+		logging.Fatal(fmt.Errorf("%s", output))
 	}
 	fmt.Print(output)
 }

--- a/cmd/restic/viewSnapshots.go
+++ b/cmd/restic/viewSnapshots.go
@@ -29,7 +29,7 @@ func viewSnapshots() {
 	commandArgs = append(commandArgs, "snapshots")
 	err, output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
 	if err != nil {
-		logging.Fatal(fmt.Errorf(output))
+		logging.Fatal(fmt.Errorf("%s", output))
 	}
 	fmt.Print(output)
 }

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -38,7 +38,7 @@ multiple Canasta instances, including wiki farms with multiple wikis per instanc
 		logging.Print("Setting verbose")
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Help()
+		_ = cmd.Help()
 	},
 }
 

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -107,7 +107,7 @@ func CreateEnvFile(customEnvPath, installPath, workingDir, rootDBpass, wikiDBpas
 	logging.Print(fmt.Sprintf("Copying %s to %s/.env\n", examplePath, installPath))
 	err, output := execute.Run("", "cp", examplePath, installPath+"/.env")
 	if err != nil {
-		return fmt.Errorf(output)
+		return fmt.Errorf("%s", output)
 	}
 
 	// Step 2: If custom env file provided, merge its values
@@ -171,7 +171,7 @@ func CopyYaml(yamlPath, installPath string) error {
 	logging.Print(fmt.Sprintf("Copying %s to %s/config/wikis.yaml\n", yamlPath, installPath))
 	err, output := execute.Run("", "cp", yamlPath, installPath+"/config/wikis.yaml")
 	if err != nil {
-		return fmt.Errorf(output)
+		return fmt.Errorf("%s", output)
 	}
 	return nil
 }
@@ -270,7 +270,7 @@ func CopyWikiSettingFile(installPath, wikiID, settingsFilePath, workingDir strin
 	logging.Print(fmt.Sprintf("Copying %s to %s\n", settingsFilePath, destPath))
 	err, output := execute.Run("", "cp", settingsFilePath, destPath)
 	if err != nil {
-		return fmt.Errorf(output)
+		return fmt.Errorf("%s", output)
 	}
 
 	return nil
@@ -298,7 +298,7 @@ func CopyGlobalSettingFile(installPath, settingsFilePath, workingDir string) err
 	logging.Print(fmt.Sprintf("Copying %s to %s\n", settingsFilePath, destPath))
 	err, output := execute.Run("", "cp", settingsFilePath, destPath)
 	if err != nil {
-		return fmt.Errorf(output)
+		return fmt.Errorf("%s", output)
 	}
 
 	return nil
@@ -671,9 +671,9 @@ func CheckCanastaId(instance config.Installation) (config.Installation, error) {
 
 func DeleteConfigAndContainers(keepConfig bool, installationDir string, orch orchestrators.Orchestrator) {
 	fmt.Println("Removing containers")
-	orch.Destroy(installationDir)
+	_, _ = orch.Destroy(installationDir)
 	fmt.Println("Deleting config files")
-	orchestrators.DeleteConfig(installationDir)
+	_, _ = orchestrators.DeleteConfig(installationDir)
 	fmt.Println("Deleted all containers and config files")
 }
 
@@ -683,7 +683,7 @@ func RemoveSettings(installPath, id string) error {
 	if _, err := os.Stat(newPath); err == nil {
 		err, output := execute.Run("", "rm", "-rf", newPath)
 		if err != nil {
-			return fmt.Errorf(output)
+			return fmt.Errorf("%s", output)
 		}
 		return nil
 	}
@@ -693,7 +693,7 @@ func RemoveSettings(installPath, id string) error {
 	if _, err := os.Stat(legacyPath); err == nil {
 		err, output := execute.Run("", "rm", "-rf", legacyPath)
 		if err != nil {
-			return fmt.Errorf(output)
+			return fmt.Errorf("%s", output)
 		}
 	} else if !os.IsNotExist(err) {
 		return err
@@ -710,7 +710,7 @@ func RemoveImages(installPath, id string) error {
 		// If the file exists, remove it
 		err, output := execute.Run("", "rm", "-rf", filePath)
 		if err != nil {
-			return fmt.Errorf(output)
+			return fmt.Errorf("%s", output)
 		}
 	} else if os.IsNotExist(err) {
 		// File does not exist, do nothing
@@ -731,7 +731,7 @@ func RemovePublicAssets(installPath, id string) error {
 		// If the file exists, remove it
 		err, output := execute.Run("", "rm", "-rf", filePath)
 		if err != nil {
-			return fmt.Errorf(output)
+			return fmt.Errorf("%s", output)
 		}
 	} else if os.IsNotExist(err) {
 		// File does not exist, do nothing

--- a/internal/devmode/devmode.go
+++ b/internal/devmode/devmode.go
@@ -113,7 +113,7 @@ func ExtractMediaWikiCode(installPath, baseImage string) error {
 	// Run the symlinks script to create extensions/ and skins/ symlinks
 	logging.Print("Creating extension and skin symlinks...\n")
 	if err, output := execute.Run("", "docker", "exec", containerName, "/create-symlinks.sh"); err != nil {
-		execute.Run("", "docker", "rm", "-f", containerName)
+		_, _ = execute.Run("", "docker", "rm", "-f", containerName)
 		return fmt.Errorf("failed to create symlinks: %s", output)
 	}
 
@@ -125,7 +125,7 @@ func ExtractMediaWikiCode(installPath, baseImage string) error {
 	cmd := exec.Command("bash", "-c", tarCmd)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		// Clean up container on failure
-		execute.Run("", "docker", "rm", "-f", containerName)
+		_, _ = execute.Run("", "docker", "rm", "-f", containerName)
 		return fmt.Errorf("failed to copy code from container: %s (output: %s)", err, string(output))
 	}
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -23,7 +23,7 @@ var skipPaths = []string{
 func Clone(repo, path string) error {
 	err, output := execute.Run("", "git", "clone", repo, path)
 	if err != nil {
-		return fmt.Errorf(output)
+		return fmt.Errorf("%s", output)
 	}
 	return nil
 }
@@ -31,7 +31,7 @@ func Clone(repo, path string) error {
 func Cloneb(repo, path string, branch string) error {
 	err, output := execute.Run("", "git", "clone", "-b", branch, repo, path)
 	if err != nil {
-		return fmt.Errorf(output)
+		return fmt.Errorf("%s", output)
 	}
 	return nil
 }
@@ -44,13 +44,13 @@ func FetchAndCheckout(path string, dryRun bool) (bool, error) {
 	// Fetch latest from origin
 	err, output := execute.Run(path, "git", "fetch", "origin")
 	if err != nil {
-		return false, fmt.Errorf(output)
+		return false, fmt.Errorf("%s", output)
 	}
 
 	// Get files that are added or modified in origin/main (safe to checkout)
 	err, output = execute.Run(path, "git", "diff", "--diff-filter=d", "--name-only", "HEAD", "origin/main")
 	if err != nil {
-		return false, fmt.Errorf(output)
+		return false, fmt.Errorf("%s", output)
 	}
 
 	var filesToUpdate []string
@@ -69,7 +69,7 @@ func FetchAndCheckout(path string, dryRun bool) (bool, error) {
 	// Get files that were deleted in origin/main
 	err, output = execute.Run(path, "git", "diff", "--diff-filter=D", "--name-only", "HEAD", "origin/main")
 	if err != nil {
-		return false, fmt.Errorf(output)
+		return false, fmt.Errorf("%s", output)
 	}
 
 	var filesToRemove []string
@@ -86,7 +86,7 @@ func FetchAndCheckout(path string, dryRun bool) (bool, error) {
 	// These won't appear in the HEAD vs origin/main diff if the committed versions match.
 	err, output = execute.Run(path, "git", "diff", "--name-only", "HEAD")
 	if err != nil {
-		return false, fmt.Errorf(output)
+		return false, fmt.Errorf("%s", output)
 	}
 
 	var locallyModified []string
@@ -163,7 +163,7 @@ func FetchAndCheckout(path string, dryRun bool) (bool, error) {
 		args := append([]string{"checkout", "origin/main", "--"}, filesToUpdate...)
 		err, output = execute.Run(path, "git", args...)
 		if err != nil {
-			return false, fmt.Errorf(output)
+			return false, fmt.Errorf("%s", output)
 		}
 		fmt.Println("Files updated from upstream:")
 		for _, file := range filesToUpdate {
@@ -203,7 +203,7 @@ func FetchAndCheckout(path string, dryRun bool) (bool, error) {
 	// Working tree is left as-is (denylist files keep their local changes).
 	err, output = execute.Run(path, "git", "reset", "origin/main")
 	if err != nil {
-		return false, fmt.Errorf(output)
+		return false, fmt.Errorf("%s", output)
 	}
 
 	return true, nil

--- a/internal/mediawiki/mediawiki.go
+++ b/internal/mediawiki/mediawiki.go
@@ -33,7 +33,7 @@ func Install(path, yamlPath string, orch orchestrators.Orchestrator, canastaInfo
 	command := "/wait-for-it.sh -t 60 db:3306"
 	output, err := orch.ExecWithError(path, "web", command)
 	if err != nil {
-		return canastaInfo, fmt.Errorf(output)
+		return canastaInfo, fmt.Errorf("%s", output)
 	}
 
 	WikiIDs, domainNames, _, err := farmsettings.ReadWikisYaml(yamlPath)
@@ -50,7 +50,7 @@ func Install(path, yamlPath string, orch orchestrators.Orchestrator, canastaInfo
 
 		output, err = orch.ExecWithError(path, "web", command)
 		if err != nil {
-			return canastaInfo, fmt.Errorf(output)
+			return canastaInfo, fmt.Errorf("%s", output)
 		}
 
 		// Save admin password to config/admin-password_{wikiid}
@@ -115,7 +115,7 @@ func InstallOne(installPath, id, domain, admin, adminPassword, dbuser, workingDi
 	command := "/wait-for-it.sh -t 60 db:3306"
 	output, err := orch.ExecWithError(installPath, "web", command)
 	if err != nil {
-		return fmt.Errorf(output)
+		return fmt.Errorf("%s", output)
 	}
 
 	localExists, _ := fileExists(filepath.Join(installPath, "config", localSettingsFile))
@@ -188,7 +188,7 @@ func InstallOne(installPath, id, domain, admin, adminPassword, dbuser, workingDi
 		installCmd, dbServer, id, confPath, scriptPath, domain, installdbuser, installdbpass, dbuser, dbpass, adminPassword, id, admin)
 	output, err = orch.ExecWithError(installPath, "web", command)
 	if err != nil {
-		return fmt.Errorf(output)
+		return fmt.Errorf("%s", output)
 	}
 
 	// Save admin password to config/admin-password_{wikiid}

--- a/internal/spinner/spinner.go
+++ b/internal/spinner/spinner.go
@@ -39,7 +39,7 @@ func New(description string) (*progressbar.ProgressBar, chan struct{}) {
 			case <-done:
 				return
 			default:
-				spinner.Add(1)
+				_ = spinner.Add(1)
 				time.Sleep(5 * time.Millisecond)
 			}
 		}


### PR DESCRIPTION
Closes #223

## Summary

- Fix SA1006 warnings: use `fmt.Errorf("%s", output)` instead of `fmt.Errorf(output)` to prevent dynamic strings from being interpreted as format strings
- Fix errcheck warnings: explicitly ignore error returns on cleanup calls and `MarkFlagRequired` with `_ =`

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` passes with no warnings