### PR TITLE
Use persistent Docker volume for backup file staging

### DIFF
--- a/cmd/backup/create.go
+++ b/cmd/backup/create.go
@@ -17,9 +17,9 @@ func createBackupCmdCreate() *cobra.Command {
 		Use:   "create",
 		Short: "Create a backup",
 		Long: `Create a new backup snapshot of the Canasta installation. This dumps the
-database, copies configuration files, extensions, images, and skins into
-a staging directory, then uploads the snapshot to the backup repository
-with the specified tag.`,
+database, stages configuration files, extensions, images, and skins into
+a Docker volume, then uploads the snapshot to the backup repository with
+the specified tag.`,
 		Example: `  # Create a backup with a descriptive tag
   canasta backup create -i myinstance -t before-upgrade`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -38,11 +38,6 @@ func takeSnapshot(tag string) error {
 	if err != nil {
 		return err
 	}
-	currentSnapshotFolder := instance.Path + "/currentsnapshot"
-
-	if err := checkCurrentSnapshotFolder(currentSnapshotFolder); err != nil {
-		return err
-	}
 
 	_, err = orch.ExecWithError(instance.Path, "web", fmt.Sprintf("mysqldump -h db -u root -p%s --databases %s > %s", EnvVariables["MYSQL_PASSWORD"], EnvVariables["WG_DB_NAME"], mysqldumpPath))
 	if err != nil {
@@ -50,19 +45,13 @@ func takeSnapshot(tag string) error {
 	}
 	logging.Print("mysqldump mediawiki completed")
 
+	volumes := make(map[string]string)
 	for _, dir := range []string{"config", "extensions", "images", "skins"} {
-		src := filepath.Join(instance.Path, dir)
-		dst := filepath.Join(currentSnapshotFolder, dir)
-		if err := copyDir(src, dst); err != nil {
-			return fmt.Errorf("failed to copy %s: %w", dir, err)
-		}
+		volumes[filepath.Join(instance.Path, dir)] = "/currentsnapshot/" + dir
 	}
-	logging.Print("Copy folders and files completed.")
 
 	hostname, _ := os.Hostname()
-	volumes := map[string]string{
-		currentSnapshotFolder: "/currentsnapshot/",
-	}
+	logging.Print("Staging files to backup volume...")
 	output, err := runBackup(volumes, "-r", repoURL, "--tag", fmt.Sprintf("%s__on__%s", tag, hostname), "backup", "/currentsnapshot")
 	if err != nil {
 		return err

--- a/cmd/maintenanceUpdate/extension_test.go
+++ b/cmd/maintenanceUpdate/extension_test.go
@@ -60,6 +60,10 @@ func (m *extMockOrchestrator) CopyTo(installPath, service, hostPath, containerPa
 func (m *extMockOrchestrator) RunBackup(installPath, envPath string, volumes map[string]string, args ...string) (string, error) {
 	return "", nil
 }
+
+func (m *extMockOrchestrator) RestoreFromBackupVolume(installPath string, dirs map[string]string) error {
+	return nil
+}
 func (m *extMockOrchestrator) StopAndStart(inst config.Installation) error {
 	return nil
 }

--- a/internal/orchestrators/compose.go
+++ b/internal/orchestrators/compose.go
@@ -347,7 +347,7 @@ func (c *ComposeOrchestrator) RunBackup(installPath, envPath string, volumes map
 	cmdArgs = append(cmdArgs, "restic/restic")
 	cmdArgs = append(cmdArgs, args...)
 
-	err, output := execute.Run(installPath, "sudo", cmdArgs...)
+	err, output := execute.Run(installPath, cmdArgs[0], cmdArgs[1:]...)
 	if err != nil {
 		return output, fmt.Errorf("restic command failed: %s", output)
 	}

--- a/internal/orchestrators/compose.go
+++ b/internal/orchestrators/compose.go
@@ -339,19 +339,95 @@ func (c *ComposeOrchestrator) CopyTo(installPath, service, hostPath, containerPa
 	return nil
 }
 
+// backupVolumeName returns the persistent Docker volume name for an installation.
+func backupVolumeName(installPath string) string {
+	return "canasta-backup-" + filepath.Base(installPath)
+}
+
 func (c *ComposeOrchestrator) RunBackup(installPath, envPath string, volumes map[string]string, args ...string) (string, error) {
-	cmdArgs := []string{"docker", "run", "--rm", "-i", "--env-file", envPath}
-	for hostPath, containerPath := range volumes {
-		cmdArgs = append(cmdArgs, "-v", hostPath+":"+containerPath)
+	volName := backupVolumeName(installPath)
+
+	// Ensure the persistent backup volume exists (idempotent)
+	err, output := execute.Run("", "docker", "volume", "create", volName)
+	if err != nil {
+		return "", fmt.Errorf("failed to create backup volume: %s", output)
+	}
+
+	// If host paths are provided, stage them into the volume via alpine
+	if len(volumes) > 0 {
+		if err := stageToVolume(volName, volumes); err != nil {
+			return "", err
+		}
+	}
+
+	// Run restic with the persistent volume mounted
+	cmdArgs := []string{"docker", "run", "--rm", "-i", "--env-file", envPath,
+		"-v", volName + ":/currentsnapshot",
 	}
 	cmdArgs = append(cmdArgs, "restic/restic")
 	cmdArgs = append(cmdArgs, args...)
 
-	err, output := execute.Run(installPath, cmdArgs[0], cmdArgs[1:]...)
+	err, output = execute.Run(installPath, cmdArgs[0], cmdArgs[1:]...)
 	if err != nil {
 		return output, fmt.Errorf("restic command failed: %s", output)
 	}
 	return output, nil
+}
+
+// stageToVolume copies host directories into the backup volume via an alpine container.
+func stageToVolume(volName string, volumes map[string]string) error {
+	cmdArgs := []string{"docker", "run", "--rm",
+		"-v", volName + ":/currentsnapshot",
+	}
+
+	var copyParts []string
+	i := 0
+	for hostPath, containerPath := range volumes {
+		mountPoint := fmt.Sprintf("/src%d", i)
+		cmdArgs = append(cmdArgs, "-v", hostPath+":"+mountPoint+":ro")
+		copyParts = append(copyParts, fmt.Sprintf("cp -a %s %s", mountPoint, containerPath))
+		i++
+	}
+
+	shellCmd := "rm -rf /currentsnapshot/* && " + strings.Join(copyParts, " && ")
+	cmdArgs = append(cmdArgs, "alpine", "sh", "-c", shellCmd)
+
+	err, output := execute.Run("", cmdArgs[0], cmdArgs[1:]...)
+	if err != nil {
+		return fmt.Errorf("failed to stage files to backup volume: %s", output)
+	}
+	return nil
+}
+
+func (c *ComposeOrchestrator) RestoreFromBackupVolume(installPath string, dirs map[string]string) error {
+	volName := backupVolumeName(installPath)
+
+	cmdArgs := []string{"docker", "run", "--rm",
+		"-v", volName + ":/currentsnapshot:ro",
+		"-v", installPath + ":/install",
+	}
+
+	var copyParts []string
+	for volumePath, hostPath := range dirs {
+		relPath, err := filepath.Rel(installPath, hostPath)
+		if err != nil {
+			return fmt.Errorf("failed to compute relative path for %s: %w", hostPath, err)
+		}
+		dst := "/install/" + relPath
+		// Handle both directories and individual files
+		copyParts = append(copyParts,
+			fmt.Sprintf("if [ -d %s ]; then rm -rf %s && cp -a %s %s; elif [ -f %s ]; then cp -a %s %s; fi",
+				volumePath, dst, volumePath, dst, volumePath, volumePath, dst))
+	}
+
+	shellCmd := strings.Join(copyParts, " && ")
+	cmdArgs = append(cmdArgs, "alpine", "sh", "-c", shellCmd)
+
+	err, output := execute.Run("", cmdArgs[0], cmdArgs[1:]...)
+	if err != nil {
+		return fmt.Errorf("failed to restore files from backup volume: %s", output)
+	}
+	return nil
 }
 
 func (c *ComposeOrchestrator) CopyOverrideFile(installPath, sourceFilename, workingDir string) error {

--- a/internal/orchestrators/orchestrator.go
+++ b/internal/orchestrators/orchestrator.go
@@ -26,6 +26,7 @@ type Orchestrator interface {
 	CopyFrom(installPath, service, containerPath, hostPath string) error
 	CopyTo(installPath, service, hostPath, containerPath string) error
 	RunBackup(installPath, envPath string, volumes map[string]string, args ...string) (string, error)
+	RestoreFromBackupVolume(installPath string, dirs map[string]string) error
 }
 
 // ImageInfo holds information about a Docker image

--- a/internal/orchestrators/orchestrator_test.go
+++ b/internal/orchestrators/orchestrator_test.go
@@ -67,6 +67,11 @@ func (m *mockOrchestrator) RunBackup(installPath, envPath string, volumes map[st
 	return m.execOutput, m.execErr
 }
 
+func (m *mockOrchestrator) RestoreFromBackupVolume(installPath string, dirs map[string]string) error {
+	m.calls = append(m.calls, "RestoreFromBackupVolume")
+	return nil
+}
+
 func TestNew(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary

Closes #265. Part 3 of 3 for #253 (split from #254). Depends on #267.

Replaces host-side file staging with a persistent Docker volume to fix macOS Docker Desktop bind mount I/O errors. On macOS, restic fails to read files from bind-mounted host directories due to Docker Desktop's file sharing layer (gRPC-FUSE). Using a Docker volume avoids this entirely.

### How it works

1. A persistent named volume `canasta-backup-{name}` is created per installation (idempotent via `docker volume create`)
2. **`backup create`**: An alpine container bind-mounts installation directories (read-only) and copies them into the volume. Restic then backs up from the volume.
3. **`backup restore`**: Restic restores into the volume. An alpine container copies files from the volume back to the host installation directories.
4. Other subcommands (`init`, `list`, `check`, etc.) mount the volume harmlessly — no staging needed.

### Changes

- `RunBackup` (compose.go): Creates volume, stages host files via alpine when volumes are provided, always mounts volume for restic
- `RestoreFromBackupVolume`: New `Orchestrator` interface method for copying restored files from the volume back to the installation
- `create.go`: Passes individual installation directories as volume entries instead of staging to a host directory
- `restore.go`: Uses `RestoreFromBackupVolume` instead of host-side `copyDir`
- `backup.go`: Removes `copyDir`, `copyFile`, `checkCurrentSnapshotFolder` (no longer needed)
- Also removes unnecessary `sudo` from `docker run` in `RunBackup`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] `golangci-lint run ./...` passes
- [ ] Manual test on macOS: `canasta backup create` and `canasta backup restore` succeed
- [ ] Manual test on Linux: same commands still work
- [ ] Verify existing snapshots can be restored with new code