### PR TITLE
Replace Fatal calls with error returns in internal packages

### DIFF
--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -59,7 +59,10 @@ func Delete(instance config.Installation) error {
 		return err
 	}
 
-	orch := orchestrators.New(instance.Orchestrator)
+	orch, err := orchestrators.New(instance.Orchestrator)
+	if err != nil {
+		return err
+	}
 
 	// Ensure containers are running so we can clean up images from inside
 	// (needed on Linux where container-created files are owned by www-data)

--- a/cmd/extension/disable.go
+++ b/cmd/extension/disable.go
@@ -30,9 +30,11 @@ extension for a specific wiki only.`,
 					fmt.Print(err.Error() + "\n")
 					continue
 				}
-				extensionsskins.Disable(extensionName, wiki, instance, orch, constants)
+				if err := extensionsskins.Disable(extensionName, wiki, instance, orch, constants); err != nil {
+					return err
+				}
 			}
-			return err
+			return nil
 		},
 	}
 	return disableCmd

--- a/cmd/extension/enable.go
+++ b/cmd/extension/enable.go
@@ -33,9 +33,11 @@ extension for a specific wiki only.`,
 					fmt.Print(err.Error() + "\n")
 					continue
 				}
-				extensionsskins.Enable(extensionName, wiki, instance, orch, constants)
+				if err := extensionsskins.Enable(extensionName, wiki, instance, orch, constants); err != nil {
+					return err
+				}
 			}
-			return err
+			return nil
 		},
 	}
 	return enableCmd

--- a/cmd/extension/extension.go
+++ b/cmd/extension/extension.go
@@ -42,8 +42,8 @@ a specific wiki in a farm.`,
 			if err != nil {
 				return err
 			}
-			orch = orchestrators.New(instance.Orchestrator)
-			return nil
+			orch, err = orchestrators.New(instance.Orchestrator)
+			return err
 		},
 	}
 

--- a/cmd/extension/list.go
+++ b/cmd/extension/list.go
@@ -14,8 +14,7 @@ func listCmdCreate() *cobra.Command {
 is shown with its enabled/disabled status.`,
 		Example: `  canasta extension list -i myinstance`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			extensionsskins.List(instance, orch, constants)
-			return err
+			return extensionsskins.List(instance, orch, constants)
 		},
 	}
 

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -26,6 +26,5 @@ ID, path, and orchestrator as recorded in the Canasta configuration file.`,
 }
 
 func List(instance config.Installation) error {
-	config.ListAll()
-	return nil
+	return config.ListAll()
 }

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -38,11 +38,9 @@ for confirmation before any data is deleted.`,
 		Example: `  # Remove a wiki by ID
   canasta remove -i myinstance -w docs`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var err error
 			fmt.Printf("Removing wiki '%s' from Canasta instance '%s'...\n", wikiID, instance.Id)
