### PR TITLE
Add generic canasta maintenance extension subcommand

### DIFF
--- a/cmd/maintenanceUpdate/extension.go
+++ b/cmd/maintenanceUpdate/extension.go
@@ -1,0 +1,247 @@
+package maintenance
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
+	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
+)
+
+func extensionCmdCreate() *cobra.Command {
+
+	extensionCmd := &cobra.Command{
+		Use:   `extension [extension-name] ["script.php [args]"]`,
+		Short: "Run extension maintenance scripts",
+		Long: `Run maintenance scripts provided by MediaWiki extensions.
+
+With no arguments, lists all extensions that have a maintenance/ directory.
+With one argument (extension name), lists available maintenance scripts for
+that extension. With two arguments (extension name and a quoted script string),
+runs the specified script. Any arguments to the script should be included in
+the quoted string.
+
+In a wiki farm, use --wiki to target a specific wiki, or --all to run
+on every wiki.`,
+		Example: `  # List extensions with maintenance scripts
+  canasta maintenance extension -i myinstance
+
+  # List maintenance scripts for an extension
+  canasta maintenance extension SemanticMediaWiki -i myinstance
+
+  # Run an extension maintenance script
+  canasta maintenance extension SemanticMediaWiki "rebuildData.php" -i myinstance
+
+  # Run with script arguments (in quotes)
+  canasta maintenance extension SemanticMediaWiki "rebuildData.php -s 1000 -e 2000" -i myinstance
+
+  # Run for a specific wiki in a farm
+  canasta maintenance extension CirrusSearch "UpdateSearchIndexConfig.php" -i myinstance --wiki=docs
+
+  # Run for all wikis
+  canasta maintenance extension SemanticMediaWiki "rebuildData.php" -i myinstance --all`,
+		Args: cobra.RangeArgs(0, 2),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			instance, err = canasta.CheckCanastaId(instance)
+			return err
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			switch len(args) {
+			case 0:
+				return listExtensionsWithMaintenance(instance)
+			case 1:
+				return listExtensionScripts(instance, args[0])
+			case 2:
+				if wiki != "" && all {
+					return fmt.Errorf("cannot use --wiki with --all")
+				}
+				if all {
+					wikiIDs, err := getWikiIDs(instance)
+					if err != nil {
+						return err
+					}
+					for _, id := range wikiIDs {
+						if err := runExtensionScript(instance, args[0], args[1], id); err != nil {
+							return err
+						}
+					}
+					return nil
+				}
+				return runExtensionScript(instance, args[0], args[1], wiki)
+			}
+			return nil
+		},
+	}
+
+	return extensionCmd
+}
+
+func listExtensionsWithMaintenance(inst config.Installation) error {
+	return listExtensionsWithMaintenanceWith(nil, inst)
+}
+
+func listExtensionsWithMaintenanceWith(orch orchestrators.Orchestrator, inst config.Installation) error {
+	if orch == nil {
+		var err error
+		orch, err = orchestrators.New(inst.Orchestrator)
+		if err != nil {
+			return err
+		}
+	}
+
+	cmd := `find extensions/ canasta-extensions/ -maxdepth 2 -name maintenance -type d 2>/dev/null`
+	output, _ := orch.ExecWithError(inst.Path, "web", cmd)
+
+	names := parseExtensionNames(output)
+	if len(names) == 0 {
+		fmt.Println("No extensions with maintenance scripts found.")
+		return nil
+	}
+
+	fmt.Println("Extensions with maintenance scripts:")
+	for _, name := range names {
+		fmt.Printf("  %s\n", name)
+	}
+	return nil
+}
+
+func listExtensionScripts(inst config.Installation, extName string) error {
+	return listExtensionScriptsWith(nil, inst, extName)
+}
+
+func listExtensionScriptsWith(orch orchestrators.Orchestrator, inst config.Installation, extName string) error {
+	if orch == nil {
+		var err error
+		orch, err = orchestrators.New(inst.Orchestrator)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Check that the extension has a maintenance directory
+	checkCmd := fmt.Sprintf(
+		`test -d extensions/%s/maintenance && echo exists || test -d canasta-extensions/%s/maintenance && echo exists`,
+		extName, extName)
+	checkOutput, _ := orch.ExecWithError(inst.Path, "web", checkCmd)
+	if !strings.Contains(checkOutput, "exists") {
+		return fmt.Errorf("extension %q has no maintenance directory", extName)
+	}
+
+	cmd := fmt.Sprintf(
+		`find extensions/%s/maintenance/ canasta-extensions/%s/maintenance/ -maxdepth 1 -name '*.php' -type f 2>/dev/null`,
+		extName, extName)
+	output, _ := orch.ExecWithError(inst.Path, "web", cmd)
+
+	scripts := parseScriptNames(output)
+	if len(scripts) == 0 {
+		fmt.Printf("No maintenance scripts found for %s.\n", extName)
+		return nil
+	}
+
+	fmt.Printf("Maintenance scripts for %s:\n", extName)
+	for _, script := range scripts {
+		fmt.Printf("  %s\n", script)
+	}
+	return nil
+}
+
+func runExtensionScript(inst config.Installation, extName, scriptStr, wikiID string) error {
+	return runExtensionScriptWith(nil, inst, extName, scriptStr, wikiID)
+}
+
+func runExtensionScriptWith(orch orchestrators.Orchestrator, inst config.Installation, extName, scriptStr, wikiID string) error {
+	if orch == nil {
+		var err error
+		orch, err = orchestrators.New(inst.Orchestrator)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Determine which path the extension is at
+	extPath := ""
+	for _, prefix := range []string{"extensions", "canasta-extensions"} {
+		checkCmd := fmt.Sprintf("test -d %s/%s/maintenance && echo exists", prefix, extName)
+		checkOutput, _ := orch.ExecWithError(inst.Path, "web", checkCmd)
+		if strings.Contains(checkOutput, "exists") {
+			extPath = prefix + "/" + extName
+			break
+		}
+	}
+	if extPath == "" {
+		return fmt.Errorf("extension %q has no maintenance directory", extName)
+	}
+
+	wikiFlag := ""
+	wikiMsg := ""
+	if wikiID != "" {
+		wikiFlag = " --wiki=" + wikiID
+		wikiMsg = " for wiki '" + wikiID + "'"
+	}
+
+	cmd := "php " + extPath + "/maintenance/" + scriptStr + wikiFlag
+
+	fmt.Printf("Running %s%s...\n", scriptStr, wikiMsg)
+	if err := orch.ExecStreaming(inst.Path, "web", cmd); err != nil {
+		return fmt.Errorf("%s failed%s: %v", scriptStr, wikiMsg, err)
+	}
+
+	fmt.Printf("Completed %s%s\n", scriptStr, wikiMsg)
+	return nil
+}
+
+// parseExtensionNames extracts extension names from find output like:
+//
+//	extensions/Foo/maintenance
+//	canasta-extensions/Bar/maintenance
+func parseExtensionNames(output string) []string {
+	seen := make(map[string]bool)
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// Extract extension name from path like "extensions/Foo/maintenance"
+		parts := strings.Split(line, "/")
+		if len(parts) >= 3 {
+			name := parts[1]
+			seen[name] = true
+		}
+	}
+
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// parseScriptNames extracts script filenames from find output like:
+//
+//	extensions/Foo/maintenance/rebuildData.php
+func parseScriptNames(output string) []string {
+	seen := make(map[string]bool)
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		name := filepath.Base(line)
+		if strings.HasSuffix(name, ".php") {
+			seen[name] = true
+		}
+	}
+
+	scripts := make([]string, 0, len(seen))
+	for name := range seen {
+		scripts = append(scripts, name)
+	}
+	sort.Strings(scripts)
+	return scripts
+}

--- a/cmd/maintenanceUpdate/extension.go
+++ b/cmd/maintenanceUpdate/extension.go
@@ -54,8 +54,9 @@ selected automatically.`,
 
   # Run for all wikis
   canasta maintenance extension -i myinstance --all SemanticMediaWiki rebuildData.php`,
-		Args:         cobra.ArbitraryArgs,
-		SilenceUsage: true,
+		Args:           cobra.ArbitraryArgs,
+		SilenceUsage:   true,
+		SilenceErrors:  true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			instance, err = canasta.CheckCanastaId(instance)
 			return err

--- a/cmd/maintenanceUpdate/extension.go
+++ b/cmd/maintenanceUpdate/extension.go
@@ -191,7 +191,7 @@ func listExtensionScriptsWith(orch orchestrators.Orchestrator, inst config.Insta
 		}
 	}
 	if !loaded {
-		return fmt.Errorf("extension %q is not loaded for the target wiki(s)", extName)
+		return fmt.Errorf("Extension %q is not loaded for the target wiki(s)", extName)
 	}
 
 	// Check that the extension has a maintenance directory
