### PR TITLE
Add canasta maintenance smw-rebuild command

### DIFF
--- a/cmd/maintenanceUpdate/maintenance.go
+++ b/cmd/maintenanceUpdate/maintenance.go
@@ -32,6 +32,7 @@ runJobs.php, and SMW rebuildData.php) or execute arbitrary maintenance scripts.`
 
 	maintenanceCmd.AddCommand(updateCmdCreate())
 	maintenanceCmd.AddCommand(scriptCmdCreate())
+	maintenanceCmd.AddCommand(smwRebuildCmdCreate())
 
 	maintenanceCmd.PersistentFlags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
 	maintenanceCmd.PersistentFlags().StringVarP(&wiki, "wiki", "w", "", "Wiki ID to run maintenance on")

--- a/cmd/maintenanceUpdate/smwRebuild.go
+++ b/cmd/maintenanceUpdate/smwRebuild.go
@@ -1,0 +1,126 @@
+package maintenance
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
+	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
+)
+
+func smwRebuildCmdCreate() *cobra.Command {
+
+	smwRebuildCmd := &cobra.Command{
+		Use:   "smw-rebuild [-- [rebuildData.php options]]",
+		Short: "Run Semantic MediaWiki rebuildData.php",
+		Long: `Run Semantic MediaWiki's rebuildData.php maintenance script to populate
+or rebuild the SMW store. Any arguments after -- are passed directly to
+rebuildData.php (e.g., --startidfile, -s, -e, --skip-properties).
+
+In a wiki farm, use --wiki to target a specific wiki, or --all to run
+the rebuild on every wiki. If there is only one wiki, it is selected
+automatically.`,
+		Example: `  # Basic rebuild
+  canasta maintenance smw-rebuild -i myinstance
+
+  # Rebuild specific wiki in a farm
+  canasta maintenance smw-rebuild -i myinstance --wiki=docs
+
+  # Rebuild all wikis
+  canasta maintenance smw-rebuild -i myinstance --all
+
+  # Pass options to rebuildData.php
+  canasta maintenance smw-rebuild -i myinstance -- --startidfile /tmp/progress
+
+  # Rebuild a specific page range
+  canasta maintenance smw-rebuild -i myinstance -- -s 1000 -e 2000`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			instance, err = canasta.CheckCanastaId(instance)
+			return err
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if wiki != "" && all {
+				return fmt.Errorf("cannot use --wiki with --all")
+			}
+
+			extraArgs := strings.Join(args, " ")
+
+			if all {
+				wikiIDs, err := getWikiIDs(instance)
+				if err != nil {
+					return err
+				}
+				for _, id := range wikiIDs {
+					if err := runSMWRebuild(instance, id, extraArgs); err != nil {
+						return err
+					}
+				}
+			} else if wiki != "" {
+				if err := runSMWRebuild(instance, wiki, extraArgs); err != nil {
+					return err
+				}
+			} else {
+				wikiIDs, err := getWikiIDs(instance)
+				if err != nil {
+					return err
+				}
+				if len(wikiIDs) == 1 {
+					if err := runSMWRebuild(instance, wikiIDs[0], extraArgs); err != nil {
+						return err
+					}
+				} else {
+					return fmt.Errorf("multiple wikis found; use --wiki=<id> or --all")
+				}
+			}
+			return nil
+		},
+	}
+
+	return smwRebuildCmd
+}
+
+func runSMWRebuild(instance config.Installation, wikiID string, extraArgs string) error {
+	return runSMWRebuildWith(nil, instance, wikiID, extraArgs)
+}
+
+func runSMWRebuildWith(orch orchestrators.Orchestrator, instance config.Installation, wikiID string, extraArgs string) error {
+	if orch == nil {
+		var err error
+		orch, err = orchestrators.New(instance.Orchestrator)
+		if err != nil {
+			return err
+		}
+	}
+
+	const rebuildScript = "extensions/SemanticMediaWiki/maintenance/rebuildData.php"
+
+	// Check that SMW is installed
+	checkCmd := fmt.Sprintf("test -f %s && echo exists", rebuildScript)
+	checkOutput, _ := orch.ExecWithError(instance.Path, "web", checkCmd)
+	if !strings.Contains(checkOutput, "exists") {
+		return fmt.Errorf("Semantic MediaWiki is not installed")
+	}
+
+	wikiFlag := ""
+	wikiMsg := ""
+	if wikiID != "" {
+		wikiFlag = " --wiki=" + wikiID
+		wikiMsg = " for wiki '" + wikiID + "'"
+	}
+
+	cmd := "php " + rebuildScript + wikiFlag
+	if extraArgs != "" {
+		cmd += " " + extraArgs
+	}
+
+	fmt.Printf("Running rebuildData.php%s...\n", wikiMsg)
+	if err := orch.ExecStreaming(instance.Path, "web", cmd); err != nil {
+		return fmt.Errorf("rebuildData.php failed%s: %v", wikiMsg, err)
+	}
+
+	fmt.Printf("Completed rebuildData.php%s\n", wikiMsg)
+	return nil
+}

--- a/cmd/maintenanceUpdate/smwRebuild_test.go
+++ b/cmd/maintenanceUpdate/smwRebuild_test.go
@@ -1,0 +1,126 @@
+package maintenance
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
+)
+
+// smwMockOrchestrator records calls and returns configurable results.
+type smwMockOrchestrator struct {
+	calls          []string
+	execOutput     string
+	execErr        error
+	streamingErr   error
+	streamingCalls []string
+}
+
+func (m *smwMockOrchestrator) CheckDependencies() error { return nil }
+func (m *smwMockOrchestrator) GetRepoLink() string      { return "" }
+func (m *smwMockOrchestrator) Start(inst config.Installation) error {
+	return nil
+}
+func (m *smwMockOrchestrator) Stop(inst config.Installation) error {
+	return nil
+}
+func (m *smwMockOrchestrator) Update(installPath string) (*orchestrators.UpdateReport, error) {
+	return nil, nil
+}
+func (m *smwMockOrchestrator) Destroy(installPath string) (string, error) {
+	return "", nil
+}
+func (m *smwMockOrchestrator) ExecWithError(installPath, service, command string) (string, error) {
+	m.calls = append(m.calls, fmt.Sprintf("ExecWithError:%s:%s", service, command))
+	return m.execOutput, m.execErr
+}
+func (m *smwMockOrchestrator) ExecStreaming(installPath, service, command string) error {
+	m.streamingCalls = append(m.streamingCalls, command)
+	return m.streamingErr
+}
+func (m *smwMockOrchestrator) CheckRunningStatus(inst config.Installation) error {
+	return nil
+}
+func (m *smwMockOrchestrator) CopyFrom(installPath, service, containerPath, hostPath string) error {
+	return nil
+}
+func (m *smwMockOrchestrator) CopyTo(installPath, service, hostPath, containerPath string) error {
+	return nil
+}
+func (m *smwMockOrchestrator) StopAndStart(inst config.Installation) error {
+	return nil
+}
+
+func TestSMWRebuildNotInstalled(t *testing.T) {
+	mock := &smwMockOrchestrator{execOutput: ""}
+	inst := config.Installation{Path: "/test"}
+	err := runSMWRebuildWith(mock, inst, "mywiki", "")
+	if err == nil {
+		t.Fatal("expected error when SMW is not installed")
+	}
+	if !strings.Contains(err.Error(), "not installed") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSMWRebuildBasic(t *testing.T) {
+	mock := &smwMockOrchestrator{execOutput: "exists"}
+	inst := config.Installation{Path: "/test"}
+	err := runSMWRebuildWith(mock, inst, "mywiki", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mock.streamingCalls) != 1 {
+		t.Fatalf("expected 1 streaming call, got %d", len(mock.streamingCalls))
+	}
+	cmd := mock.streamingCalls[0]
+	if !strings.Contains(cmd, "rebuildData.php") {
+		t.Errorf("expected rebuildData.php in command, got: %s", cmd)
+	}
+	if !strings.Contains(cmd, "--wiki=mywiki") {
+		t.Errorf("expected --wiki=mywiki in command, got: %s", cmd)
+	}
+}
+
+func TestSMWRebuildNoWiki(t *testing.T) {
+	mock := &smwMockOrchestrator{execOutput: "exists"}
+	inst := config.Installation{Path: "/test"}
+	err := runSMWRebuildWith(mock, inst, "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cmd := mock.streamingCalls[0]
+	if strings.Contains(cmd, "--wiki") {
+		t.Errorf("expected no --wiki flag, got: %s", cmd)
+	}
+}
+
+func TestSMWRebuildExtraArgs(t *testing.T) {
+	mock := &smwMockOrchestrator{execOutput: "exists"}
+	inst := config.Installation{Path: "/test"}
+	err := runSMWRebuildWith(mock, inst, "mywiki", "--startidfile /tmp/progress")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cmd := mock.streamingCalls[0]
+	if !strings.Contains(cmd, "--startidfile /tmp/progress") {
+		t.Errorf("expected extra args in command, got: %s", cmd)
+	}
+}
+
+func TestSMWRebuildStreamingError(t *testing.T) {
+	mock := &smwMockOrchestrator{
+		execOutput:   "exists",
+		streamingErr: fmt.Errorf("container error"),
+	}
+	inst := config.Installation{Path: "/test"}
+	err := runSMWRebuildWith(mock, inst, "mywiki", "")
+	if err == nil {
+		t.Fatal("expected error when streaming fails")
+	}
+	if !strings.Contains(err.Error(), "rebuildData.php failed") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/docs/guide/extensions-and-skins.md
+++ b/docs/guide/extensions-and-skins.md
@@ -192,6 +192,22 @@ When the container starts, Canasta detects if `config/composer.local.json` or an
 
 On the first startup after enabling SMW, Canasta automatically runs `setupStore.php` to initialize the SMW database tables. This creates a `smw.json` configuration file in `config/smw/` on the persistent volume, so the setup only runs once.
 
+### Rebuilding SMW data
+
+After initial setup, you need to run `rebuildData.php` to populate the SMW store. Canasta does not run this automatically because it can take a long time on large wikis. Use the CLI command:
+
+```bash
+canasta maintenance smw-rebuild -i myinstance
+```
+
+For large wikis, pass options to `rebuildData.php` after `--` to run in segments:
+
+```bash
+canasta maintenance smw-rebuild -i myinstance -- --startidfile /tmp/smw-progress
+```
+
+See [Rebuilding Semantic MediaWiki data](general-concepts.md#rebuilding-semantic-mediawiki-data) for more examples.
+
 ### Notes
 
 - The `enableSemantics()` function is provided by SMW's composer autoloader. Canasta's unified autoloader ensures it is available without any additional steps.

--- a/docs/guide/general-concepts.md
+++ b/docs/guide/general-concepts.md
@@ -12,6 +12,7 @@ This page covers foundational concepts that apply to all Canasta installations, 
 - [Maintenance scripts](#maintenance-scripts)
   - [Automatic maintenance](#automatic-maintenance)
   - [Running the update sequence](#running-the-update-sequence)
+  - [Rebuilding Semantic MediaWiki data](#rebuilding-semantic-mediawiki-data)
   - [Running scripts manually](#running-scripts-manually)
 - [Deploying behind a reverse proxy](#deploying-behind-a-reverse-proxy)
 - [Running on non-standard ports](#running-on-non-standard-ports)
@@ -318,6 +319,34 @@ Use `--skip-jobs` and `--skip-smw` to skip individual steps:
 ```bash
 # Run only update.php
 canasta maintenance update -i myinstance --skip-jobs --skip-smw