-			err = RemoveWiki(instance, wikiID)
-			if err != nil {
-				log.Fatal(err)
+			if err := RemoveWiki(instance, wikiID); err != nil {
+				return err
 			}
 			fmt.Println("Done.")
 			return nil
@@ -63,7 +61,10 @@ func RemoveWiki(instance config.Installation, wikiID string) error {
 		return err
 	}
 
-	orch := orchestrators.New(instance.Orchestrator)
+	orch, err := orchestrators.New(instance.Orchestrator)
+	if err != nil {
+		return err
+	}
 
 	// Ensure containers are running (starts them if needed)
 	// Needed for database removal and image cleanup on Linux

--- a/cmd/restart/restart.go
+++ b/cmd/restart/restart.go
@@ -44,12 +44,11 @@ restart. Use --dev or --no-dev to change the development mode setting.`,
 			}
 			resolvedInstance, err := canasta.CheckCanastaId(instance)
 			if err != nil {
-				log.Fatal(err)
+				return err
 			}
 			fmt.Println("Restarting Canasta installation '" + resolvedInstance.Id + "'...")
-			err = Restart(resolvedInstance, devModeFlag, noDevFlag)
-			if err != nil {
-				log.Fatal(err)
+			if err = Restart(resolvedInstance, devModeFlag, noDevFlag); err != nil {
+				return err
 			}
 			fmt.Println("Restarted.")
 			return nil
@@ -68,10 +67,12 @@ func Restart(instance config.Installation, enableDev, disableDev bool) error {
 		return fmt.Errorf("cannot specify both --dev and --no-dev")
 	}
 
-	orch := orchestrators.New(instance.Orchestrator)
+	orch, err := orchestrators.New(instance.Orchestrator)
+	if err != nil {
+		return err
+	}
 
 	// Migrate to the new version Canasta
-	var err error
 	if err = canasta.MigrateToNewVersion(instance.Path); err != nil {
 		return err
 	}

--- a/cmd/restic/check.go
+++ b/cmd/restic/check.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/execute"
-	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 )
 
 func checkCmdCreate() *cobra.Command {
@@ -17,20 +16,22 @@ func checkCmdCreate() *cobra.Command {
 		Long: `Verify the integrity of the Restic backup repository and its data. This
 checks for errors in the repository structure and snapshot data.`,
 		Example: `  canasta restic check -i myinstance`,
-		Run: func(cmd *cobra.Command, args []string) {
-			check()
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return check()
 		},
 	}
 	checkCmd.Flags().StringVarP(&tag, "tag", "t", "", "Restic snapshot ID (required)")
 	return checkCmd
 }
 
-func check() {
+func check() error {
 	commandArgs = append(commandArgs, "check")
 	err, output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
 	if err != nil {
-		logging.Fatal(fmt.Errorf("%s", output))
 	} else {
 		fmt.Print(output)
+		return fmt.Errorf("%s", output)
 	}
+	fmt.Print(output)
+	return nil
 }

--- a/cmd/restic/diff.go
+++ b/cmd/restic/diff.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/execute"
-	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 )
 
 var (
@@ -23,8 +22,7 @@ contents and metadata of both snapshots, displaying added, removed, and
 modified files.`,
 		Example: `  canasta restic diff -i myinstance --tag1 abc123 --tag2 def456`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			diff()
-			return nil
+			return diff()
 		},
 	}
 	diffCmd.Flags().StringVar(&tag1, "tag1", "", "Restic snapshot ID (required)")
@@ -34,12 +32,14 @@ modified files.`,
 	return diffCmd
 }
 
-func diff() {
+func diff() error {
 	commandArgs = append(commandArgs, "diff", tag1, tag2)
 	err, output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
 	if err != nil {
-		logging.Fatal(fmt.Errorf("%s", output))
 	} else {
 		fmt.Print(output)
+		return fmt.Errorf("%s", output)
 	}
+	fmt.Print(output)
+	return nil
 }

--- a/cmd/restic/forgetSnapshots.go
+++ b/cmd/restic/forgetSnapshots.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/execute"
-	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -22,8 +21,7 @@ may still exist until a 'restic prune' is run on the repository.`,
 			} else if tag == "" {
 				tag = args[0]
 			}
-			forgetSnapshot()
-			return nil
+			return forgetSnapshot()
 		},
 	}
 
@@ -31,12 +29,14 @@ may still exist until a 'restic prune' is run on the repository.`,
 	return forgetSnapshotCmd
 }
 
-func forgetSnapshot() {
+func forgetSnapshot() error {
 	commandArgs = append(commandArgs, "forget", tag)
 	err, output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
 	if err != nil {
-		logging.Fatal(fmt.Errorf("%s", output))
 	} else {
 		fmt.Print(output)
+		return fmt.Errorf("%s", output)
 	}
+	fmt.Print(output)
+	return nil
 }

--- a/cmd/restic/init.go
+++ b/cmd/restic/init.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/execute"
-	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 )
 
 var (
@@ -23,20 +22,21 @@ taking any snapshots. The repository location is read from the
 RESTIC_REPOSITORY variable (or AWS S3 settings) in the installation's .env file.`,
 		Example: `  canasta restic init -i myinstance`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			initRestic()