@@ -267,7 +267,7 @@ func runExtensionScriptWith(orch orchestrators.Orchestrator, inst config.Install
 		}
 	}
 	if !loaded {
-		return fmt.Errorf("extension %q is not loaded for wiki %q", extName, checkWiki)
+		return fmt.Errorf("Extension %q is not loaded for wiki %q", extName, checkWiki)
 	}
 
 	// Determine which path the extension is at

--- a/cmd/maintenanceUpdate/extension.go
+++ b/cmd/maintenanceUpdate/extension.go
@@ -143,7 +143,7 @@ func listExtensionsWithMaintenanceWith(orch orchestrators.Orchestrator, inst con
 	}
 
 	if len(filtered) == 0 {
-		fmt.Println("No loaded extensions with maintenance scripts found.")
+		fmt.Println("No loaded extensions with maintenance scripts found")
 		return nil
 	}
 

--- a/cmd/maintenanceUpdate/extension.go
+++ b/cmd/maintenanceUpdate/extension.go
@@ -54,9 +54,7 @@ selected automatically.`,
 
   # Run for all wikis
   canasta maintenance extension -i myinstance --all SemanticMediaWiki rebuildData.php`,
-		Args:           cobra.ArbitraryArgs,
-		SilenceUsage:   true,
-		SilenceErrors:  true,
+		Args: cobra.ArbitraryArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			instance, err = canasta.CheckCanastaId(instance)
 			return err

