### PR TITLE
Remove backup staging volume when deleting installation

### DIFF
--- a/internal/orchestrators/compose.go
+++ b/internal/orchestrators/compose.go
@@ -229,12 +229,20 @@ func (c *ComposeOrchestrator) Destroy(installPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	var output string
 	if compose.Path != "" {
-		err, output := execute.Run(installPath, compose.Path, "down", "-v")
+		err, output = execute.Run(installPath, compose.Path, "down", "-v")
+	} else {
+		err, output = execute.Run(installPath, "docker", "compose", "down", "-v")
+	}
+	if err != nil {
 		return output, err
 	}
-	err, output := execute.Run(installPath, "docker", "compose", "down", "-v")
-	return output, err
+
+	// Remove the backup staging volume (not part of docker-compose.yml)
+	execute.Run("", "docker", "volume", "rm", backupVolumeName(installPath))
+
+	return output, nil
 }
 
 func (c *ComposeOrchestrator) ExecWithError(installPath, service, command string) (string, error) {


### PR DESCRIPTION
## Summary

Closes #270.

The backup staging volume (`canasta-backup-{dirname}`) is created dynamically via `docker volume create` during backup operations and is not part of `docker-compose.yml`. As a result, `docker compose down -v` does not remove it when an installation is deleted, leaving orphaned volumes.

This adds an explicit `docker volume rm` call in `Destroy()` after the compose teardown.

Also refactors `Destroy()` to use the `if/else` pattern for the custom compose path, matching `Start()`, `Stop()`, `Build()`, and other methods. The original code used early returns from both branches, which prevented adding any post-teardown cleanup logic.

## Test plan

- [x] Create an installation and run a backup (to create the staging volume)
- [x] Delete the installation with `canasta delete`
- [x] Verify `docker volume ls | grep canasta-backup` shows no orphaned volume