-			return nil
+			return initRestic()
 		},
 	}
 	return initCmd
 }
 
-func initRestic() {
+func initRestic() error {
 	fmt.Println("Initializing Restic repo")
 	commandArgs = append(commandArgs, "init")
 	err, output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
 	if err != nil {
-		logging.Fatal(fmt.Errorf("%s", output))
 	} else {
 		fmt.Print(output)
+		return fmt.Errorf("%s", output)
 	}
+	fmt.Print(output)
+	return nil
 }

--- a/cmd/restic/listFiles.go
+++ b/cmd/restic/listFiles.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/execute"
-	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 )
 
 func listFilesCmdCreate() *cobra.Command {
@@ -23,20 +22,21 @@ for inspecting what was backed up before performing a restore.`,
 			} else if tag == "" {
 				tag = args[0]
 			}
-			listFiles()
-			return nil
+			return listFiles()
 		},
 	}
 	listFilesCmd.Flags().StringVarP(&tag, "tag", "t", "", "Restic snapshot ID (required)")
 	return listFilesCmd
 }
 
-func listFiles() {
+func listFiles() error {
 	commandArgs = append(commandArgs, "ls", tag)
 	err, output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
 	if err != nil {
-		logging.Fatal(fmt.Errorf("%s", output))
 	} else {
 		fmt.Print(output)
+		return fmt.Errorf("%s", output)
 	}
+	fmt.Print(output)
+	return nil
 }

--- a/cmd/restic/restic.go
+++ b/cmd/restic/restic.go
@@ -41,7 +41,10 @@ AWS S3 settings) and RESTIC_PASSWORD to be configured in the installation's .env
 				return err
 			}
 			envPath := instance.Path + "/.env"
-			EnvVariables := canasta.GetEnvVariable(envPath)
+			EnvVariables, envErr := canasta.GetEnvVariable(envPath)
+			if envErr != nil {
+				return envErr
+			}
 			repoURL := getRepoURL(EnvVariables)
 			commandArgs = append(make([]string, 0), "sudo", "docker", "run", "--rm", "-i", "--env-file", envPath, "restic/restic", "-r", repoURL)
 
@@ -76,25 +79,25 @@ func getRepoURL(env map[string]string) string {
 	return "s3:" + env["AWS_S3_API"] + "/" + env["AWS_S3_BUCKET"]
 }
 
-func checkCurrentSnapshotFolder(currentSnapshotFolder string) {
-
+func checkCurrentSnapshotFolder(currentSnapshotFolder string) error {
 	if _, err := os.Stat(currentSnapshotFolder); err != nil {
 		if os.IsNotExist(err) {
 			logging.Print("Creating..." + currentSnapshotFolder)
 			if err := os.Mkdir(currentSnapshotFolder, 0o700); err != nil {
-				logging.Fatal(err)
+				return err
 			}
 		} else {
-			logging.Fatal(err)
+			return err
 		}
 	} else {
 		logging.Print("Emptying... " + currentSnapshotFolder)
 		if err := os.RemoveAll(currentSnapshotFolder); err != nil {
-			logging.Fatal(err)
+			return err
 		}
 		if err := os.Mkdir(currentSnapshotFolder, 0o700); err != nil {
-			logging.Fatal(err)
+			return err
 		}
 		logging.Print("Emptied.. " + currentSnapshotFolder)
 	}
+	return nil
 }

--- a/cmd/restic/unlock.go
+++ b/cmd/restic/unlock.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/execute"
-	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 )
 
 func unlockCmdCreate() *cobra.Command {
@@ -17,18 +16,19 @@ func unlockCmdCreate() *cobra.Command {
 		Long: `Remove stale lock files from the Restic repository. Use this if a previous
 backup operation was interrupted and left the repository in a locked state.`,
 		Example: `  canasta restic unlock -i myinstance`,
-		Run: func(cmd *cobra.Command, args []string) {
-			unlock()
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return unlock()
 		},
 	}
 	return unlockCmd
 }
 
-func unlock() {
+func unlock() error {
 	commandArgs = append(commandArgs, "unlock")
 	err, output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
 	if err != nil {
-		logging.Fatal(fmt.Errorf("%s", output))
+		return fmt.Errorf("%s", output)
 	}
 	fmt.Print(output)
+	return nil
 }

--- a/cmd/restic/viewSnapshots.go
+++ b/cmd/restic/viewSnapshots.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/execute"
-	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 )
 
 func viewSnapshotsCmdCreate() *cobra.Command {
@@ -18,18 +17,18 @@ func viewSnapshotsCmdCreate() *cobra.Command {
 each snapshot's ID, timestamp, hostname, and tags.`,
 		Example: `  canasta restic view -i myinstance`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			viewSnapshots()
-			return nil
+			return viewSnapshots()
 		},
 	}
 	return initCmd
 }
 
