### PR TITLE
Make execute.Run() mockable for testing

### DIFF
--- a/internal/execute/execute.go
+++ b/internal/execute/execute.go
@@ -23,7 +23,17 @@ func (w *writerWithPrint) String() string {
 	return w.buf.String()
 }
 
-func Run(path, command string, cmdArgs ...string) (error, string) {
+// RunFunc is the signature for the command execution function.
+type RunFunc func(path, command string, cmdArgs ...string) (error, string)
+
+// Run is the package-level function variable for executing commands.
+// Tests can replace this with a mock implementation.
+var Run RunFunc = defaultRun
+
+// ResetForTesting restores Run to the default implementation.
+func ResetForTesting() { Run = defaultRun }
+
+func defaultRun(path, command string, cmdArgs ...string) (error, string) {
 	outWriter := &writerWithPrint{}
 	errWriter := &writerWithPrint{}
 


### PR DESCRIPTION
Closes #229

## Summary

- Convert `execute.Run` from a fixed function to a package-level variable of type `RunFunc`
- No caller changes needed — `execute.Run(...)` works identically
- Tests can replace `execute.Run` with a mock and call `execute.ResetForTesting()` to restore

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` is clean
- [ ] Manual smoke test: any command that calls docker compose

Depends on #228.