### PR TITLE
Improve backup command completion and error messages

### DIFF
--- a/cmd/backup/create.go
+++ b/cmd/backup/create.go
@@ -24,7 +24,11 @@ uploads the snapshot to the backup repository with the specified tag.`,
 		Example: `  # Create a backup with a descriptive tag
   canasta backup create -i myinstance -t before-upgrade`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return takeSnapshot(tag)
+			if err := takeSnapshot(tag); err != nil {
+				return err
+			}
+			fmt.Println("Backup completed")
+			return nil
 		},
 	}
 
@@ -84,6 +88,5 @@ func takeSnapshot(tag string) error {
 	// Clean up the backup directory containing database dumps
 	os.RemoveAll(filepath.Join(instance.Path, "config", "backup"))
 
-	fmt.Println("Backup completed")
 	return nil
 }

--- a/cmd/backup/restore.go
+++ b/cmd/backup/restore.go
@@ -94,6 +94,7 @@ func restoreSnapshot(snapshotId string, skipBeforeSnapshot bool) error {
 	os.RemoveAll(filepath.Join(instance.Path, "config", "backup"))
 
 	logging.Print("Database restore completed")
+	fmt.Println("Restore completed")
 	return nil
 }
 

--- a/internal/orchestrators/compose.go
+++ b/internal/orchestrators/compose.go
@@ -369,6 +369,9 @@ func (c *ComposeOrchestrator) RunBackup(installPath, envPath string, volumes map
 
 	err, output = execute.Run(installPath, cmdArgs[0], cmdArgs[1:]...)
 	if err != nil {
+		if strings.Contains(output, "repository does not exist") {
+			return output, fmt.Errorf("backup repository not found. Run 'canasta backup init' to create it")
+		}
 		return output, fmt.Errorf("restic command failed: %s", output)
 	}
 	return output, nil


### PR DESCRIPTION
## Summary

- Moves "Backup completed" message from `takeSnapshot()` to the `backup create` command's `RunE`, so `backup restore` no longer incorrectly prints it during the safety backup
- Adds "Restore completed" message to the `backup restore` command
- Shows a helpful hint to run `canasta backup init` when the backup repository doesn't exist, instead of the raw restic error

Fixes #276

## Test plan

- [ ] `canasta backup create -t tag` prints "Backup completed" at the end
- [ ] `canasta backup restore -s <id>` prints "Restore completed" at the end (not "Backup completed")
- [ ] Running any backup command before `backup init` shows: "backup repository not found. Run 'canasta backup init' to create it"
- [ ] `go test ./...` passes