-func viewSnapshots() {
+func viewSnapshots() error {
 	commandArgs = append(commandArgs, "snapshots")
 	err, output := execute.Run(instance.Path, commandArgs[0], commandArgs[1:]...)
 	if err != nil {
-		logging.Fatal(fmt.Errorf("%s", output))
+		return fmt.Errorf("%s", output)
 	}
 	fmt.Print(output)
+	return nil
 }

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -80,13 +80,20 @@ func init() {
 	rootCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
 		defaultHelp(cmd, args)
 		if cmd == rootCmd {
-			configDir := config.GetConfigDir()
-			cmd.Printf("\nConfig file: %s/conf.json\n", configDir)
+			configDir, err := config.GetConfigDir()
+			if err != nil {
+				cmd.Printf("\nConfig file: (error: %s)\n", err)
+			} else {
+				cmd.Printf("\nConfig file: %s/conf.json\n", configDir)
+			}
 		}
 	})
 
 	cobra.OnInitialize(func() {
-		orch := orchestrators.New("compose")
+		orch, err := orchestrators.New("compose")
+		if err != nil {
+			logging.Fatal(err)
+		}
 		if err := orch.CheckDependencies(); err != nil {
 			logging.Fatal(err)
 		}

--- a/cmd/skin/disable.go
+++ b/cmd/skin/disable.go
@@ -30,9 +30,11 @@ specific wiki only.`,
 					fmt.Print(err.Error() + "\n")
 					continue
 				}
-				extensionsskins.Disable(skinName, wiki, instance, orch, constants)
+				if err := extensionsskins.Disable(skinName, wiki, instance, orch, constants); err != nil {
+					return err
+				}
 			}
-			return err
+			return nil
 		},
 	}
 	return disableCmd

--- a/cmd/skin/enable.go
+++ b/cmd/skin/enable.go
@@ -30,9 +30,11 @@ specific wiki only.`,
 					fmt.Print(err.Error() + "\n")
 					continue
 				}
-				extensionsskins.Enable(skinName, wiki, instance, orch, constants)
+				if err := extensionsskins.Enable(skinName, wiki, instance, orch, constants); err != nil {
+					return err
+				}
 			}
-			return err
+			return nil
 		},
 	}
 	return enableCmd

