### PR TITLE
Add Cobra-level tests for maintenance commands

### DIFF
--- a/cmd/maintenanceUpdate/maintenance_test.go
+++ b/cmd/maintenanceUpdate/maintenance_test.go
@@ -1,0 +1,134 @@
+package maintenance
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// findSubcommand returns the named subcommand, or nil if not found.
+func findSubcommand(parent interface{ Commands() []*cobra.Command }, name string) *cobra.Command {
+	for _, c := range parent.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	return nil
+}
+
+func TestMaintenanceSubcommands(t *testing.T) {
+	cmd := NewCmdCreate()
+
+	expected := []string{"update", "script"}
+	for _, name := range expected {
+		if findSubcommand(cmd, name) == nil {
+			t.Errorf("expected subcommand %q not found", name)
+		}
+	}
+}
+
+func TestMaintenancePersistentFlags(t *testing.T) {
+	cmd := NewCmdCreate()
+
+	flags := []struct {
+		name      string
+		shorthand string
+	}{
+		{"id", "i"},
+		{"wiki", "w"},
+		{"all", ""},
+	}
+
+	for _, f := range flags {
+		pf := cmd.PersistentFlags().Lookup(f.name)
+		if pf == nil {
+			t.Errorf("persistent flag --%s not found", f.name)
+			continue
+		}
+		if f.shorthand != "" && pf.Shorthand != f.shorthand {
+			t.Errorf("flag --%s shorthand = %q, want %q", f.name, pf.Shorthand, f.shorthand)
+		}
+	}
+}
+
+func TestUpdateFlags(t *testing.T) {
+	cmd := NewCmdCreate()
+	updateCmd := findSubcommand(cmd, "update")
+	if updateCmd == nil {
+		t.Fatal("update subcommand not found")
+	}
+
+	for _, name := range []string{"skip-jobs", "skip-smw"} {
+		if updateCmd.Flags().Lookup(name) == nil {
+			t.Errorf("flag --%s not found on update subcommand", name)
+		}
+	}
+}
+
+func TestScriptRequiresArg(t *testing.T) {
+	cmd := NewCmdCreate()
+	scriptCmd := findSubcommand(cmd, "script")
+	if scriptCmd == nil {
+		t.Fatal("script subcommand not found")
+	}
+
+	// script requires exactly 1 arg — override PreRunE/RunE to isolate arg validation
+	scriptCmd.PreRunE = nil
+	scriptCmd.RunE = func(cmd *cobra.Command, args []string) error { return nil }
+
+	cmd.SetArgs([]string{"script"})
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected error when script is called without arguments")
+	}
+}
+
+func TestUpdateFlagParsing(t *testing.T) {
+	cmd := NewCmdCreate()
+	updateCmd := findSubcommand(cmd, "update")
+	if updateCmd == nil {
+		t.Fatal("update subcommand not found")
+	}
+
+	// Reset package-level variables
+	skipJobs = false
+	skipSMW = false
+
+	if err := updateCmd.ParseFlags([]string{"--skip-jobs", "--skip-smw"}); err != nil {
+		t.Fatalf("ParseFlags error: %v", err)
+	}
+
+	if !skipJobs {
+		t.Error("--skip-jobs should set skipJobs to true")
+	}
+	if !skipSMW {
+		t.Error("--skip-smw should set skipSMW to true")
+	}
+}
+
+func TestWikiAndAllConflict(t *testing.T) {
+	cmd := NewCmdCreate()
+	updateCmd := findSubcommand(cmd, "update")
+	if updateCmd == nil {
+		t.Fatal("update subcommand not found")
+	}
+
+	// Override PreRunE to skip CheckCanastaId
+	updateCmd.PreRunE = nil
+
+	// Set wiki and all flags, then execute
+	wiki = "docs"
+	all = true
+	defer func() {
+		wiki = ""
+		all = false
+	}()
+
+	cmd.SetArgs([]string{"update", "--wiki=docs", "--all"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --wiki and --all are both set")
+	}
+	if err.Error() != "cannot use --wiki with --all" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add command-level tests for the `canasta maintenance` command group
- Tests verify Cobra wiring without requiring Docker or real installations
- Covers: subcommand registration, flag registration/parsing, argument validation, flag conflict detection

Closes #246

## Test cases
| Test | Verifies |
|---|---|
| `TestMaintenanceSubcommands` | `update` and `script` subcommands are registered |
| `TestMaintenancePersistentFlags` | `--id`, `--wiki`, `--all` exist as persistent flags |
| `TestUpdateFlags` | `--skip-jobs`, `--skip-smw` exist on `update` |
| `TestScriptRequiresArg` | `script` requires exactly 1 argument |
| `TestUpdateFlagParsing` | `--skip-jobs` and `--skip-smw` bind to correct variables |
| `TestWikiAndAllConflict` | `--wiki` + `--all` together returns error |

## Test plan
- [x] `go test -v ./cmd/maintenanceUpdate/` — all 6 tests pass
- [x] `golangci-lint run ./...` — clean
- [x] `go test ./...` — full suite passes