### PR TITLE
K8s 4/5: Add Kubernetes restic backup support

### DIFF
--- a/internal/orchestrators/kubernetes.go
+++ b/internal/orchestrators/kubernetes.go
@@ -213,7 +213,54 @@ func (k *KubernetesOrchestrator) CopyTo(installPath, service, hostPath, containe
 }
 
 func (k *KubernetesOrchestrator) RunBackup(installPath, envPath string, volumes map[string]string, args ...string) (string, error) {
-	return "", fmt.Errorf("backup is not yet supported for Kubernetes installations")
+	ns, err := getNamespaceFromPath(installPath)
+	if err != nil {
+		return "", err
+	}
+
+	cmdArgs := []string{"run", "backup-cli", "--rm", "-i",
+		"--restart=Never", "-n", ns,
+		"--image=restic/restic",
+		"--env-from=configmap/canasta-env"}
+
+	// Add PVC volume mounts via --overrides if volumes are specified
+	if len(volumes) > 0 {
+		overrides := buildPodOverrides(volumes)
+		cmdArgs = append(cmdArgs, "--overrides", overrides)
+	}
+
+	cmdArgs = append(cmdArgs, "--")
+	cmdArgs = append(cmdArgs, args...)
+
+	cmd := exec.Command("kubectl", cmdArgs...)
+	outputByte, err := cmd.CombinedOutput()
+	output := string(outputByte)
+	logging.Print(output)
+	if err != nil {
+		return output, fmt.Errorf("backup command failed: %s", strings.TrimSpace(output))
+	}
+	return output, nil
+}
+
+// buildPodOverrides generates a JSON override spec for kubectl run
+// that mounts host paths as emptyDir volumes (for staging data).
+func buildPodOverrides(volumes map[string]string) string {
+	var volumeMounts []string
+	var volumeDefs []string
+	i := 0
+	for _, containerPath := range volumes {
+		name := fmt.Sprintf("vol%d", i)
+		volumeMounts = append(volumeMounts,
+			fmt.Sprintf(`{"name":"%s","mountPath":"%s"}`, name, containerPath))
+		volumeDefs = append(volumeDefs,
+			fmt.Sprintf(`{"name":"%s","emptyDir":{}}`, name))
+		i++
+	}
+	return fmt.Sprintf(
+		`{"spec":{"containers":[{"name":"backup-cli","volumeMounts":[%s]}],"volumes":[%s]}}`,
+		strings.Join(volumeMounts, ","),
+		strings.Join(volumeDefs, ","),
+	)
 }
 
 func (k *KubernetesOrchestrator) RestoreFromBackupVolume(installPath string, dirs map[string]string) error {


### PR DESCRIPTION
## Summary

Part of #131. **PR 4 of 5** — merge order: #254 → #256 → #257 → #258 → **#259** → #260

Adds Kubernetes-specific restic backup support and guards cron scheduling for K8s installations.

### Changes

- **`internal/orchestrators/kubernetes.go`**: `RunRestic` implementation — runs restic as an ephemeral pod via `kubectl run` with optional PVC volume mounts via `--overrides`
- **`cmd/restic/schedule.go`**: Guard for K8s — returns error directing users to edit the backup CronJob in kustomization.yaml instead of using host cron

### How K8s restic works

```
kubectl run restic-cli --rm -i --restart=Never -n {namespace} \
  --image=restic/restic --env-from=configmap/canasta-env \
  [--overrides=<pod spec with volume mounts>] \
  -- <restic args>
```

### Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `golangci-lint run ./...` passes
- [ ] Compose restic commands unchanged