--- a/cmd/skin/list.go
+++ b/cmd/skin/list.go
@@ -14,8 +14,7 @@ func listCmdCreate() *cobra.Command {
 is shown with its enabled/disabled status.`,
 		Example: `  canasta skin list -i myinstance`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			extensionsskins.List(instance, orch, constants)
-			return err
+			return extensionsskins.List(instance, orch, constants)
 		},
 	}
 

--- a/cmd/skin/skin.go
+++ b/cmd/skin/skin.go
@@ -42,8 +42,8 @@ a specific wiki in a farm.`,
 			if err != nil {
 				return err
 			}
-			orch = orchestrators.New(instance.Orchestrator)
-			return nil
+			orch, err = orchestrators.New(instance.Orchestrator)
+			return err
 		},
 	}
 

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -47,11 +47,11 @@ Use --dev to enable or --no-dev to disable development mode at start time.`,
 			}
 			resolvedInstance, err := canasta.CheckCanastaId(instance)
 			if err != nil {
-				logging.Fatal(err)
+				return err
 			}
 			fmt.Println("Starting Canasta installation '" + resolvedInstance.Id + "'...")
 			if err := Start(resolvedInstance, devModeFlag, noDevFlag); err != nil {
-				logging.Fatal(err)
+				return err
 			}
 			fmt.Println("Started.")
 			return nil
@@ -69,9 +69,10 @@ func Start(instance config.Installation, enableDev, disableDev bool) error {
 		return fmt.Errorf("cannot specify both --dev and --no-dev")
 	}
 
-	orch := orchestrators.New(instance.Orchestrator)
-
-	var err error
+	orch, err := orchestrators.New(instance.Orchestrator)
+	if err != nil {
+		return err
+	}
 	if enableDev {
 		// Enable dev mode using default registry image
 		baseImage := canasta.GetDefaultImage()

--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -33,12 +33,11 @@ are stopped gracefully, preserving all data in Docker volumes.`,
 			}
 			resolvedInstance, err := canasta.CheckCanastaId(instance)
 			if err != nil {
-				log.Fatal(err)
+				return err
 			}
 			fmt.Println("Stopping Canasta installation '" + resolvedInstance.Id + "'...")
