### PR TITLE
Replace config.init() with lazy initialization

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/user"
-	"path"
+	"path/filepath"
 	"sync"
 	"syscall"
 	"text/tabwriter"
@@ -55,7 +55,7 @@ func ensureInitialized() error {
 			}
 		}
 		directory = dir
-		confFile = path.Join(directory, "conf.json")
+		confFile = filepath.Join(directory, "conf.json")
 
 		// Check for the conf.json file
 		_, err = os.Stat(confFile)
@@ -66,12 +66,14 @@ func ensureInitialized() error {
 				return
 			}
 		} else if err != nil {
-			initErr = fmt.Errorf("error statting %s (%s)", confFile, err)
+			initErr = fmt.Errorf("error statting %s (%w)", confFile, err)
 			return
 		}
 
 		// Check if the file is writable/has enough permissions
-		if err = syscall.Access(confFile, syscall.O_RDWR); err != nil {
+		// 0x2 is W_OK (write permission check). We use the raw value because
+	// syscall.W_OK is not defined on all platforms (e.g., macOS).
+	if err = syscall.Access(confFile, 0x2); err != nil {
 			initErr = err
 			return
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -326,7 +326,7 @@ func GetConfigDir() (string, error) {
 			return "", err
 		}
 	} else if err != nil {
-		return "", fmt.Errorf("error statting %s (%s)", dir, err)
+		return "", fmt.Errorf("error statting %s (%w)", dir, err)
 	} else {
 		mode := fi.Mode()
 		if !mode.IsDir() {


### PR DESCRIPTION
Closes #227

## Summary

- Delete `init()` that ran filesystem I/O at package import time, blocking testability
- Add `ensureInitialized()` using `sync.Once` for lazy initialization on first public function call
- Add `ResetForTesting(dir)` to redirect config storage to a temporary directory in tests
- Add `ensureInitialized()` call to all 12 public functions in the config package

## Details

The `configDirOverride` variable lets `ensureInitialized()` skip `GetConfigDir()` when a test override is active, so tests don't hit the real system config path.

Depends on #226.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` is clean
- [ ] Manual smoke test: `canasta list`, `canasta create`