### PR TITLE
Fix create command destroying existing installation on duplicate ID

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -79,6 +79,11 @@ instead of running the installer, or enable development mode with Xdebug.`,
 				return fmt.Errorf("Canasta instance ID should not contain spaces or non-ASCII characters, only alphanumeric characters are allowed")
 			}
 
+			// Check for duplicate ID before doing any work
+			if _, err := config.GetDetails(canastaInfo.Id); err == nil {
+				return fmt.Errorf("Canasta installation with ID '%s' already exists", canastaInfo.Id)
+			}
+
 			// Validate --dev-tag and --build-from are mutually exclusive
 			if devTag != "latest" && buildFromPath != "" {
 				return fmt.Errorf("--dev-tag and --build-from are mutually exclusive")
@@ -193,9 +198,6 @@ func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiI
 	defer func() {
 		done <- struct{}{}
 	}()
-	if _, err := config.GetDetails(canastaInfo.Id); err == nil {
-		return fmt.Errorf("Canasta installation with the ID already exist!")
-	}
 
 	// Determine the base image to use
 	var baseImage string


### PR DESCRIPTION
## Summary

- Moves the duplicate instance ID check from inside `createCanasta()` to the `RunE` validation block, so it returns an error immediately without reaching the cleanup handler
- Previously, the "ID already exists" error was treated as a partial-installation failure, causing `DeleteConfigAndContainers` to destroy the existing working installation

Fixes #274

## Test plan

- [ ] `canasta create -i existing-id ...` with an existing ID prints error and exits without modifying the existing installation
- [ ] `canasta create -i new-id ...` still works normally
- [ ] A failed installation mid-setup (e.g. bad domain) still cleans up as before
- [ ] `go test ./...` passes