--- a/cmd/maintenanceUpdate/extension.go
+++ b/cmd/maintenanceUpdate/extension.go
@@ -54,7 +54,8 @@ selected automatically.`,
 
   # Run for all wikis
   canasta maintenance extension -i myinstance --all SemanticMediaWiki rebuildData.php`,
-		Args: cobra.ArbitraryArgs,
+		Args:         cobra.ArbitraryArgs,
+		SilenceUsage: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			instance, err = canasta.CheckCanastaId(instance)
 			return err

--- a/cmd/maintenanceUpdate/extension_test.go
+++ b/cmd/maintenanceUpdate/extension_test.go
@@ -1,0 +1,253 @@
+package maintenance
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
+)
+
+// extMockOrchestrator records calls and returns configurable results.
+type extMockOrchestrator struct {
+	calls          []string
+	execOutputs    map[string]string // command -> output
+	execErr        error
+	streamingCalls []string
+	streamingErr   error
+}
+
+func (m *extMockOrchestrator) CheckDependencies() error { return nil }
+func (m *extMockOrchestrator) GetRepoLink() string      { return "" }
+func (m *extMockOrchestrator) Start(inst config.Installation) error {
+	return nil
+}
+func (m *extMockOrchestrator) Stop(inst config.Installation) error {
+	return nil
+}
+func (m *extMockOrchestrator) Update(installPath string) (*orchestrators.UpdateReport, error) {
+	return nil, nil
+}
+func (m *extMockOrchestrator) Destroy(installPath string) (string, error) {
+	return "", nil
+}
+func (m *extMockOrchestrator) ExecWithError(installPath, service, command string) (string, error) {
+	m.calls = append(m.calls, command)
+	if m.execOutputs != nil {
+		for key, output := range m.execOutputs {
+			if strings.Contains(command, key) {
+				return output, m.execErr
+			}
+		}
+	}
+	return "", m.execErr
+}
+func (m *extMockOrchestrator) ExecStreaming(installPath, service, command string) error {
+	m.streamingCalls = append(m.streamingCalls, command)
+	return m.streamingErr
+}
+func (m *extMockOrchestrator) CheckRunningStatus(inst config.Installation) error {
+	return nil
+}
+func (m *extMockOrchestrator) CopyFrom(installPath, service, containerPath, hostPath string) error {
+	return nil
+}
+func (m *extMockOrchestrator) CopyTo(installPath, service, hostPath, containerPath string) error {
+	return nil
+}
+func (m *extMockOrchestrator) StopAndStart(inst config.Installation) error {
+	return nil
+}
+
+func TestParseExtensionNames(t *testing.T) {
+	output := `extensions/CirrusSearch/maintenance
+canasta-extensions/SemanticMediaWiki/maintenance
+extensions/Cargo/maintenance
+canasta-extensions/CirrusSearch/maintenance`
+
+	names := parseExtensionNames(output)
+	expected := []string{"Cargo", "CirrusSearch", "SemanticMediaWiki"}
+
+	if len(names) != len(expected) {
+		t.Fatalf("expected %d names, got %d: %v", len(expected), len(names), names)
+	}
+	for i, name := range names {
+		if name != expected[i] {
+			t.Errorf("name[%d] = %q, want %q", i, name, expected[i])
+		}
+	}
+}
+
+func TestParseExtensionNamesEmpty(t *testing.T) {
+	names := parseExtensionNames("")
+	if len(names) != 0 {
+		t.Errorf("expected empty, got %v", names)
+	}
+}
+
+func TestParseScriptNames(t *testing.T) {
+	output := `extensions/SemanticMediaWiki/maintenance/rebuildData.php
+extensions/SemanticMediaWiki/maintenance/setupStore.php
+canasta-extensions/SemanticMediaWiki/maintenance/rebuildData.php`
+
+	scripts := parseScriptNames(output)
+	expected := []string{"rebuildData.php", "setupStore.php"}
+
+	if len(scripts) != len(expected) {
+		t.Fatalf("expected %d scripts, got %d: %v", len(expected), len(scripts), scripts)
+	}
+	for i, s := range scripts {
+		if s != expected[i] {
+			t.Errorf("script[%d] = %q, want %q", i, s, expected[i])
+		}
+	}
+}
+
+func TestListExtensionsWithMaintenance(t *testing.T) {
+	mock := &extMockOrchestrator{
+		execOutputs: map[string]string{
+			"find extensions": "extensions/CirrusSearch/maintenance\ncanasta-extensions/SemanticMediaWiki/maintenance\n",
+		},
+	}
+	inst := config.Installation{Path: "/test"}
+	err := listExtensionsWithMaintenanceWith(mock, inst)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestListExtensionScripts(t *testing.T) {
+	mock := &extMockOrchestrator{
+		execOutputs: map[string]string{
+			"test -d": "exists",
+			"find extensions": `extensions/SemanticMediaWiki/maintenance/rebuildData.php
+extensions/SemanticMediaWiki/maintenance/setupStore.php`,
+		},
+	}
+	inst := config.Installation{Path: "/test"}
+	err := listExtensionScriptsWith(mock, inst, "SemanticMediaWiki")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestListExtensionScriptsNotFound(t *testing.T) {
+	mock := &extMockOrchestrator{
+		execOutputs: map[string]string{},
+	}
+	inst := config.Installation{Path: "/test"}
+	err := listExtensionScriptsWith(mock, inst, "NonExistent")
+	if err == nil {
+		t.Fatal("expected error for non-existent extension")
+	}
+	if !strings.Contains(err.Error(), "no maintenance directory") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunExtensionScript(t *testing.T) {
+	mock := &extMockOrchestrator{
+		execOutputs: map[string]string{
+			"test -d extensions/SemanticMediaWiki": "exists",
+		},
+	}
+	inst := config.Installation{Path: "/test"}
+	err := runExtensionScriptWith(mock, inst, "SemanticMediaWiki", "rebuildData.php", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mock.streamingCalls) != 1 {
+		t.Fatalf("expected 1 streaming call, got %d", len(mock.streamingCalls))
+	}
+	cmd := mock.streamingCalls[0]
+	if !strings.Contains(cmd, "extensions/SemanticMediaWiki/maintenance/rebuildData.php") {
+		t.Errorf("expected path to rebuildData.php, got: %s", cmd)
+	}
+	if strings.Contains(cmd, "--wiki") {
+		t.Errorf("expected no --wiki flag, got: %s", cmd)
+	}
+}
+
+func TestRunExtensionScriptWithWiki(t *testing.T) {
+	mock := &extMockOrchestrator{
+		execOutputs: map[string]string{
+			"test -d extensions/CirrusSearch": "exists",
+		},
+	}
+	inst := config.Installation{Path: "/test"}
+	err := runExtensionScriptWith(mock, inst, "CirrusSearch", "UpdateSearchIndexConfig.php", "docs")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cmd := mock.streamingCalls[0]
+	if !strings.Contains(cmd, "--wiki=docs") {
+		t.Errorf("expected --wiki=docs, got: %s", cmd)
+	}
+}
+
+func TestRunExtensionScriptWithArgs(t *testing.T) {
+	mock := &extMockOrchestrator{
+		execOutputs: map[string]string{
+			"test -d extensions/SemanticMediaWiki": "exists",
+		},
+	}
+	inst := config.Installation{Path: "/test"}
+	err := runExtensionScriptWith(mock, inst, "SemanticMediaWiki", "rebuildData.php -s 1000 -e 2000", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cmd := mock.streamingCalls[0]
+	if !strings.Contains(cmd, "-s 1000 -e 2000") {
+		t.Errorf("expected script args, got: %s", cmd)
+	}
+}
+
+func TestRunExtensionScriptNotFound(t *testing.T) {
+	mock := &extMockOrchestrator{
+		execOutputs: map[string]string{},
+	}
+	inst := config.Installation{Path: "/test"}
+	err := runExtensionScriptWith(mock, inst, "NonExistent", "something.php", "")
+	if err == nil {
+		t.Fatal("expected error for non-existent extension")
+	}
+	if !strings.Contains(err.Error(), "no maintenance directory") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunExtensionScriptStreamingError(t *testing.T) {
+	mock := &extMockOrchestrator{
+		execOutputs: map[string]string{
+			"test -d extensions/SemanticMediaWiki": "exists",
+		},
+		streamingErr: fmt.Errorf("container error"),
+	}
+	inst := config.Installation{Path: "/test"}
+	err := runExtensionScriptWith(mock, inst, "SemanticMediaWiki", "rebuildData.php", "")
+	if err == nil {
+		t.Fatal("expected error when streaming fails")
+	}
+	if !strings.Contains(err.Error(), "failed") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunExtensionScriptCanastaExtensions(t *testing.T) {
+	// Extension found in canasta-extensions, not extensions
+	mock := &extMockOrchestrator{
+		execOutputs: map[string]string{
+			"test -d canasta-extensions/Foo": "exists",
+		},
+	}
+	inst := config.Installation{Path: "/test"}
+	err := runExtensionScriptWith(mock, inst, "Foo", "doSomething.php", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cmd := mock.streamingCalls[0]
+	if !strings.Contains(cmd, "canasta-extensions/Foo/maintenance/doSomething.php") {
+		t.Errorf("expected canasta-extensions path, got: %s", cmd)
+	}
+}

--- a/cmd/maintenanceUpdate/maintenance.go
+++ b/cmd/maintenanceUpdate/maintenance.go
@@ -26,12 +26,13 @@ func NewCmdCreate() *cobra.Command {
 		Use:   "maintenance",
 		Short: "Use to run update and other maintenance scripts",
 		Long: `Run MediaWiki maintenance operations on a Canasta installation. This command
-group provides subcommands to run the standard update jobs (update.php,
-runJobs.php, and SMW rebuildData.php) or execute arbitrary maintenance scripts.`,
+group provides subcommands to run the standard update sequence, execute
+arbitrary core maintenance scripts, or run extension-specific maintenance scripts.`,
 	}
 
 	maintenanceCmd.AddCommand(updateCmdCreate())
 	maintenanceCmd.AddCommand(scriptCmdCreate())
+	maintenanceCmd.AddCommand(extensionCmdCreate())
 
 	maintenanceCmd.PersistentFlags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
 	maintenanceCmd.PersistentFlags().StringVarP(&wiki, "wiki", "w", "", "Wiki ID to run maintenance on")

--- a/cmd/maintenanceUpdate/maintenanceScript.go
+++ b/cmd/maintenanceUpdate/maintenanceScript.go
@@ -2,6 +2,7 @@ package maintenance
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
@@ -12,14 +13,19 @@ import (
 func scriptCmdCreate() *cobra.Command {
 
 	scriptCmd := &cobra.Command{
-		Use:   `script "[scriptname.php] [args]"`,
+		Use:   `script ["scriptname.php [args]"]`,
 		Short: "Run maintenance scripts",
-		Long: `Run an arbitrary MediaWiki maintenance script inside the web container.
-The script name is relative to the maintenance/ directory. Any additional
-arguments are passed directly to the PHP script.
+		Long: `Run a MediaWiki core maintenance script inside the web container.
+
+With no arguments, lists all available maintenance scripts. With one argument
+(a quoted script name and optional arguments), runs that script. The script
+name is relative to the maintenance/ directory.
 
 Use --wiki to target a specific wiki in a farm.`,
-		Example: `  # Run rebuildrecentchanges.php
+		Example: `  # List all available maintenance scripts
+  canasta maintenance script -i myinstance
+
+  # Run rebuildrecentchanges.php
   canasta maintenance script "rebuildrecentchanges.php" -i myinstance
 
   # Run a script with arguments
@@ -27,17 +33,50 @@ Use --wiki to target a specific wiki in a farm.`,
 
   # Run a script for a specific wiki in a farm
   canasta maintenance script "rebuildrecentchanges.php" -i myinstance --wiki=docs`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.RangeArgs(0, 1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			instance, err = canasta.CheckCanastaId(instance)
 			return err
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return listMaintenanceScripts(instance)
+			}
 			return runMaintenanceScript(instance, args[0], wiki)
 		},
 	}
 
 	return scriptCmd
+}
+
+func listMaintenanceScripts(inst config.Installation) error {
+	return listMaintenanceScriptsWith(nil, inst)
+}
+
+func listMaintenanceScriptsWith(orch orchestrators.Orchestrator, inst config.Installation) error {
+	if orch == nil {
+		var err error
+		orch, err = orchestrators.New(inst.Orchestrator)
+		if err != nil {
+			return err
+		}
+	}
+
+	cmd := `find maintenance/ -maxdepth 1 -name '*.php' -type f 2>/dev/null`
+	output, _ := orch.ExecWithError(inst.Path, "web", cmd)
+
+	scripts := parseScriptNames(output)
+	if len(scripts) == 0 {
+		fmt.Println("No maintenance scripts found.")
+		return nil
+	}
+
+	sort.Strings(scripts)
+	fmt.Println("Available maintenance scripts:")
+	for _, script := range scripts {
+		fmt.Printf("  %s\n", script)
+	}
+	return nil
 }
 
 func runMaintenanceScript(instance config.Installation, script string, wiki string) error {

--- a/cmd/maintenanceUpdate/maintenanceScript.go
+++ b/cmd/maintenanceUpdate/maintenanceScript.go
@@ -67,7 +67,7 @@ func listMaintenanceScriptsWith(orch orchestrators.Orchestrator, inst config.Ins
 
 	scripts := parseScriptNames(output)
 	if len(scripts) == 0 {
-		fmt.Println("No maintenance scripts found.")
+		fmt.Println("No maintenance scripts found")
 		return nil
 	}
 

--- a/cmd/maintenanceUpdate/maintenance_test.go
+++ b/cmd/maintenanceUpdate/maintenance_test.go
@@ -19,7 +19,7 @@ func findSubcommand(parent interface{ Commands() []*cobra.Command }, name string
 func TestMaintenanceSubcommands(t *testing.T) {
 	cmd := NewCmdCreate()
 
-	expected := []string{"update", "script"}
+	expected := []string{"update", "script", "extension"}
 	for _, name := range expected {
 		if findSubcommand(cmd, name) == nil {
 			t.Errorf("expected subcommand %q not found", name)
@@ -65,20 +65,21 @@ func TestUpdateFlags(t *testing.T) {
 	}
 }
 
-func TestScriptRequiresArg(t *testing.T) {
+func TestScriptAcceptsZeroArgs(t *testing.T) {
 	cmd := NewCmdCreate()
 	scriptCmd := findSubcommand(cmd, "script")
 	if scriptCmd == nil {
 		t.Fatal("script subcommand not found")
 	}
 
-	// script requires exactly 1 arg — override PreRunE/RunE to isolate arg validation
+	// script accepts 0 args (lists scripts) or 1 arg (runs a script)
+	// override PreRunE/RunE to isolate arg validation
 	scriptCmd.PreRunE = nil
 	scriptCmd.RunE = func(cmd *cobra.Command, args []string) error { return nil }
 
 	cmd.SetArgs([]string{"script"})
-	if err := cmd.Execute(); err == nil {
-		t.Error("expected error when script is called without arguments")
+	if err := cmd.Execute(); err != nil {
+		t.Errorf("expected no error with zero args, got: %v", err)
 	}
 }
 

--- a/docs/guide/extensions-and-skins.md
+++ b/docs/guide/extensions-and-skins.md
@@ -198,13 +198,13 @@ On the first startup after enabling SMW, Canasta automatically runs `setupStore.
 After initial setup, you need to run `rebuildData.php` to populate the SMW store. Canasta does not run this automatically because it can take a long time on large wikis. Use the extension maintenance command:
 
 ```bash
-canasta maintenance extension SemanticMediaWiki "rebuildData.php" -i myinstance
+canasta maintenance extension -i myinstance SemanticMediaWiki rebuildData.php
 ```
 
 For large wikis, pass options to run in segments:
 
 ```bash
-canasta maintenance extension SemanticMediaWiki "rebuildData.php -s 1000 -e 2000" -i myinstance
+canasta maintenance extension -i myinstance SemanticMediaWiki rebuildData.php -s 1000 -e 2000
 ```
 
 See [Running extension maintenance scripts](general-concepts.md#running-extension-maintenance-scripts) for more examples.
@@ -238,19 +238,19 @@ After enabling CirrusSearch (or after a major upgrade), you need to build the se
 **Step 1 — Configure index mappings:**
 
 ```bash
-canasta maintenance extension CirrusSearch "UpdateSearchIndexConfig.php --reindexAndRemoveOk --indexIdentifier now" -i myinstance
+canasta maintenance extension -i myinstance CirrusSearch UpdateSearchIndexConfig.php --reindexAndRemoveOk --indexIdentifier now
 ```
 
 **Step 2 — Index page content:**
 
 ```bash
-canasta maintenance extension CirrusSearch "ForceSearchIndex.php --skipLinks --indexOnSkip" -i myinstance
+canasta maintenance extension -i myinstance CirrusSearch ForceSearchIndex.php --skipLinks --indexOnSkip
 ```
 
 **Step 3 — Index links:**
 
 ```bash
-canasta maintenance extension CirrusSearch "ForceSearchIndex.php --skipParse" -i myinstance
+canasta maintenance extension -i myinstance CirrusSearch ForceSearchIndex.php --skipParse
 ```
 
 All three steps must run in order. On large wikis, the indexing steps (2 and 3) can take a significant amount of time.
@@ -260,7 +260,7 @@ All three steps must run in order. On large wikis, the indexing steps (2 and 3) 
 To destroy and recreate the index (e.g., after changing analyzers or mappings), use `--startOver` instead of `--reindexAndRemoveOk --indexIdentifier now` in step 1:
 
 ```bash
-canasta maintenance extension CirrusSearch "UpdateSearchIndexConfig.php --startOver" -i myinstance
+canasta maintenance extension -i myinstance CirrusSearch UpdateSearchIndexConfig.php --startOver
 ```
 
 Then run steps 2 and 3 as above.
@@ -270,17 +270,17 @@ Then run steps 2 and 3 as above.
 In a wiki farm, each wiki has its own search index. Use `--wiki` to target a specific wiki:
 
 ```bash
-canasta maintenance extension CirrusSearch "UpdateSearchIndexConfig.php --reindexAndRemoveOk --indexIdentifier now" -i myinstance --wiki=docs
-canasta maintenance extension CirrusSearch "ForceSearchIndex.php --skipLinks --indexOnSkip" -i myinstance --wiki=docs
-canasta maintenance extension CirrusSearch "ForceSearchIndex.php --skipParse" -i myinstance --wiki=docs
+canasta maintenance extension -i myinstance --wiki=docs CirrusSearch UpdateSearchIndexConfig.php --reindexAndRemoveOk --indexIdentifier now
+canasta maintenance extension -i myinstance --wiki=docs CirrusSearch ForceSearchIndex.php --skipLinks --indexOnSkip
+canasta maintenance extension -i myinstance --wiki=docs CirrusSearch ForceSearchIndex.php --skipParse
 ```
 
 Or use `--all` to rebuild indexes for every wiki:
 
 ```bash
-canasta maintenance extension CirrusSearch "UpdateSearchIndexConfig.php --reindexAndRemoveOk --indexIdentifier now" -i myinstance --all
-canasta maintenance extension CirrusSearch "ForceSearchIndex.php --skipLinks --indexOnSkip" -i myinstance --all
-canasta maintenance extension CirrusSearch "ForceSearchIndex.php --skipParse" -i myinstance --all
+canasta maintenance extension -i myinstance --all CirrusSearch UpdateSearchIndexConfig.php --reindexAndRemoveOk --indexIdentifier now
+canasta maintenance extension -i myinstance --all CirrusSearch ForceSearchIndex.php --skipLinks --indexOnSkip
+canasta maintenance extension -i myinstance --all CirrusSearch ForceSearchIndex.php --skipParse
 ```
 
 See [Running extension maintenance scripts](general-concepts.md#running-extension-maintenance-scripts) for general usage of the extension maintenance command.

--- a/docs/guide/extensions-and-skins.md
+++ b/docs/guide/extensions-and-skins.md
@@ -192,6 +192,22 @@ When the container starts, Canasta detects if `config/composer.local.json` or an
 
 On the first startup after enabling SMW, Canasta automatically runs `setupStore.php` to initialize the SMW database tables. This creates a `smw.json` configuration file in `config/smw/` on the persistent volume, so the setup only runs once.
 
+### Rebuilding SMW data
+
+After initial setup, you need to run `rebuildData.php` to populate the SMW store. Canasta does not run this automatically because it can take a long time on large wikis. Use the extension maintenance command:
+
+```bash
+canasta maintenance extension SemanticMediaWiki "rebuildData.php" -i myinstance
+```
+
+For large wikis, pass options to run in segments:
+
+```bash
+canasta maintenance extension SemanticMediaWiki "rebuildData.php -s 1000 -e 2000" -i myinstance
+```
+
+See [Running extension maintenance scripts](general-concepts.md#running-extension-maintenance-scripts) for more examples.
+
 ### Notes
 
 - The `enableSemantics()` function is provided by SMW's composer autoloader. Canasta's unified autoloader ensures it is available without any additional steps.

--- a/docs/guide/general-concepts.md
+++ b/docs/guide/general-concepts.md
@@ -13,6 +13,7 @@ This page covers foundational concepts that apply to all Canasta installations, 
   - [Automatic maintenance](#automatic-maintenance)
   - [Running the update sequence](#running-the-update-sequence)
   - [Running scripts manually](#running-scripts-manually)
+  - [Running extension maintenance scripts](#running-extension-maintenance-scripts)
 - [Deploying behind a reverse proxy](#deploying-behind-a-reverse-proxy)
 - [Running on non-standard ports](#running-on-non-standard-ports)
 
@@ -322,16 +323,58 @@ canasta maintenance update -i myinstance --skip-jobs --skip-smw
 
 ### Running scripts manually
 
-To run an arbitrary maintenance script, use `canasta maintenance script`. Wrap the script name and any arguments in quotes so they are passed as a single argument:
+To run an arbitrary MediaWiki core maintenance script, use `canasta maintenance script`. Wrap the script name and any arguments in quotes so they are passed as a single argument:
 
 ```bash
 canasta maintenance script "createAndPromote.php WikiSysop MyPassword --bureaucrat --sysop" -i myinstance
+```
+
+To list all available core maintenance scripts:
+
+```bash
+canasta maintenance script -i myinstance
 ```
 
 Use `--wiki` to target a specific wiki in a farm:
 
 ```bash
 canasta maintenance script "rebuildrecentchanges.php" -i myinstance --wiki=docs
+```
+
+### Running extension maintenance scripts
+
+Many extensions include their own maintenance scripts (e.g., Semantic MediaWiki, CirrusSearch, Cargo). Use `canasta maintenance extension` to discover and run them.
+
+List all extensions that have maintenance scripts:
+
+```bash
+canasta maintenance extension -i myinstance
+```
+
+List available scripts for a specific extension:
+
+```bash
+canasta maintenance extension SemanticMediaWiki -i myinstance
+```
+
+Run an extension maintenance script (script name and arguments in quotes):
+
+```bash
+canasta maintenance extension SemanticMediaWiki "rebuildData.php" -i myinstance
+canasta maintenance extension CirrusSearch "UpdateSearchIndexConfig.php --reindexAndRemoveOk --indexIdentifier now" -i myinstance
+```
+
+For large operations, pass script-specific options in the quoted string:
+
+```bash
+canasta maintenance extension SemanticMediaWiki "rebuildData.php -s 1000 -e 2000" -i myinstance
+```
+
+Use `--wiki` and `--all` for wiki farms, just like other maintenance commands:
+
+```bash
+canasta maintenance extension SemanticMediaWiki "rebuildData.php" -i myinstance --wiki=docs
+canasta maintenance extension SemanticMediaWiki "rebuildData.php" -i myinstance --all
 ```
 
 See the [CLI Reference](../cli/canasta_maintenance.md) for more details.

--- a/docs/guide/general-concepts.md
+++ b/docs/guide/general-concepts.md
@@ -345,7 +345,7 @@ canasta maintenance script "rebuildrecentchanges.php" -i myinstance --wiki=docs
 
 Many extensions include their own maintenance scripts (e.g., Semantic MediaWiki, CirrusSearch, Cargo). Use `canasta maintenance extension` to discover and run them.
 
-List all extensions that have maintenance scripts:
+List all loaded extensions that have maintenance scripts:
 
 ```bash
 canasta maintenance extension -i myinstance
@@ -354,28 +354,30 @@ canasta maintenance extension -i myinstance
 List available scripts for a specific extension:
 
 ```bash
-canasta maintenance extension SemanticMediaWiki -i myinstance
+canasta maintenance extension -i myinstance SemanticMediaWiki
 ```
 
-Run an extension maintenance script (script name and arguments in quotes):
+Run an extension maintenance script. Flags (`-i`, `--wiki`, `--all`) come before the extension name; everything after is the script and its arguments — no quotes needed:
 
 ```bash
-canasta maintenance extension SemanticMediaWiki "rebuildData.php" -i myinstance
-canasta maintenance extension CirrusSearch "UpdateSearchIndexConfig.php --reindexAndRemoveOk --indexIdentifier now" -i myinstance
+canasta maintenance extension -i myinstance SemanticMediaWiki rebuildData.php
+canasta maintenance extension -i myinstance CirrusSearch UpdateSearchIndexConfig.php --reindexAndRemoveOk --indexIdentifier now
 ```
 
-For large operations, pass script-specific options in the quoted string:
+For large operations, pass script-specific options directly:
 
 ```bash
-canasta maintenance extension SemanticMediaWiki "rebuildData.php -s 1000 -e 2000" -i myinstance
+canasta maintenance extension -i myinstance SemanticMediaWiki rebuildData.php -s 1000 -e 2000
 ```
 
 Use `--wiki` and `--all` for wiki farms, just like other maintenance commands:
 
 ```bash
-canasta maintenance extension SemanticMediaWiki "rebuildData.php" -i myinstance --wiki=docs
-canasta maintenance extension SemanticMediaWiki "rebuildData.php" -i myinstance --all
+canasta maintenance extension -i myinstance --wiki=docs SemanticMediaWiki rebuildData.php
+canasta maintenance extension -i myinstance --all SemanticMediaWiki rebuildData.php
 ```
+
+Only extensions that are currently loaded (enabled) for the target wiki are shown and can be run.
 
 See the [CLI Reference](../cli/canasta_maintenance.md) for more details.
 


### PR DESCRIPTION
## Summary

Adds `canasta maintenance extension` — a generic subcommand for discovering and running maintenance scripts from any extension that ships a `maintenance/` directory.

**Three modes:**
- `canasta maintenance extension -i myinstance` — list extensions with maintenance scripts
- `canasta maintenance extension SemanticMediaWiki -i myinstance` — list available scripts for an extension
- `canasta maintenance extension SemanticMediaWiki "rebuildData.php" -i myinstance` — run a script

Also updates `canasta maintenance script` to list all available core maintenance scripts when called with no arguments.

Supports `--wiki` and `--all` flags for wiki farms. Searches both `extensions/` and `canasta-extensions/` directories.

**This generic approach supersedes #245 (search-index) and #249 (smw-rebuild) — no per-extension subcommands needed.**

Closes #248
Supersedes #245 and #249

## Changes

- **New**: `cmd/maintenanceUpdate/extension.go` — extension subcommand with list/run modes
- **New**: `cmd/maintenanceUpdate/extension_test.go` — 12 unit tests
- **Modified**: `cmd/maintenanceUpdate/maintenance.go` — register extension subcommand
- **Modified**: `cmd/maintenanceUpdate/maintenanceScript.go` — add listing mode (0 args)
- **Modified**: `docs/guide/general-concepts.md` — document extension maintenance commands
- **Modified**: `docs/guide/extensions-and-skins.md` — document SMW rebuildData via extension command

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./cmd/maintenanceUpdate/` — all 12 tests pass
- [x] `golangci-lint run ./...` — clean
- [ ] Manual: `canasta maintenance extension -i <instance>` lists extensions
- [ ] Manual: `canasta maintenance extension SemanticMediaWiki -i <instance>` lists scripts
- [ ] Manual: `canasta maintenance extension SemanticMediaWiki "rebuildData.php" -i <instance>` runs script
- [ ] Manual: `canasta maintenance script -i <instance>` lists core scripts