### PR TITLE
Log scheduled backups to installation directory instead of /var/log

### DIFF
--- a/cmd/backup/schedule.go
+++ b/cmd/backup/schedule.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
@@ -14,7 +15,8 @@ func scheduleCmdCreate() *cobra.Command {
 	scheduleCmd := &cobra.Command{
 		Use:   "schedule",
 		Short: "Manage scheduled backups",
-		Long:  `Manage recurring backup schedules using crontab.`,
+		Long: `Manage recurring backup schedules using crontab. Backup output is
+logged to backup.log in the installation directory.`,
 	}
 
 	scheduleCmd.AddCommand(scheduleSetCmdCreate())
@@ -29,7 +31,8 @@ func scheduleSetCmdCreate() *cobra.Command {
 		Short: "Set a recurring backup schedule",
 		Long: `Schedule recurring backups using a cron expression. This adds or
 updates a crontab entry that runs 'canasta backup create' on the
-specified schedule. Backup output is logged to /var/log/canasta-backup.log.`,
+specified schedule. Backup output is logged to backup.log in the
+installation directory.`,
 		Example: `  # Schedule daily backups at 2:00 AM
   canasta backup schedule set -i myinstance "0 2 * * *"
 
@@ -118,7 +121,8 @@ func scheduleBackup(cronExpression string) error {
 		return fmt.Errorf("failed to get executable path: %w", err)
 	}
 
-	cmdStr := fmt.Sprintf("%s %s backup create -i %s --tag scheduled-$(date +\\%%Y\\%%m\\%%d\\%%H\\%%M\\%%S) >> /var/log/canasta-backup.log 2>&1", cronExpression, executable, instance.Id)
+	logPath := filepath.Join(instance.Path, "backup.log")
+	cmdStr := fmt.Sprintf("%s %s backup create -i %s --tag scheduled-$(date +\\%%Y\\%%m\\%%d\\%%H\\%%M\\%%S) >> %s 2>&1", cronExpression, executable, instance.Id, logPath)
 
 	logging.Print(fmt.Sprintf("Scheduling backup with cron: %s", cronExpression))
 


### PR DESCRIPTION
## Summary

- Changes the backup schedule log path from hardcoded `/var/log/canasta-backup.log` to `backup.log` in the installation directory
- This removes the root access requirement for scheduled backups
- Updates help text to reflect the new log location

Fixes #280

## Test plan

- [x] Set a backup schedule: `canasta backup schedule set -i myinstance "0 2 * * *"`
- [x] Verify the crontab entry uses `<install-path>/backup.log` instead of `/var/log/canasta-backup.log`
- [x] Replace an existing schedule and verify the crontab entry is updated with the new log path
- [x] Verify `canasta backup schedule list -i myinstance` works correctly
- [x] Verify `canasta backup schedule remove -i myinstance` works correctly