### PR TITLE
Add missing files to restic backup and restore

### DIFF
--- a/cmd/backup/restore.go
+++ b/cmd/backup/restore.go
@@ -22,8 +22,8 @@ func restoreCmdCreate() *cobra.Command {
 		Short: "Restore a backup",
 		Long: `Restore a Canasta installation from a backup snapshot. By default, a safety
 snapshot is taken before restoring. The restore replaces configuration files,
-extensions, images, skins, and the database with the contents of the
-specified snapshot.`,
+extensions, images, skins, public_assets, .env, docker-compose.override.yml,
+my.cnf, and the database with the contents of the specified snapshot.`,
 		Example: `  # Restore a snapshot by ID
   canasta backup restore -i myinstance -s abc123
 
@@ -61,11 +61,14 @@ func restoreSnapshot(snapshotId string, skipBeforeSnapshot bool) error {
 	}
 
 	logging.Print("Copying files from backup volume...")
-	dirs := make(map[string]string)
-	for _, dir := range []string{"config", "extensions", "images", "skins"} {
-		dirs["/currentsnapshot/"+dir] = filepath.Join(instance.Path, dir)
+	paths := make(map[string]string)
+	for _, dir := range []string{"config", "extensions", "images", "skins", "public_assets"} {
+		paths["/currentsnapshot/"+dir] = filepath.Join(instance.Path, dir)
 	}
-	if err := orch.RestoreFromBackupVolume(instance.Path, dirs); err != nil {
+	for _, file := range []string{".env", "docker-compose.override.yml", "my.cnf"} {
+		paths["/currentsnapshot/"+file] = filepath.Join(instance.Path, file)
+	}
+	if err := orch.RestoreFromBackupVolume(instance.Path, paths); err != nil {
 		return err
 	}
 	logging.Print("Copied files...")


### PR DESCRIPTION
## Summary

- Adds `public_assets/` to the directories backed up and restored by `restic take-snapshot` and `restic restore`
- Copies `.env`, `docker-compose.override.yml`, and `my.cnf` during backup (if present) and restores them (if present in snapshot)
- Updates `Long` descriptions for both commands

Fixes #233

## Test plan

- [ ] Run `canasta restic take-snapshot` and verify `currentsnapshot/` contains `public_assets/`, `.env`, `docker-compose.override.yml`, and `my.cnf`
- [ ] Run `canasta restic restore` and verify all files are restored to the installation directory
- [ ] Verify optional files (e.g. missing `my.cnf`) are silently skipped without errors