### PR TITLE
Make backup commands wiki farm aware

### DIFF
--- a/cmd/backup/backup_test.go
+++ b/cmd/backup/backup_test.go
@@ -1,0 +1,116 @@
+package backup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
+)
+
+func writeWikisYaml(t *testing.T, dir string, wikis []farmsettings.Wiki) {
+	t.Helper()
+	configDir := filepath.Join(dir, "config")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := yaml.Marshal(farmsettings.Wikis{Wikis: wikis})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "wikis.yaml"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDumpPath(t *testing.T) {
+	got := dumpPath("main")
+	want := "/mediawiki/config/backup/db_main.sql"
+	if got != want {
+		t.Errorf("dumpPath(\"main\") = %q, want %q", got, want)
+	}
+
+	got = dumpPath("wiki2")
+	want = "/mediawiki/config/backup/db_wiki2.sql"
+	if got != want {
+		t.Errorf("dumpPath(\"wiki2\") = %q, want %q", got, want)
+	}
+}
+
+func TestGetWikiIDs(t *testing.T) {
+	dir := t.TempDir()
+	wikis := []farmsettings.Wiki{
+		{ID: "main", URL: "localhost", NAME: "main"},
+		{ID: "wiki2", URL: "localhost/wiki2", NAME: "wiki2"},
+	}
+	writeWikisYaml(t, dir, wikis)
+
+	t.Run("returns all wikis", func(t *testing.T) {
+		ids, err := getWikiIDs(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(ids) != 2 || ids[0] != "main" || ids[1] != "wiki2" {
+			t.Errorf("got %v, want [main wiki2]", ids)
+		}
+	})
+
+	t.Run("missing wikis.yaml", func(t *testing.T) {
+		emptyDir := t.TempDir()
+		_, err := getWikiIDs(emptyDir)
+		if err == nil {
+			t.Fatal("expected error for missing wikis.yaml")
+		}
+	})
+}
+
+func TestGetWikiIDsForRestore(t *testing.T) {
+	dir := t.TempDir()
+	wikis := []farmsettings.Wiki{
+		{ID: "main", URL: "localhost", NAME: "main"},
+		{ID: "wiki2", URL: "localhost/wiki2", NAME: "wiki2"},
+	}
+	writeWikisYaml(t, dir, wikis)
+
+	t.Run("all dumps present", func(t *testing.T) {
+		// Create per-wiki dump files in config/backup/
+		backupDir := filepath.Join(dir, "config", "backup")
+		if err := os.MkdirAll(backupDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		for _, id := range []string{"main", "wiki2"} {
+			f := filepath.Join(backupDir, "db_"+id+".sql")
+			if err := os.WriteFile(f, []byte("-- dump"), 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		ids, err := getWikiIDsForRestore(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(ids) != 2 {
+			t.Errorf("got %d wiki IDs, want 2", len(ids))
+		}
+	})
+
+	t.Run("no dump files returns error", func(t *testing.T) {
+		noDumpsDir := t.TempDir()
+		writeWikisYaml(t, noDumpsDir, wikis)
+
+		_, err := getWikiIDsForRestore(noDumpsDir)
+		if err == nil {
+			t.Fatal("expected error when no dump files found")
+		}
+	})
+
+	t.Run("missing wikis.yaml returns error", func(t *testing.T) {
+		emptyDir := t.TempDir()
+		_, err := getWikiIDsForRestore(emptyDir)
+		if err == nil {
+			t.Fatal("expected error for missing wikis.yaml")
+		}
+	})
+}

--- a/cmd/backup/create.go
+++ b/cmd/backup/create.go
@@ -16,11 +16,11 @@ func createBackupCmdCreate() *cobra.Command {
 	createBackupCmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a backup",
-		Long: `Create a new backup snapshot of the Canasta installation. This dumps the
-database, stages configuration files, extensions, images, skins, and
-public_assets into a Docker volume, along with .env,
-docker-compose.override.yml, and my.cnf (if present), then uploads the
-snapshot to the backup repository with the specified tag.`,
+		Long: `Create a new backup snapshot of the Canasta installation. This dumps each
+wiki's database (read from wikis.yaml), stages configuration files,
+extensions, images, skins, and public_assets into a Docker volume, along
+with .env, docker-compose.override.yml, and my.cnf (if present), then
+uploads the snapshot to the backup repository with the specified tag.`,
 		Example: `  # Create a backup with a descriptive tag
   canasta backup create -i myinstance -t before-upgrade`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -40,11 +40,27 @@ func takeSnapshot(tag string) error {
 		return err
 	}
 
-	_, err = orch.ExecWithError(instance.Path, "web", fmt.Sprintf("mysqldump -h db -u root -p%s --databases %s > %s", EnvVariables["MYSQL_PASSWORD"], EnvVariables["WG_DB_NAME"], mysqldumpPath))
+	wikiIDs, err := getWikiIDs(instance.Path)
 	if err != nil {
-		return fmt.Errorf("mysqldump failed: %w", err)
+		return err
 	}
-	logging.Print("mysqldump mediawiki completed")
+
+	// Create the backup directory inside the container for database dumps
+	_, err = orch.ExecWithError(instance.Path, "web", "mkdir -p /mediawiki/config/backup")
+	if err != nil {
+		return fmt.Errorf("failed to create backup directory: %w", err)
+	}
+
+	for _, id := range wikiIDs {
+		logging.Print(fmt.Sprintf("Dumping database for wiki '%s'...", id))
+		cmd := fmt.Sprintf("mysqldump -h db -u root -p%s --databases %s > %s",
+			EnvVariables["MYSQL_PASSWORD"], id, dumpPath(id))
+		_, err = orch.ExecWithError(instance.Path, "web", cmd)
+		if err != nil {
+			return fmt.Errorf("mysqldump failed for wiki '%s': %w", id, err)
+		}
+	}
+	logging.Print("Database dumps completed")
 
 	volumes := make(map[string]string)
 	for _, dir := range []string{"config", "extensions", "images", "skins", "public_assets"} {
@@ -64,6 +80,10 @@ func takeSnapshot(tag string) error {
 		return err
 	}
 	fmt.Print(output)
+
+	// Clean up the backup directory containing database dumps
+	os.RemoveAll(filepath.Join(instance.Path, "config", "backup"))
+
 	fmt.Println("Backup completed")
 	return nil
 }


### PR DESCRIPTION
## Summary

Closes #263.

- Replace single `mysqldump`/`mysql` calls with per-wiki loops, reading wiki IDs from `config/wikis.yaml` via `farmsettings.ReadWikisYaml()`
- Store per-wiki dump files in `config/backup/db_{wikiId}.sql` (reserved subdirectory to avoid filename collisions)
- Use `--databases` flag in mysqldump so each dump is self-contained with `CREATE DATABASE` and `USE` statements
- Auto-detect which wikis have dump files on restore and restore each
- Remove dependency on `WG_DB_NAME` entirely
- Add unit tests for `getWikiIDs`, `getWikiIDsForRestore`, and `dumpPath`

## Test plan

- [ ] Build and run `go test ./cmd/backup/...`
- [ ] Create a wiki farm backup: `canasta backup create -t farm-test`
- [ ] Verify per-wiki dumps in snapshot: `canasta backup files -s <id>` shows `db_main.sql`, `db_wiki2.sql`, etc. in `config/backup/`
- [ ] Restore full farm: `canasta backup restore -s <id> --skip-safety-backup`