### PR TITLE
Add --sitemap flag to canasta create and canasta add

### DIFF
--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -811,7 +811,7 @@ func MigrateToNewVersion(installPath string) error {
 
 	// Create the wikis.yaml file using farmsettings.GenerateWikisYaml
 	// Pass empty string for siteName to default to id
-	_, err = farmsettings.GenerateWikisYaml(yamlPath, id, mwSiteServer, "")
+	_, err = farmsettings.GenerateWikisYaml(yamlPath, id, mwSiteServer, "", false)
 	if err != nil {
 		return err
 	}

--- a/internal/farmsettings/farmsettings.go
+++ b/internal/farmsettings/farmsettings.go
@@ -11,9 +11,10 @@ import (
 )
 
 type Wiki struct {
-	ID   string `yaml:"id"`
-	URL  string `yaml:"url"`
-	NAME string `yaml:"name"`
+	ID      string `yaml:"id"`
+	URL     string `yaml:"url"`
+	NAME    string `yaml:"name"`
+	Sitemap bool   `yaml:"sitemap,omitempty"`
 }
 
 type Wikis struct {
@@ -39,12 +40,12 @@ func ValidateWikiID(wikiID string) error {
 	return nil
 }
 
-func GenerateWikisYaml(filePath, wikiID, domain, siteName string) (string, error) {
+func GenerateWikisYaml(filePath, wikiID, domain, siteName string, sitemap bool) (string, error) {
 	if siteName == "" {
 		siteName = wikiID
 	}
 	wikis := Wikis{}
-	wikis.Wikis = append(wikis.Wikis, Wiki{ID: wikiID, URL: domain, NAME: siteName})
+	wikis.Wikis = append(wikis.Wikis, Wiki{ID: wikiID, URL: domain, NAME: siteName, Sitemap: sitemap})
 
 	out, err := yaml.Marshal(&wikis)
 	if err != nil {
@@ -160,7 +161,7 @@ func WikiUrlExists(installPath, domain, wikiPath string) (bool, error) {
 	return false, nil
 }
 
-func AddWiki(wikiID, installPath, domain, wikiPath, siteName string) error {
+func AddWiki(wikiID, installPath, domain, wikiPath, siteName string, sitemap bool) error {
 	// Get the absolute path to the wikis.yaml file
 	filePath := filepath.Join(installPath, "config", "wikis.yaml")
 
@@ -189,7 +190,7 @@ func AddWiki(wikiID, installPath, domain, wikiPath, siteName string) error {
 	}
 
 	// Create a new wiki
-	newWiki := Wiki{ID: wikiID, URL: filepath.Join(domain, wikiPath), NAME: siteName}
+	newWiki := Wiki{ID: wikiID, URL: filepath.Join(domain, wikiPath), NAME: siteName, Sitemap: sitemap}
 
 	// Append the new wiki to the list of wikis
 	wikis.Wikis = append(wikis.Wikis, newWiki)


### PR DESCRIPTION
## Summary

- Add `sitemap` boolean field to `Wiki` struct in `wikis.yaml` (defaults to `false`, omitted when false)
- Add `--sitemap` flag to `canasta create`: sets `sitemap: true` for the first wiki and `MW_ENABLE_SITEMAP_GENERATOR=true` in `.env`
- Add `--sitemap` flag to `canasta add`: sets `sitemap: true` for the new wiki and enables the global generator if not already set
- To change the sitemap setting for an existing wiki, edit `wikis.yaml` directly

Private wikis are not exposed to search engines by default since `sitemap` defaults to `false`.

## Example

```yaml
# wikis.yaml after: canasta create --sitemap -w public ...  then canasta add -w private ...
wikis:
- id: public
  url: public.example.com
  name: public
  sitemap: true
- id: private
  url: private.example.com
  name: private
  # sitemap omitted = false
```

## Depends on

- CanastaWiki/CanastaBase#99
- CanastaWiki/Canasta-DockerCompose#95

## Test plan

- [ ] `canasta create --sitemap -i test -w mywiki -n example.com -a admin` → verify `.env` has `MW_ENABLE_SITEMAP_GENERATOR=true` and `wikis.yaml` has `sitemap: true`
- [ ] `canasta create -i test2 -w mywiki -n example.com -a admin` (without --sitemap) → verify `.env` has no `MW_ENABLE_SITEMAP_GENERATOR` and `wikis.yaml` has no `sitemap` field
- [ ] `canasta add --sitemap -i test2 -w wiki2 -u wiki2.example.com -a admin` → verify `wikis.yaml` has `sitemap: true` for wiki2 and `.env` now has `MW_ENABLE_SITEMAP_GENERATOR=true`
- [ ] `go test ./...` passes

Fixes #281