### PR TITLE
Silence duplicate error output on command failures

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -33,6 +33,8 @@ var rootCmd = &cobra.Command{
 	Long: `Canasta CLI manages Canasta MediaWiki installations using Docker Compose.
 It supports creating, importing, starting, stopping, upgrading, and backing up
 multiple Canasta instances, including wiki farms with multiple wikis per instance.`,
+	SilenceErrors: true,
+	SilenceUsage:  true,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		logging.SetVerbose(verbose)
 		logging.Print("Setting verbose")


### PR DESCRIPTION
## Summary

Set `SilenceErrors` and `SilenceUsage` on the root command so Cobra does not print errors or usage text when `RunE` returns an error. The error is still printed once by `logging.Fatal` in `Execute()`.

Previously every command failure would print the error twice: once by Cobra with an "Error:" prefix plus full usage text, and again by `logging.Fatal`. This affected all ~35 commands that use `RunE`.

Closes #251

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Run any command with bad input (e.g., `canasta start -i nonexistent`) and verify the error prints only once, with no usage dump