### PR TITLE
Fix all hadolint warnings in Dockerfile.xdebug

### DIFF
--- a/internal/devmode/files/Dockerfile.xdebug
+++ b/internal/devmode/files/Dockerfile.xdebug
@@ -3,7 +3,8 @@ ARG BASE_IMAGE=ghcr.io/canastawiki/canasta:latest
 # --- Stage 1: build xdebug.so ---
 FROM ${BASE_IMAGE} AS builder
 
-# hadolint ignore=DL3008 -- pinning system package versions is impractical on Debian
+# Pinning system package versions is impractical on Debian
+# hadolint ignore=DL3008
 RUN PHP_VERSION=$(php -r 'echo PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION;') \
  && apt-get update && apt-get install -y --no-install-recommends \
     "php${PHP_VERSION}-dev" autoconf build-essential php-pear \

--- a/internal/devmode/files/Dockerfile.xdebug
+++ b/internal/devmode/files/Dockerfile.xdebug
@@ -3,7 +3,7 @@ ARG BASE_IMAGE=ghcr.io/canastawiki/canasta:latest
 # --- Stage 1: build xdebug.so ---
 FROM ${BASE_IMAGE} AS builder
 
-# hadolint ignore=DL3008
+# hadolint ignore=DL3008 -- pinning system package versions is impractical on Debian
 RUN PHP_VERSION=$(php -r 'echo PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION;') \
  && apt-get update && apt-get install -y --no-install-recommends \
     "php${PHP_VERSION}-dev" autoconf build-essential php-pear \

--- a/internal/devmode/files/Dockerfile.xdebug
+++ b/internal/devmode/files/Dockerfile.xdebug
@@ -3,9 +3,10 @@ ARG BASE_IMAGE=ghcr.io/canastawiki/canasta:latest
 # --- Stage 1: build xdebug.so ---
 FROM ${BASE_IMAGE} AS builder
 
+# hadolint ignore=DL3008
 RUN PHP_VERSION=$(php -r 'echo PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION;') \
- && apt-get update && apt-get install -y \
-    php${PHP_VERSION}-dev autoconf build-essential php-pear \
+ && apt-get update && apt-get install -y --no-install-recommends \
+    "php${PHP_VERSION}-dev" autoconf build-essential php-pear \
  && pecl install xdebug-3.2.1 \
  && mkdir -p /xdebug-out \
  && cp "$(php -r 'echo ini_get("extension_dir");')/xdebug.so" /xdebug-out/
@@ -21,10 +22,10 @@ COPY --from=builder /xdebug-out/xdebug.so /tmp/xdebug.so
 RUN EXT_DIR="$(php -r 'echo ini_get("extension_dir");')" \
  && PHP_VERSION=$(php -r 'echo PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION;') \
  && mv /tmp/xdebug.so "$EXT_DIR/xdebug.so" \
- && mkdir -p /etc/php/${PHP_VERSION}/cli/conf.d \
-             /etc/php/${PHP_VERSION}/apache2/conf.d \
-             /etc/php/${PHP_VERSION}/fpm/conf.d \
- && echo "zend_extension=$EXT_DIR/xdebug.so" > /etc/php/${PHP_VERSION}/cli/conf.d/20-xdebug.ini \
- && echo "zend_extension=$EXT_DIR/xdebug.so" > /etc/php/${PHP_VERSION}/apache2/conf.d/20-xdebug.ini \
- && echo "zend_extension=$EXT_DIR/xdebug.so" > /etc/php/${PHP_VERSION}/fpm/conf.d/20-xdebug.ini \
- && ln -s /etc/php/${PHP_VERSION}/fpm/conf.d /etc/php/fpm-conf.d
+ && mkdir -p "/etc/php/${PHP_VERSION}/cli/conf.d" \
+             "/etc/php/${PHP_VERSION}/apache2/conf.d" \
+             "/etc/php/${PHP_VERSION}/fpm/conf.d" \
+ && echo "zend_extension=$EXT_DIR/xdebug.so" > "/etc/php/${PHP_VERSION}/cli/conf.d/20-xdebug.ini" \
+ && echo "zend_extension=$EXT_DIR/xdebug.so" > "/etc/php/${PHP_VERSION}/apache2/conf.d/20-xdebug.ini" \
+ && echo "zend_extension=$EXT_DIR/xdebug.so" > "/etc/php/${PHP_VERSION}/fpm/conf.d/20-xdebug.ini" \
+ && ln -s "/etc/php/${PHP_VERSION}/fpm/conf.d" /etc/php/fpm-conf.d


### PR DESCRIPTION
## Summary
- Add `--no-install-recommends` to apt-get install
- Double-quote variable interpolations in paths
- Suppress DL3008 (pin versions) — PHP version is determined dynamically at build time

Closes #242

## Test plan
- [x] `hadolint internal/devmode/files/Dockerfile.xdebug` produces no output
- [x] Dev mode build works: `canasta create -i test --dev`