### PR TITLE
K8s 1/5: Add Kubernetes orchestrator infrastructure

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	addCmd "github.com/CanastaWiki/Canasta-CLI/cmd/add"
 	createCmd "github.com/CanastaWiki/Canasta-CLI/cmd/create"
@@ -96,11 +97,11 @@ func init() {
 	cobra.OnInitialize(func() {
 		orch, err := orchestrators.New("compose")
 		if err != nil {
-			logging.Print(fmt.Sprintf("Warning: %s\n", err))
+			fmt.Fprintf(os.Stderr, "Warning: %s\n", err)
 			return
 		}
 		if err := orch.CheckDependencies(); err != nil {
-			logging.Print(fmt.Sprintf("Warning: Docker Compose not available: %s\n", err))
+			fmt.Fprintf(os.Stderr, "Warning: Docker Compose not available: %s\n", err)
 		}
 	})
 }

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	addCmd "github.com/CanastaWiki/Canasta-CLI/cmd/add"
 	createCmd "github.com/CanastaWiki/Canasta-CLI/cmd/create"
 	deleteCmd "github.com/CanastaWiki/Canasta-CLI/cmd/delete"
@@ -94,10 +96,11 @@ func init() {
 	cobra.OnInitialize(func() {
 		orch, err := orchestrators.New("compose")
 		if err != nil {
-			logging.Fatal(err)
+			logging.Print(fmt.Sprintf("Warning: %s\n", err))
+			return
 		}
 		if err := orch.CheckDependencies(); err != nil {
-			logging.Fatal(err)
+			logging.Print(fmt.Sprintf("Warning: Docker Compose not available: %s\n", err))
 		}
 	})
 }

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-
 	addCmd "github.com/CanastaWiki/Canasta-CLI/cmd/add"
 	createCmd "github.com/CanastaWiki/Canasta-CLI/cmd/create"
 	deleteCmd "github.com/CanastaWiki/Canasta-CLI/cmd/delete"
@@ -23,7 +20,6 @@ import (
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
 	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
-	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 
 	"github.com/spf13/cobra"
 )
@@ -91,17 +87,6 @@ func init() {
 			} else {
 				cmd.Printf("\nConfig file: %s/conf.json\n", configDir)
 			}
-		}
-	})
-
-	cobra.OnInitialize(func() {
-		orch, err := orchestrators.New("compose")
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: %s\n", err)
-			return
-		}
-		if err := orch.CheckDependencies(); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Docker Compose not available: %s\n", err)
 		}
 	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -239,6 +239,7 @@ func AddOrchestrator(details Orchestrator) error {
 	supportedOrchestrators := map[string]bool{
 		"compose":    true,
 		"kubernetes": true,
+		"k8s":        true,
 	}
 	if !supportedOrchestrators[details.Id] {
 		return fmt.Errorf("orchestrator %s is not supported", details.Id)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -236,8 +236,12 @@ func AddOrchestrator(details Orchestrator) error {
 	if existingInstallations.Orchestrators == nil {
 		existingInstallations.Orchestrators = map[string]Orchestrator{}
 	}
-	if details.Id != "compose" {
-		return fmt.Errorf("orchestrator %s is not suported", details.Id)
+	supportedOrchestrators := map[string]bool{
+		"compose":    true,
+		"kubernetes": true,
+	}
+	if !supportedOrchestrators[details.Id] {
+		return fmt.Errorf("orchestrator %s is not supported", details.Id)
 	}
 	existingInstallations.Orchestrators[details.Id] = details
 	err := write(existingInstallations)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -178,6 +178,7 @@ func TestAddOrchestratorSupported(t *testing.T) {
 	}{
 		{"compose accepted", "compose", false},
 		{"kubernetes accepted", "kubernetes", false},
+		{"k8s alias accepted", "k8s", false},
 		{"unknown rejected", "nomad", true},
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -166,6 +167,31 @@ func TestGetCanastaID(t *testing.T) {
 	_, err = GetCanastaID("/tmp/nonexistent")
 	if err == nil {
 		t.Fatal("expected error for nonexistent path, got nil")
+	}
+}
+
+func TestAddOrchestratorSupported(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      string
+		wantErr bool
+	}{
+		{"compose accepted", "compose", false},
+		{"kubernetes accepted", "kubernetes", false},
+		{"unknown rejected", "nomad", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupTestDir(t)
+			err := AddOrchestrator(Orchestrator{Id: tt.id, Path: "/usr/bin/test"})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AddOrchestrator(%q) error = %v, wantErr %v", tt.id, err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && !strings.Contains(err.Error(), "not supported") {
+				t.Errorf("AddOrchestrator(%q) error = %q, want 'not supported'", tt.id, err.Error())
+			}
+		})
 	}
 }
 

--- a/internal/orchestrators/orchestrator_test.go
+++ b/internal/orchestrators/orchestrator_test.go
@@ -80,7 +80,9 @@ func TestNew(t *testing.T) {
 	}{
 		{"compose", "compose", false},
 		{"docker-compose alias", "docker-compose", false},
-		{"unknown", "kubernetes", true},
+		{"kubernetes not yet implemented", "kubernetes", true},
+		{"k8s not yet implemented", "k8s", true},
+		{"unknown", "unknown-orch", true},
 		{"empty", "", true},
 	}
 
@@ -94,6 +96,18 @@ func TestNew(t *testing.T) {
 				t.Error("expected non-nil orchestrator")
 			}
 		})
+	}
+}
+
+func TestNewKubernetesNotYetImplemented(t *testing.T) {
+	for _, id := range []string{"kubernetes", "k8s"} {
+		_, err := New(id)
+		if err == nil {
+			t.Fatalf("New(%q) expected error, got nil", id)
+		}
+		if !strings.Contains(err.Error(), "not yet implemented") {
+			t.Errorf("New(%q) error = %q, want 'not yet implemented'", id, err.Error())
+		}
 	}
 }
 

--- a/internal/orchestrators/registry.go
+++ b/internal/orchestrators/registry.go
@@ -10,6 +10,8 @@ func New(orchestratorID string) (Orchestrator, error) {
 	switch orchestratorID {
 	case "compose", "docker-compose":
 		return &ComposeOrchestrator{}, nil
+	case "kubernetes", "k8s":
+		return nil, fmt.Errorf("kubernetes orchestrator not yet implemented")
 	default:
 		return nil, fmt.Errorf("orchestrator: %s is not available", orchestratorID)
 	}


### PR DESCRIPTION
## Summary

Part of #131. **PR 1 of 5** — merge order: #254 → **#256** → #257 → #258 → #259 → #260

Removes hardcoded "compose" assumptions so the Kubernetes orchestrator can be added in subsequent PRs.

### Changes

- **`internal/orchestrators/registry.go`**: Add `"kubernetes"`, `"k8s"` cases, returning placeholder error for now
- **`internal/config/config.go`**: Replace hardcoded `if details.Id != "compose"` with a supported set (`compose`, `kubernetes`, `k8s`)
- **`cmd/root/root.go`**: Remove the `OnInitialize` block that hardcoded a compose orchestrator dependency check — dependencies are now checked when commands actually use their orchestrator, so K8s-only users don't see spurious Docker Compose warnings
- **Tests**: Updated `orchestrator_test.go` and `config_test.go` for new orchestrator types, including `k8s` alias

### Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] Existing Docker Compose workflows unchanged — dependency errors surface when commands run, not at startup
- [x] `canasta version` and `canasta --help` no longer print Docker Compose warnings