-			err = Stop(resolvedInstance)
-			if err != nil {
-				log.Fatal(err)
+			if err = Stop(resolvedInstance); err != nil {
+				return err
 			}
 			fmt.Println("Stopped.")
 			return nil
@@ -49,6 +48,9 @@ are stopped gracefully, preserving all data in Docker volumes.`,
 }
 
 func Stop(instance config.Installation) error {
-	orch := orchestrators.New(instance.Orchestrator)
+	orch, err := orchestrators.New(instance.Orchestrator)
+	if err != nil {
+		return err
+	}
 	return orch.Stop(instance)
 }

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -89,7 +89,10 @@ every registered installation.`,
 }
 
 func upgradeAllInstances(dryRun bool) error {
-	installations := config.GetAll()
+	installations, err := config.GetAll()
+	if err != nil {
+		return err
+	}
 	if len(installations) == 0 {
 		fmt.Println("No registered installations found")
 		return nil
@@ -131,7 +134,10 @@ func Upgrade(instance config.Installation, dryRun bool) error {
 		return err
 	}
 
-	orch := orchestrators.New(instance.Orchestrator)
+	orch, err := orchestrators.New(instance.Orchestrator)
+	if err != nil {
+		return err
+	}
 
 	if dryRun {
 		fmt.Println("Dry run mode - showing what would change without applying")
@@ -152,7 +158,10 @@ func Upgrade(instance config.Installation, dryRun bool) error {
 	// Check if this is a locally-built image (created with --build-from)
 	var imagesUpdated bool
 	envPath := filepath.Join(instance.Path, ".env")
-	envVars := canasta.GetEnvVariable(envPath)
+	envVars, err := canasta.GetEnvVariable(envPath)
+	if err != nil {
+		return err
+	}
 	canastaImage := envVars["CANASTA_IMAGE"]
 	isLocalBuild := strings.HasPrefix(canastaImage, "canasta:local")
 
@@ -283,7 +292,10 @@ func extractSecretKey(installPath string, dryRun bool) (bool, error) {
 	envPath := filepath.Join(installPath, ".env")
 
 	// Check if MW_SECRET_KEY is already set in .env
-	envVars := canasta.GetEnvVariable(envPath)
+	envVars, err := canasta.GetEnvVariable(envPath)
+	if err != nil {
+		return false, err
+	}
 	if val, ok := envVars["MW_SECRET_KEY"]; ok && val != "" {
 		return false, nil
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,11 +10,9 @@ require (
 )
 
 require (
-	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
-	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/term v0.6.0 // indirect
 )
@@ -22,5 +20,5 @@ require (
 require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/sethvargo/go-password v0.2.0 // direct
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.5
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-github.com/cpuguy83/go-md2man/v2 v2.0.1 h1:r/myEWzV9lfsM1tFLgDyu0atFtJ1fXn261LKYj/3DxU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -18,7 +17,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
-github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/schollz/progressbar/v3 v3.13.1 h1:o8rySDYiQ59Mwzy2FELeHY5ZARXZTVJC7iHD6PEFUiE=
 github.com/schollz/progressbar/v3 v3.13.1/go.mod h1:xvrbki8kfT1fzWzBT/UZd9L6GA+jdL7HAgq2RFnO6fQ=

--- a/internal/execute/execute.go
+++ b/internal/execute/execute.go
@@ -44,7 +44,7 @@ func Run(path, command string, cmdArgs ...string) (error, string) {
 	}
 
 	if err := cmd.Start(); err != nil {
-		logging.Fatal(err)
+		return err, ""
 	}
 
 	err := cmd.Wait()

--- a/internal/extensionsskins/extensionsskins.go
+++ b/internal/extensionsskins/extensionsskins.go
@@ -24,13 +24,14 @@ func Contains(list []string, element string) bool {
 	return false
 }
 
-func List(instance config.Installation, orch orchestrators.Orchestrator, constants Item) {
+func List(instance config.Installation, orch orchestrators.Orchestrator, constants Item) error {
 	log.Printf("Available %s:\n", constants.Name)
 	output, err := orch.ExecWithError(instance.Path, "web", "cd $MW_HOME/"+constants.RelativeInstallationPath+" && find * -maxdepth 0 -type d")
 	if err != nil {
-		log.Fatal(fmt.Errorf("%s", output))
+		return fmt.Errorf("%s", output)
 	}
 	log.Print(output)
+	return nil
 }
 
 func CheckInstalled(name string, instance config.Installation, orch orchestrators.Orchestrator, constants Item) (string, error) {
@@ -44,7 +45,7 @@ func CheckInstalled(name string, instance config.Installation, orch orchestrator
 	return name, nil
 }
 
-func Enable(name, wiki string, instance config.Installation, orch orchestrators.Orchestrator, constants Item) {
+func Enable(name, wiki string, instance config.Installation, orch orchestrators.Orchestrator, constants Item) error {
 	if wiki == "" {
 		log.Println("You didn't specify a wiki. The extension or skin will affect all wikis in the corresponding Canasta instance.")
 	}
@@ -67,10 +68,11 @@ func Enable(name, wiki string, instance config.Installation, orch orchestrators.
 		command := fmt.Sprintf(`echo -e "%s" > %s`, phpScript, filePath)
 		execOutput, execErr := orch.ExecWithError(instance.Path, "web", command)
 		if execErr != nil {
-			log.Fatal(fmt.Errorf("%s", execOutput))
+			return fmt.Errorf("%s", execOutput)
 		}
 		log.Printf("%s %s enabled\n", constants.Name, name)
 	}
+	return nil
 }
 
 func CheckEnabled(name, wiki string, instance config.Installation, orch orchestrators.Orchestrator, constants Item) (string, error) {
@@ -104,7 +106,7 @@ func CheckEnabled(name, wiki string, instance config.Installation, orch orchestr
 	return name, nil
 }
 
-func Disable(name, wiki string, instance config.Installation, orch orchestrators.Orchestrator, constants Item) {
+func Disable(name, wiki string, instance config.Installation, orch orchestrators.Orchestrator, constants Item) error {
 	if wiki == "" {
 		log.Println("You didn't specify a wiki. The common settings will disable the extension or skin in the corresponding Canasta instance.")
 	}
@@ -120,7 +122,8 @@ func Disable(name, wiki string, instance config.Installation, orch orchestrators
 	command := fmt.Sprintf(`rm %s`, filePath)
 	output, err := orch.ExecWithError(instance.Path, "web", command)
 	if err != nil {
-		log.Fatal(fmt.Errorf("%s", output))
+		return fmt.Errorf("%s", output)
 	}
 	log.Printf("%s %s disabled\n", constants.Name, name)
+	return nil
 }

--- a/internal/orchestrators/compose.go
+++ b/internal/orchestrators/compose.go
@@ -23,7 +23,8 @@ type ComposeOrchestrator struct{}
 
 // getCompose returns the configured compose orchestrator path.
 func (c *ComposeOrchestrator) getCompose() config.Orchestrator {
-	return config.GetOrchestrator("compose")
+	orch, _ := config.GetOrchestrator("compose")
+	return orch
 }
 
 func (c *ComposeOrchestrator) CheckDependencies() error {
@@ -314,7 +315,7 @@ func (c *ComposeOrchestrator) CopyOverrideFile(installPath, sourceFilename, work
 		logging.Print(fmt.Sprintf("Copying %s to %s\n", sourceFilename, overrideFilename))
 		err, output := execute.Run("", "cp", sourceFilename, overrideFilename)
 		if err != nil {
-			logging.Fatal(fmt.Errorf("%s", output))
+			return fmt.Errorf("%s", output)
 		}
 	}
 	return nil

--- a/internal/orchestrators/orchestrator.go
+++ b/internal/orchestrators/orchestrator.go
@@ -47,13 +47,13 @@ func DeleteConfig(installPath string) (string, error) {
 	return output, err
 }
 
-// Exec runs a command in a service container and fatals on error.
-func Exec(orch Orchestrator, installPath, service, command string) string {
+// Exec runs a command in a service container and returns an error on failure.
+func Exec(orch Orchestrator, installPath, service, command string) (string, error) {
 	output, err := orch.ExecWithError(installPath, service, command)
 	if err != nil {
-		logging.Fatal(fmt.Errorf("%s", output))
+		return output, fmt.Errorf("%s", output)
 	}
-	return output
+	return output, nil
 }
 
 // StopAndStart stops and then starts the containers for an installation.

--- a/internal/orchestrators/registry.go
+++ b/internal/orchestrators/registry.go
@@ -2,18 +2,15 @@ package orchestrators
 
 import (
 	"fmt"
-
-	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 )
 
 // New creates an Orchestrator implementation for the given orchestrator ID.
 // This is the single point where orchestrator IDs are mapped to implementations.
-func New(orchestratorID string) Orchestrator {
+func New(orchestratorID string) (Orchestrator, error) {
 	switch orchestratorID {
 	case "compose", "docker-compose":
-		return &ComposeOrchestrator{}
+		return &ComposeOrchestrator{}, nil
 	default:
-		logging.Fatal(fmt.Errorf("orchestrator: %s is not available", orchestratorID))
-		return nil // unreachable, but satisfies compiler
+		return nil, fmt.Errorf("orchestrator: %s is not available", orchestratorID)
 	}
 }


### PR DESCRIPTION
Closes #225

## Summary

- Remove 18 `log.Fatal`/`logging.Fatal` calls from internal packages that previously terminated the process on errors, preventing testability
- Update function signatures to return errors instead of calling Fatal
- Update all ~30 callers in `cmd/` packages to propagate errors through Cobra's `RunE` pattern
- Convert several restic and maintenance commands from `Run` to `RunE` handlers

## Key signature changes

| Function | Before | After |
|----------|--------|-------|
| `config.Exists()` | `bool` | `(bool, error)` |
| `config.GetAll()` | `map[string]Installation` | `(map[string]Installation, error)` |
| `config.ListAll()` | `(none)` | `error` |
| `config.GetConfigDir()` | `string` | `(string, error)` |
| `config.GetOrchestrator()` | `Orchestrator` | `(Orchestrator, error)` |
| `orchestrators.New()` | `Orchestrator` | `(Orchestrator, error)` |
| `orchestrators.Exec()` | `string` | `(string, error)` |
| `canasta.GetEnvVariable()` | `map[string]string` | `(map[string]string, error)` |
| `extensionsskins.List/Enable/Disable` | `(none)` | `error` |

This is phase 1 of a testability refactoring effort.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` is clean
- [ ] `make lint` passes
- [ ] Manual smoke test: `canasta create`, `canasta list`, `canasta delete`