### PR TITLE
Add canasta sitemap generate and remove commands

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -12,6 +12,7 @@ import (
 	removeCmd "github.com/CanastaWiki/Canasta-CLI/cmd/remove"
 	restartCmd "github.com/CanastaWiki/Canasta-CLI/cmd/restart"
 	backupCmd "github.com/CanastaWiki/Canasta-CLI/cmd/backup"
+	sitemapCmd "github.com/CanastaWiki/Canasta-CLI/cmd/sitemap"
 	skinCmd "github.com/CanastaWiki/Canasta-CLI/cmd/skin"
 	startCmd "github.com/CanastaWiki/Canasta-CLI/cmd/start"
 	stopCmd "github.com/CanastaWiki/Canasta-CLI/cmd/stop"
@@ -68,6 +69,7 @@ func init() {
 	rootCmd.AddCommand(maintenanceCmd.NewCmdCreate())
 	rootCmd.AddCommand(restartCmd.NewCmdCreate())
 	rootCmd.AddCommand(backupCmd.NewCmdCreate())
+	rootCmd.AddCommand(sitemapCmd.NewCmdCreate())
 	rootCmd.AddCommand(skinCmd.NewCmdCreate())
 	rootCmd.AddCommand(startCmd.NewCmdCreate())
 	rootCmd.AddCommand(stopCmd.NewCmdCreate())

--- a/cmd/sitemap/generate.go
+++ b/cmd/sitemap/generate.go
@@ -55,13 +55,6 @@ func runGenerate(wikiID string) error {
 	}
 	scheme := extractScheme(envVars["MW_SITE_SERVER"])
 
-	// Get wgScriptPath from inside the container
-	scriptPathCmd := `php /getMediawikiSettings.php --variable="wgScriptPath" --format="string"`
-	scriptPath, err := orch.ExecWithError(instance.Path, "web", scriptPathCmd)
-	if err != nil {
-		return fmt.Errorf("failed to get wgScriptPath: %w", err)
-	}
-
 	// Determine which wikis to generate for
 	type wikiInfo struct {
 		id         string
@@ -108,8 +101,8 @@ func runGenerate(wikiID string) error {
 		// Run generateSitemap.php
 		fmt.Printf("Generating sitemap for wiki '%s'...\n", wiki.id)
 		genCmd := fmt.Sprintf(
-			"php /mediawiki/maintenance/generateSitemap.php --wiki=%s --fspath=%s --urlpath=%s/public_assets/sitemap --compress yes --server=%s --skip-redirects --identifier=%s",
-			wiki.id, fspath, scriptPath, serverURL, wiki.id,
+			"php maintenance/generateSitemap.php --wiki=%s --fspath=%s --urlpath=/public_assets/sitemap --compress yes --server=%s --skip-redirects --identifier=%s",
+			wiki.id, fspath, serverURL, wiki.id,
 		)
 		if err := orch.ExecStreaming(instance.Path, "web", genCmd); err != nil {
 			return fmt.Errorf("failed to generate sitemap for wiki '%s': %w", wiki.id, err)

--- a/cmd/sitemap/generate.go
+++ b/cmd/sitemap/generate.go
@@ -1,0 +1,138 @@
+package sitemap
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
+	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
+)
+
+func generateCmdCreate() *cobra.Command {
+	var wikiID string
+
+	cmd := &cobra.Command{
+		Use:   "generate",
+		Short: "Generate sitemaps for one or all wikis",
+		Long: `Generate XML sitemaps for wikis in a Canasta installation. If --wiki is
+specified, generates a sitemap for that wiki only. Otherwise, generates
+sitemaps for all wikis in the instance. Enabling sitemaps also starts
+automatic background regeneration.`,
+		Example: `  # Generate sitemap for a specific wiki
+  canasta sitemap generate -i myinstance -w mywiki
+
+  # Generate sitemaps for all wikis
+  canasta sitemap generate -i myinstance`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGenerate(wikiID)
+		},
+	}
+
+	cmd.Flags().StringVarP(&wikiID, "wiki", "w", "", "Wiki ID (omit to generate for all wikis)")
+
+	return cmd
+}
+
+func runGenerate(wikiID string) error {
+	// Check containers are running
+	if err := orch.CheckRunningStatus(instance); err != nil {
+		return fmt.Errorf("containers are not running: %w", err)
+	}
+
+	yamlPath := filepath.Join(instance.Path, "config", "wikis.yaml")
+	ids, serverNames, paths, err := farmsettings.ReadWikisYaml(yamlPath)
+	if err != nil {
+		return fmt.Errorf("failed to read wikis.yaml: %w", err)
+	}
+
+	// Get URL scheme from MW_SITE_SERVER in .env
+	envPath := filepath.Join(instance.Path, ".env")
+	envVars, err := canasta.GetEnvVariable(envPath)
+	if err != nil {
+		return fmt.Errorf("failed to read .env: %w", err)
+	}
+	scheme := extractScheme(envVars["MW_SITE_SERVER"])
+
+	// Get wgScriptPath from inside the container
+	scriptPathCmd := `php /getMediawikiSettings.php --variable="wgScriptPath" --format="string"`
+	scriptPath, err := orch.ExecWithError(instance.Path, "web", scriptPathCmd)
+	if err != nil {
+		return fmt.Errorf("failed to get wgScriptPath: %w", err)
+	}
+
+	// Determine which wikis to generate for
+	type wikiInfo struct {
+		id         string
+		serverName string
+		path       string
+	}
+	var wikis []wikiInfo
+
+	if wikiID != "" {
+		// Validate wiki exists
+		found := false
+		for idx, id := range ids {
+			if id == wikiID {
+				wikis = append(wikis, wikiInfo{id: id, serverName: serverNames[idx], path: paths[idx]})
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("wiki '%s' not found in wikis.yaml", wikiID)
+		}
+	} else {
+		// All wikis
+		for idx, id := range ids {
+			wikis = append(wikis, wikiInfo{id: id, serverName: serverNames[idx], path: paths[idx]})
+		}
+	}
+
+	for _, wiki := range wikis {
+		// Build the server URL
+		serverURL := scheme + "://" + wiki.serverName
+		if wiki.path != "/" {
+			serverURL += wiki.path
+		}
+
+		fspath := "/mediawiki/public_assets/" + wiki.id + "/sitemap"
+
+		// Create the sitemap directory
+		mkdirCmd := fmt.Sprintf("mkdir -p %s && chown www-data:www-data %s", fspath, fspath)
+		if _, err := orch.ExecWithError(instance.Path, "web", mkdirCmd); err != nil {
+			return fmt.Errorf("failed to create sitemap directory for wiki '%s': %w", wiki.id, err)
+		}
+
+		// Run generateSitemap.php
+		fmt.Printf("Generating sitemap for wiki '%s'...\n", wiki.id)
+		genCmd := fmt.Sprintf(
+			"php /mediawiki/maintenance/generateSitemap.php --wiki=%s --fspath=%s --urlpath=%s/public_assets/sitemap --compress yes --server=%s --skip-redirects --identifier=%s",
+			wiki.id, fspath, scriptPath, serverURL, wiki.id,
+		)
+		if err := orch.ExecStreaming(instance.Path, "web", genCmd); err != nil {
+			return fmt.Errorf("failed to generate sitemap for wiki '%s': %w", wiki.id, err)
+		}
+		fmt.Printf("Sitemap generated for wiki '%s'.\n", wiki.id)
+	}
+
+	// Enable MW_ENABLE_SITEMAP_GENERATOR in .env
+	if err := canasta.SaveEnvVariable(envPath, "MW_ENABLE_SITEMAP_GENERATOR", "true"); err != nil {
+		return fmt.Errorf("failed to update .env: %w", err)
+	}
+
+	fmt.Println("Sitemap generation enabled. Sitemaps will be refreshed automatically.")
+	return nil
+}
+
+// extractScheme returns the URL scheme from a server URL, defaulting to "https".
+func extractScheme(serverURL string) string {
+	if len(serverURL) >= 8 && serverURL[:8] == "https://" {
+		return "https"
+	}
+	if len(serverURL) >= 7 && serverURL[:7] == "http://" {
+		return "http"
+	}
+	return "https"
+}

--- a/cmd/sitemap/generate.go
+++ b/cmd/sitemap/generate.go
@@ -18,8 +18,8 @@ func generateCmdCreate() *cobra.Command {
 		Short: "Generate sitemaps for one or all wikis",
 		Long: `Generate XML sitemaps for wikis in a Canasta installation. If --wiki is
 specified, generates a sitemap for that wiki only. Otherwise, generates
-sitemaps for all wikis in the instance. Enabling sitemaps also starts
-automatic background regeneration.`,
+sitemaps for all wikis in the instance. Once generated, the background
+generator will automatically refresh them.`,
 		Example: `  # Generate sitemap for a specific wiki
   canasta sitemap generate -i myinstance -w mywiki
 
@@ -117,12 +117,7 @@ func runGenerate(wikiID string) error {
 		fmt.Printf("Sitemap generated for wiki '%s'.\n", wiki.id)
 	}
 
-	// Enable MW_ENABLE_SITEMAP_GENERATOR in .env
-	if err := canasta.SaveEnvVariable(envPath, "MW_ENABLE_SITEMAP_GENERATOR", "true"); err != nil {
-		return fmt.Errorf("failed to update .env: %w", err)
-	}
-
-	fmt.Println("Sitemap generation enabled. Sitemaps will be refreshed automatically.")
+	fmt.Println("Sitemaps will be refreshed automatically.")
 	return nil
 }
 

--- a/cmd/sitemap/remove.go
+++ b/cmd/sitemap/remove.go
@@ -1,0 +1,100 @@
+package sitemap
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
+	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
+)
+
+func removeCmdCreate() *cobra.Command {
+	var wikiID string
+
+	cmd := &cobra.Command{
+		Use:   "remove",
+		Short: "Remove sitemaps for one or all wikis",
+		Long: `Remove XML sitemap files for wikis in a Canasta installation. If --wiki is
+specified, removes the sitemap for that wiki only. Otherwise, removes sitemaps
+for all wikis and disables automatic background regeneration.`,
+		Example: `  # Remove sitemap for a specific wiki
+  canasta sitemap remove -i myinstance -w mywiki
+
+  # Remove sitemaps for all wikis
+  canasta sitemap remove -i myinstance`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRemove(wikiID)
+		},
+	}
+
+	cmd.Flags().StringVarP(&wikiID, "wiki", "w", "", "Wiki ID (omit to remove for all wikis)")
+
+	return cmd
+}
+
+func runRemove(wikiID string) error {
+	// Check containers are running
+	if err := orch.CheckRunningStatus(instance); err != nil {
+		return fmt.Errorf("containers are not running: %w", err)
+	}
+
+	yamlPath := filepath.Join(instance.Path, "config", "wikis.yaml")
+	ids, _, _, err := farmsettings.ReadWikisYaml(yamlPath)
+	if err != nil {
+		return fmt.Errorf("failed to read wikis.yaml: %w", err)
+	}
+
+	removingAll := wikiID == ""
+	var wikiIDs []string
+
+	if removingAll {
+		// Confirm before removing all
+		reader := bufio.NewReader(os.Stdin)
+		fmt.Print("Remove sitemaps for all wikis? [y/N] ")
+		text, _ := reader.ReadString('\n')
+		text = strings.ToLower(strings.TrimSpace(text))
+		if text != "y" {
+			fmt.Println("Operation cancelled.")
+			return nil
+		}
+		wikiIDs = ids
+	} else {
+		// Validate wiki exists
+		found := false
+		for _, id := range ids {
+			if id == wikiID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("wiki '%s' not found in wikis.yaml", wikiID)
+		}
+		wikiIDs = []string{wikiID}
+	}
+
+	for _, id := range wikiIDs {
+		fspath := "/mediawiki/public_assets/" + id + "/sitemap"
+		rmCmd := fmt.Sprintf("find %s -mindepth 1 -delete 2>/dev/null; true", fspath)
+		if _, err := orch.ExecWithError(instance.Path, "web", rmCmd); err != nil {
+			return fmt.Errorf("failed to remove sitemap files for wiki '%s': %w", id, err)
+		}
+		fmt.Printf("Removed sitemap for wiki '%s'.\n", id)
+	}
+
+	// If removing all wikis, disable the generator
+	if removingAll {
+		envPath := filepath.Join(instance.Path, ".env")
+		if err := canasta.SaveEnvVariable(envPath, "MW_ENABLE_SITEMAP_GENERATOR", "false"); err != nil {
+			return fmt.Errorf("failed to update .env: %w", err)
+		}
+		fmt.Println("Automatic sitemap generation disabled.")
+	}
+
+	return nil
+}

--- a/cmd/sitemap/remove.go
+++ b/cmd/sitemap/remove.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
 )
 
@@ -21,7 +20,7 @@ func removeCmdCreate() *cobra.Command {
 		Short: "Remove sitemaps for one or all wikis",
 		Long: `Remove XML sitemap files for wikis in a Canasta installation. If --wiki is
 specified, removes the sitemap for that wiki only. Otherwise, removes sitemaps
-for all wikis and disables automatic background regeneration.`,
+for all wikis. Once removed, the background generator will skip those wikis.`,
 		Example: `  # Remove sitemap for a specific wiki
   canasta sitemap remove -i myinstance -w mywiki
 
@@ -85,15 +84,6 @@ func runRemove(wikiID string) error {
 			return fmt.Errorf("failed to remove sitemap files for wiki '%s': %w", id, err)
 		}
 		fmt.Printf("Removed sitemap for wiki '%s'.\n", id)
-	}
-
-	// If removing all wikis, disable the generator
-	if removingAll {
-		envPath := filepath.Join(instance.Path, ".env")
-		if err := canasta.SaveEnvVariable(envPath, "MW_ENABLE_SITEMAP_GENERATOR", "false"); err != nil {
-			return fmt.Errorf("failed to update .env: %w", err)
-		}
-		fmt.Println("Automatic sitemap generation disabled.")
 	}
 
 	return nil

--- a/cmd/sitemap/sitemap.go
+++ b/cmd/sitemap/sitemap.go
@@ -1,0 +1,54 @@
+package sitemap
+
+import (
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
+	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
+)
+
+var (
+	instance   config.Installation
+	orch       orchestrators.Orchestrator
+	sitemapCmd *cobra.Command
+)
+
+func NewCmdCreate() *cobra.Command {
+	workingDir, wdErr := os.Getwd()
+	if wdErr != nil {
+		log.Fatal(wdErr)
+	}
+	instance.Path = workingDir
+
+	sitemapCmd = &cobra.Command{
+		Use:   "sitemap",
+		Short: "Manage sitemaps for a Canasta instance",
+		Long: `Generate or remove XML sitemaps for wikis in a Canasta installation.
+Sitemaps improve search engine indexing by listing all pages on your wiki.
+Use "canasta sitemap generate" to create sitemaps and "canasta sitemap remove"
+to delete them.`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			instance, err = canasta.CheckCanastaId(instance)
+			if err != nil {
+				return err
+			}
+			orch, err = orchestrators.New(instance.Orchestrator)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	sitemapCmd.AddCommand(generateCmdCreate())
+	sitemapCmd.AddCommand(removeCmdCreate())
+
+	sitemapCmd.PersistentFlags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
+
+	return sitemapCmd
+}

--- a/cmd/sitemap/sitemap_test.go
+++ b/cmd/sitemap/sitemap_test.go
@@ -80,4 +80,12 @@ func TestRemoveCmd(t *testing.T) {
 	if wikiFlag.Shorthand != "w" {
 		t.Errorf("expected wiki shorthand 'w', got %q", wikiFlag.Shorthand)
 	}
+
+	yesFlag := cmd.Flags().Lookup("yes")
+	if yesFlag == nil {
+		t.Error("expected flag 'yes'")
+	}
+	if yesFlag.Shorthand != "y" {
+		t.Errorf("expected yes shorthand 'y', got %q", yesFlag.Shorthand)
+	}
 }

--- a/cmd/sitemap/sitemap_test.go
+++ b/cmd/sitemap/sitemap_test.go
@@ -1,0 +1,83 @@
+package sitemap
+
+import "testing"
+
+func TestExtractScheme(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"https URL", "https://example.com", "https"},
+		{"http URL", "http://example.com", "http"},
+		{"empty string", "", "https"},
+		{"no scheme", "example.com", "https"},
+		{"https with port", "https://localhost:8443", "https"},
+		{"http with port", "http://localhost:8080", "http"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractScheme(tt.input)
+			if got != tt.expected {
+				t.Errorf("extractScheme(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewCmdCreate(t *testing.T) {
+	cmd := NewCmdCreate()
+	if cmd.Use != "sitemap" {
+		t.Errorf("expected Use='sitemap', got %q", cmd.Use)
+	}
+
+	// Verify subcommands exist
+	subCmds := cmd.Commands()
+	names := make(map[string]bool)
+	for _, sub := range subCmds {
+		names[sub.Use] = true
+	}
+	if !names["generate"] {
+		t.Error("expected 'generate' subcommand")
+	}
+	if !names["remove"] {
+		t.Error("expected 'remove' subcommand")
+	}
+
+	// Verify persistent flags
+	idFlag := cmd.PersistentFlags().Lookup("id")
+	if idFlag == nil {
+		t.Error("expected persistent flag 'id'")
+	}
+}
+
+func TestGenerateCmd(t *testing.T) {
+	cmd := generateCmdCreate()
+	if cmd.Use != "generate" {
+		t.Errorf("expected Use='generate', got %q", cmd.Use)
+	}
+
+	wikiFlag := cmd.Flags().Lookup("wiki")
+	if wikiFlag == nil {
+		t.Error("expected flag 'wiki'")
+	}
+	if wikiFlag.Shorthand != "w" {
+		t.Errorf("expected wiki shorthand 'w', got %q", wikiFlag.Shorthand)
+	}
+}
+
+func TestRemoveCmd(t *testing.T) {
+	cmd := removeCmdCreate()
+	if cmd.Use != "remove" {
+		t.Errorf("expected Use='remove', got %q", cmd.Use)
+	}
+
+	wikiFlag := cmd.Flags().Lookup("wiki")
+	if wikiFlag == nil {
+		t.Error("expected flag 'wiki'")
+	}
+	if wikiFlag.Shorthand != "w" {
+		t.Errorf("expected wiki shorthand 'w', got %q", wikiFlag.Shorthand)
+	}
+}

--- a/docs/guide/general-concepts.md
+++ b/docs/guide/general-concepts.md
@@ -14,6 +14,7 @@ This page covers foundational concepts that apply to all Canasta installations, 
   - [Running the update sequence](#running-the-update-sequence)
   - [Running scripts manually](#running-scripts-manually)
   - [Running extension maintenance scripts](#running-extension-maintenance-scripts)
+- [Sitemaps](#sitemaps)
 - [Deploying behind a reverse proxy](#deploying-behind-a-reverse-proxy)
 - [Running on non-standard ports](#running-on-non-standard-ports)
 
@@ -380,6 +381,48 @@ canasta maintenance extension -i myinstance --all SemanticMediaWiki rebuildData.
 Only extensions that are currently loaded (enabled) for the target wiki are shown and can be run.
 
 See the [CLI Reference](../cli/canasta_maintenance.md) for more details.
+
+---
+
+## Sitemaps
+
+XML sitemaps help search engines discover and index pages on your wiki. Canasta provides commands to generate and remove sitemaps, and a background process to keep them up to date.
+
+### Generating sitemaps
+
+Use `canasta sitemap generate` to create sitemaps. You can generate for a specific wiki or for all wikis in the installation:
+
+```bash
+# Generate sitemap for a specific wiki
+canasta sitemap generate -i myinstance -w mywiki
+
+# Generate sitemaps for all wikis
+canasta sitemap generate -i myinstance
+```
+
+Sitemap files are stored in the `public_assets/{wiki-id}/sitemap/` directory and served at `/public_assets/sitemap/`. Once generated, a background process automatically refreshes the sitemaps on a regular schedule (controlled by the `MW_SITEMAP_PAUSE_DAYS` environment variable, which defaults to 1 day).
+
+The sitemap URL is automatically advertised in the wiki's `robots.txt` when sitemap files exist.
+
+### Removing sitemaps
+
+Use `canasta sitemap remove` to delete sitemap files. Once removed, the background generator will skip those wikis until sitemaps are generated again:
+
+```bash
+# Remove sitemap for a specific wiki
+canasta sitemap remove -i myinstance -w mywiki
+
+# Remove sitemaps for all wikis (prompts for confirmation)
+canasta sitemap remove -i myinstance
+```
+
+### How it works
+
+The presence of sitemap files is the sole signal that controls sitemap behavior:
+
+- **Background refresh**: The generator only refreshes sitemaps for wikis that already have sitemap files. Generating sitemaps for a wiki opts it in; removing them opts it out.
+- **robots.txt**: The sitemap URL is advertised in `robots.txt` only when sitemap files exist for the wiki.
+- **No configuration needed**: There are no YAML fields or environment variables to set — just generate or remove.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,3 +100,7 @@ nav:
       - diff: cli/canasta_backup_diff.md
       - unlock: cli/canasta_backup_unlock.md
       - schedule: cli/canasta_backup_schedule.md
+    - sitemap:
+      - Overview: cli/canasta_sitemap.md
+      - generate: cli/canasta_sitemap_generate.md
+      - remove: cli/canasta_sitemap_remove.md


### PR DESCRIPTION
## Summary

- Adds `canasta sitemap generate [-w wiki_id]` to generate XML sitemaps for one or all wikis
- Adds `canasta sitemap remove [-w wiki_id] [-y]` to remove sitemap files for one or all wikis
- Adds `--yes`/`-y` flag to `sitemap remove` to skip the confirmation prompt for scripted usage
- Adds sitemap documentation to the general concepts guide
- Sitemap presence is filesystem-based — no `wikis.yaml` field or env var needed
- Once generated, the background generator automatically refreshes sitemaps; once removed, it skips them

Companion PR: CanastaWiki/CanastaBase#99

Resolves #281

## Test plan

- [x] `canasta sitemap generate -i wikifarm -w wiki1` — generates sitemap for one wiki, verify files in `public_assets/wiki1/sitemap/`
- [x] `canasta sitemap generate -i wikifarm` — generates sitemaps for all wikis
- [x] `canasta sitemap remove -i wikifarm -w wiki1` — removes sitemap files for one wiki
- [x] `canasta sitemap remove -i wikifarm -y` — removes all sitemaps without prompting
- [x] `canasta sitemap generate -i wikifarm -w nonexistent` — returns error
- [x] `go test ./...` passes