+```
+
+### Rebuilding Semantic MediaWiki data
+
+If you use [Semantic MediaWiki](extensions-and-skins.md#semantic-mediawiki), you may need to rebuild the SMW store after initial setup, a major upgrade, or data import. Use `canasta maintenance smw-rebuild`:
+
+```bash
+canasta maintenance smw-rebuild -i myinstance
+```
+
+In a wiki farm, use `--wiki` to target a specific wiki or `--all` to rebuild all wikis:
+
+```bash
+canasta maintenance smw-rebuild -i myinstance --wiki=docs
+canasta maintenance smw-rebuild -i myinstance --all
+```
+
+For large wikis, you can pass options directly to `rebuildData.php` after `--` to run the rebuild in segments:
+
+```bash
+# Resume from where a previous run left off
+canasta maintenance smw-rebuild -i myinstance -- --startidfile /tmp/smw-progress
+
+# Rebuild a specific page range
+canasta maintenance smw-rebuild -i myinstance -- -s 1000 -e 2000
+
+# Skip property rebuilding
+canasta maintenance smw-rebuild -i myinstance -- --skip-properties
 ```
 
 ### Running scripts manually


### PR DESCRIPTION
## Summary

- Adds `canasta maintenance smw-rebuild` subcommand for running SMW's `rebuildData.php`
- Pass-through arguments after `--` are forwarded to `rebuildData.php`, enabling segmented rebuilds on large wikis
- Checks that SMW is installed before running
- Supports `--wiki` and `--all` for wiki farms

## Context

CanastaBase previously ran `rebuildData.php` automatically during container startup, which could block for hours on large wikis (CanastaWiki/CanastaBase#91, CanastaWiki/CanastaBase#92). This command gives users explicit control over when and how to run the rebuild.

## Usage

```bash
# Basic rebuild
canasta maintenance smw-rebuild -i myinstance

# Rebuild specific wiki in a farm
canasta maintenance smw-rebuild -i myinstance --wiki=docs

# Rebuild all wikis
canasta maintenance smw-rebuild -i myinstance --all

# Pass options to rebuildData.php
canasta maintenance smw-rebuild -i myinstance -- --startidfile /tmp/progress

# Rebuild a specific page range
canasta maintenance smw-rebuild -i myinstance -- -s 1000 -e 2000
```

Fixes #248

## Test plan

- [x] Unit tests pass: `go test ./cmd/maintenanceUpdate/`
- [x] Linter passes: `golangci-lint run ./...`
- [ ] Manual test: run `canasta maintenance smw-rebuild` against an installation with SMW
- [ ] Manual test: verify error message when SMW is not installed
- [ ] Manual test: verify `--` pass-through arguments work