### PR TITLE
Improve backup schedule: use instance ID, add list/remove subcommands

### DIFF
--- a/cmd/backup/schedule.go
+++ b/cmd/backup/schedule.go
@@ -12,22 +12,100 @@ import (
 
 func scheduleCmdCreate() *cobra.Command {
 	scheduleCmd := &cobra.Command{
-		Use:   "schedule [cron expression]",
-		Short: "Schedule a recurring backup",
+		Use:   "schedule",
+		Short: "Manage scheduled backups",
+		Long:  `Manage recurring backup schedules using crontab.`,
+	}
+
+	scheduleCmd.AddCommand(scheduleSetCmdCreate())
+	scheduleCmd.AddCommand(scheduleListCmdCreate())
+	scheduleCmd.AddCommand(scheduleRemoveCmdCreate())
+	return scheduleCmd
+}
+
+func scheduleSetCmdCreate() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set [cron expression]",
+		Short: "Set a recurring backup schedule",
 		Long: `Schedule recurring backups using a cron expression. This adds or
 updates a crontab entry that runs 'canasta backup create' on the
 specified schedule. Backup output is logged to /var/log/canasta-backup.log.`,
 		Example: `  # Schedule daily backups at 2:00 AM
-  canasta backup schedule -i myinstance "0 2 * * *"
+  canasta backup schedule set -i myinstance "0 2 * * *"
 
   # Schedule hourly backups
-  canasta backup schedule -i myinstance "0 * * * *"`,
-		Args:  cobra.MinimumNArgs(1),
+  canasta backup schedule set -i myinstance "0 * * * *"`,
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return scheduleBackup(strings.Join(args, " "))
 		},
 	}
-	return scheduleCmd
+}
+
+func scheduleListCmdCreate() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "Show the backup schedule",
+		Long:  `Show the current backup schedule for this installation, if one exists.`,
+		Example: `  canasta backup schedule list -i myinstance`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listSchedule()
+		},
+	}
+}
+
+func scheduleRemoveCmdCreate() *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove",
+		Short: "Remove a scheduled backup",
+		Long:  `Remove the crontab entry for recurring backups of this installation.`,
+		Example: `  canasta backup schedule remove -i myinstance`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return unscheduleBackup()
+		},
+	}
+}
+
+// jobIdentifierForInstance returns the string used to identify a crontab entry for a given instance ID.
+func jobIdentifierForInstance(id string) string {
+	return fmt.Sprintf("backup create -i %s", id)
+}
+
+// jobIdentifier returns the string used to identify a crontab entry for this instance.
+func jobIdentifier() string {
+	return jobIdentifierForInstance(instance.Id)
+}
+
+// readCrontab returns the current crontab contents as non-empty lines.
+func readCrontab() ([]string, error) {
+	out, err := exec.Command("crontab", "-l").Output()
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			if exitError.ExitCode() == 1 {
+				return nil, nil
+			}
+		}
+		return nil, fmt.Errorf("failed to read crontab: %w", err)
+	}
+	var lines []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.TrimSpace(line) != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines, nil
+}
+
+// writeCrontab writes the given lines as the new crontab.
+func writeCrontab(lines []string) error {
+	newCrontab := strings.Join(lines, "\n") + "\n"
+	cmd := exec.Command("crontab", "-")
+	cmd.Stdin = strings.NewReader(newCrontab)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to update crontab: %s, %w", string(output), err)
+	}
+	return nil
 }
 
 func scheduleBackup(cronExpression string) error {
@@ -40,36 +118,26 @@ func scheduleBackup(cronExpression string) error {
 		return fmt.Errorf("failed to get executable path: %w", err)
 	}
 
-	cwd := instance.Path
-	cmdStr := fmt.Sprintf("%s cd %s && %s backup create --tag scheduled-$(date +\\%%Y\\%%m\\%%d\\%%H\\%%M\\%%S) >> /var/log/canasta-backup.log 2>&1", cronExpression, cwd, executable)
+	cmdStr := fmt.Sprintf("%s %s backup create -i %s --tag scheduled-$(date +\\%%Y\\%%m\\%%d\\%%H\\%%M\\%%S) >> /var/log/canasta-backup.log 2>&1", cronExpression, executable, instance.Id)
 
 	logging.Print(fmt.Sprintf("Scheduling backup with cron: %s", cronExpression))
 
-	out, err := exec.Command("crontab", "-l").Output()
-	currentCrontab := string(out)
+	lines, err := readCrontab()
 	if err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
-			if exitError.ExitCode() != 1 {
-				return fmt.Errorf("failed to read crontab: %w", err)
-			}
-			currentCrontab = ""
-		}
+		return err
 	}
 
-	// Parse and update crontab if already scheduled
-	lines := strings.Split(currentCrontab, "\n")
 	var newLines []string
 	updated := false
-	jobIdentifier := fmt.Sprintf("cd %s &&", cwd)
+	identifier := jobIdentifier()
 
 	for _, line := range lines {
-		if strings.TrimSpace(line) == "" {
-			continue
-		}
-		if strings.Contains(line, jobIdentifier) && strings.Contains(line, "backup create") {
+		if strings.Contains(line, identifier) {
+			oldCron := cronFromLine(line)
+			fmt.Printf("Replacing existing schedule '%s' with '%s' for instance '%s'.\n", oldCron, cronExpression, instance.Id)
+			fmt.Println("Tip: to schedule multiple times, combine them in one expression (e.g., \"0 0 * * 2,5\" for Tuesdays and Fridays).")
 			newLines = append(newLines, cmdStr)
 			updated = true
-			logging.Print("Updated existing backup schedule.")
 		} else {
 			newLines = append(newLines, line)
 		}
@@ -77,20 +145,92 @@ func scheduleBackup(cronExpression string) error {
 
 	if !updated {
 		newLines = append(newLines, cmdStr)
-		logging.Print("Added new backup schedule.")
-	}
-	
-	newCrontab := strings.Join(newLines, "\n") + "\n"
-
-	cmd := exec.Command("crontab", "-")
-	cmd.Stdin = strings.NewReader(newCrontab)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to update crontab: %s, %w", string(output), err)
 	}
 
-	logging.Print("Backup scheduled successfully.")
+	if err := writeCrontab(newLines); err != nil {
+		return err
+	}
+
+	fmt.Println("Backup scheduled successfully.")
 	return nil
+}
+
+func listSchedule() error {
+	lines, err := readCrontab()
+	if err != nil {
+		return err
+	}
+
+	identifier := jobIdentifier()
+	for _, line := range lines {
+		if strings.Contains(line, identifier) {
+			fmt.Printf("Instance '%s' is scheduled for backup at: %s\n", instance.Id, cronFromLine(line))
+			return nil
+		}
+	}
+
+	return fmt.Errorf("no backup schedule found for instance '%s'", instance.Id)
+}
+
+func unscheduleBackup() error {
+	removed, err := RemoveSchedule(instance.Id)
+	if err != nil {
+		return err
+	}
+	if !removed {
+		return fmt.Errorf("no backup schedule found for instance '%s'", instance.Id)
+	}
+	fmt.Println("Backup schedule removed.")
+	return nil
+}
+
+// RemoveSchedule removes any crontab entry for the given instance ID.
+// Returns true if an entry was found and removed, false if none existed.
+// This is exported so that the delete command can clean up schedules.
+func RemoveSchedule(id string) (bool, error) {
+	lines, err := readCrontab()
+	if err != nil {
+		return false, err
+	}
+
+	var newLines []string
+	found := false
+	identifier := jobIdentifierForInstance(id)
+
+	for _, line := range lines {
+		if strings.Contains(line, identifier) {
+			found = true
+		} else {
+			newLines = append(newLines, line)
+		}
+	}
+
+	if !found {
+		return false, nil
+	}
+
+	if len(newLines) == 0 {
+		// No entries left — remove the crontab entirely
+		cmd := exec.Command("crontab", "-r")
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return false, fmt.Errorf("failed to remove crontab: %s, %w", string(output), err)
+		}
+	} else {
+		if err := writeCrontab(newLines); err != nil {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+// cronFromLine extracts the cron expression (first 5 fields) from a crontab line.
+func cronFromLine(line string) string {
+	fields := strings.Fields(line)
+	if len(fields) >= 5 {
+		return strings.Join(fields[:5], " ")
+	}
+	return line
 }
 
 func validateCron(cron string) error {

--- a/cmd/backup/schedule_test.go
+++ b/cmd/backup/schedule_test.go
@@ -1,0 +1,72 @@
+package backup
+
+import "testing"
+
+func TestValidateCron(t *testing.T) {
+	tests := []struct {
+		name    string
+		cron    string
+		wantErr bool
+	}{
+		{"valid daily", "0 2 * * *", false},
+		{"valid hourly", "0 * * * *", false},
+		{"valid specific", "30 4 1 1 0", false},
+		{"too few fields", "0 2 * *", true},
+		{"too many fields", "0 2 * * * *", true},
+		{"empty string", "", true},
+		{"invalid character", "0 2 * * MON", true},
+		{"special character @", "@ daily", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCron(tt.cron)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateCron(%q) error = %v, wantErr %v", tt.cron, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCronFromLine(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{"full crontab line", "0 2 * * * /usr/local/bin/canasta backup create -i wiki --tag test", "0 2 * * *"},
+		{"just cron fields", "0 2 * * *", "0 2 * * *"},
+		{"short line", "foo bar", "foo bar"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cronFromLine(tt.line)
+			if got != tt.want {
+				t.Errorf("cronFromLine(%q) = %q, want %q", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateCronEdgeCases(t *testing.T) {
+	tests := []struct {
+		name    string
+		cron    string
+		wantErr bool
+	}{
+		{"ranges", "0-30 * * * *", false},
+		{"lists", "0,15,30,45 * * * *", false},
+		{"steps", "*/5 * * * *", false},
+		{"combined", "0-30/5 1,2,3 * * *", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCron(tt.cron)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateCron(%q) error = %v, wantErr %v", tt.cron, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	backupCmd "github.com/CanastaWiki/Canasta-CLI/cmd/backup"
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
 	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
@@ -90,6 +91,13 @@ func Delete(instance config.Installation) error {
 	//Delete config files
 	if _, err := orchestrators.DeleteConfig(instance.Path); err != nil {
 		return err
+	}
+
+	// Remove any scheduled backup crontab entry
+	if removed, err := backupCmd.RemoveSchedule(instance.Id); err != nil {
+		logging.Print(fmt.Sprintf("Warning: could not clean up backup schedule: %v\n", err))
+	} else if removed {
+		logging.Print("Removed backup schedule.\n")
 	}
 
 	//Deleting installation details from conf.json

--- a/docs/guide/backup.md
+++ b/docs/guide/backup.md
@@ -6,10 +6,12 @@ Canasta includes backup and restore support powered by [restic](https://restic.n
 
 Each backup includes:
 
-- **Database** — a full MySQL dump
+- **Database** — a full MySQL dump of each wiki's database
 - **Configuration** — the `config/` directory (Caddyfile, settings, wikis.yaml)
 - **Extensions and skins** — the `extensions/` and `skins/` directories
 - **Uploaded files** — the `images/` directory
+- **Public assets** — the `public_assets/` directory
+- **Environment and overrides** — `.env`, `docker-compose.override.yml`, and `my.cnf` (if present)
 
 ## Setup
 
@@ -103,10 +105,24 @@ Set up automatic backups using a cron expression:
 
 ```bash
 # Daily at 2:00 AM
-canasta backup schedule -i myinstance "0 2 * * *"
+canasta backup schedule set -i myinstance "0 2 * * *"
 
 # Every 6 hours
-canasta backup schedule -i myinstance "0 */6 * * *"
+canasta backup schedule set -i myinstance "0 */6 * * *"
+```
+
+If you reschedule with a new expression, the existing schedule is replaced. To schedule multiple times, combine them in one expression (e.g., `"0 0 * * 2,5"` for Tuesdays and Fridays).
+
+To view the current schedule:
+
+```bash
+canasta backup schedule list -i myinstance
+```
+
+To remove a scheduled backup:
+
+```bash
+canasta backup schedule remove -i myinstance
 ```
 
 ### Repository maintenance


### PR DESCRIPTION
## Summary

- Replaces `cd <path> && canasta backup create` with `canasta backup create -i <id>` in the generated crontab entry, making the schedule resilient to installation relocations
- Restructures `schedule` as a parent command with `set`, `list`, and `remove` subcommands
- Extracts shared crontab helpers (`readCrontab`, `writeCrontab`, `jobIdentifierForInstance`) to avoid duplication
- When replacing an existing schedule, prints a warning showing the old and new cron expressions, plus a tip about combining times in one expression
- `schedule remove` removes the crontab entry for the instance, or clears the crontab entirely if no entries remain
- `canasta delete` now cleans up any backup schedule crontab entry for the deleted instance
- Updates the backup guide documentation to reflect the new schedule subcommands and the full list of backed-up files
- Adds tests for cron validation and `cronFromLine`

Fixes #262

## Test plan

- [x] `canasta backup schedule set -i wikifarm "0 2 * * *"` — verify `crontab -l` shows `-i wikifarm`
- [x] `canasta backup schedule list -i wikifarm` — shows current schedule
- [x] `canasta backup schedule set -i wikifarm "0 3 * * *"` — verify warning about replacing, entry updated not duplicated
- [x] `canasta backup schedule remove -i wikifarm` — verify entry is removed from crontab
- [x] `canasta backup schedule remove -i wikifarm` again — shows "no backup schedule found"
- [x] Set a schedule, then `canasta delete -i wikifarm` — verify crontab entry is cleaned up
- [x] `go test ./...` passes