### PR TITLE
Add -w/--wiki flag to backup restore for per-wiki database restore

### DIFF
--- a/cmd/backup/backup_test.go
+++ b/cmd/backup/backup_test.go
@@ -106,6 +106,28 @@ func TestGetWikiIDsForRestore(t *testing.T) {
 		}
 	})
 
+	t.Run("single wiki dump present", func(t *testing.T) {
+		singleDir := t.TempDir()
+		writeWikisYaml(t, singleDir, wikis)
+
+		backupDir := filepath.Join(singleDir, "config", "backup")
+		if err := os.MkdirAll(backupDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		// Only create dump for wiki2, not main
+		if err := os.WriteFile(filepath.Join(backupDir, "db_wiki2.sql"), []byte("-- dump"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		ids, err := getWikiIDsForRestore(singleDir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(ids) != 1 || ids[0] != "wiki2" {
+			t.Errorf("got %v, want [wiki2]", ids)
+		}
+	})
+
 	t.Run("missing wikis.yaml returns error", func(t *testing.T) {
 		emptyDir := t.TempDir()
 		_, err := getWikiIDsForRestore(emptyDir)

--- a/cmd/backup/restore.go
+++ b/cmd/backup/restore.go
@@ -17,6 +17,7 @@ func restoreCmdCreate() *cobra.Command {
 	var (
 		snapshotId         string
 		skipBeforeSnapshot bool
+		wikiID             string
 	)
 
 	restoreCmd := &cobra.Command{
@@ -25,24 +26,31 @@ func restoreCmdCreate() *cobra.Command {
 		Long: `Restore a Canasta installation from a backup snapshot. By default, a safety
 snapshot is taken before restoring. The restore replaces configuration files,
 extensions, images, skins, public_assets, .env, docker-compose.override.yml,
-my.cnf, and all wiki databases with the contents of the specified snapshot.`,
+my.cnf, and all wiki databases with the contents of the specified snapshot.
+
+Use -w/--wiki to restore only a single wiki's database from the backup,
+leaving all shared files (config, extensions, skins, images, etc.) untouched.`,
 		Example: `  # Restore a snapshot by ID
   canasta backup restore -i myinstance -s abc123
 
   # Restore without taking a safety snapshot first
-  canasta backup restore -i myinstance -s abc123 --skip-safety-backup`,
+  canasta backup restore -i myinstance -s abc123 --skip-safety-backup
+
+  # Restore only a single wiki's database
+  canasta backup restore -i myinstance -s abc123 -w wiki2`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return restoreSnapshot(snapshotId, skipBeforeSnapshot)
+			return restoreSnapshot(snapshotId, skipBeforeSnapshot, wikiID)
 		},
 	}
 
 	restoreCmd.Flags().StringVarP(&snapshotId, "snapshot", "s", "", "Snapshot ID (required)")
 	restoreCmd.Flags().BoolVar(&skipBeforeSnapshot, "skip-safety-backup", false, "Skip taking a safety backup before restore")
+	restoreCmd.Flags().StringVarP(&wikiID, "wiki", "w", "", "Restore only this wiki's database (skips shared files)")
 	_ = restoreCmd.MarkFlagRequired("snapshot")
 	return restoreCmd
 }
 
-func restoreSnapshot(snapshotId string, skipBeforeSnapshot bool) error {
+func restoreSnapshot(snapshotId string, skipBeforeSnapshot bool, wikiID string) error {
 	EnvVariables, envErr := canasta.GetEnvVariable(envPath)
 	if envErr != nil {
 		return envErr
@@ -62,6 +70,67 @@ func restoreSnapshot(snapshotId string, skipBeforeSnapshot bool) error {
 		return err
 	}
 
+	if wikiID != "" {
+		return restoreWiki(wikiID, EnvVariables)
+	}
+	return restoreFull(EnvVariables)
+}
+
+// restoreWiki restores only a single wiki's database from a backup,
+// leaving all shared files (config, extensions, skins, images, etc.) untouched.
+func restoreWiki(wikiID string, env map[string]string) error {
+	// Validate that the wiki ID exists in the current installation's wikis.yaml
+	wikiIDs, err := getWikiIDs(instance.Path)
+	if err != nil {
+		return err
+	}
+	found := false
+	for _, id := range wikiIDs {
+		if id == wikiID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("wiki '%s' not found in current installation's wikis.yaml", wikiID)
+	}
+
+	// Copy only the backup directory from the backup volume
+	logging.Print("Copying database dump from backup volume...")
+	paths := map[string]string{
+		"/currentsnapshot/config/backup": filepath.Join(instance.Path, "config", "backup"),
+	}
+	if err := orch.RestoreFromBackupVolume(instance.Path, paths); err != nil {
+		return err
+	}
+
+	// Validate that the dump file exists
+	hostDumpPath := filepath.Join(instance.Path, "config", "backup", fmt.Sprintf("db_%s.sql", wikiID))
+	if _, err := os.Stat(hostDumpPath); err != nil {
+		os.RemoveAll(filepath.Join(instance.Path, "config", "backup"))
+		return fmt.Errorf("database dump file for wiki '%s' not found in backup snapshot", wikiID)
+	}
+
+	// Import the database
+	logging.Print(fmt.Sprintf("Restoring database for wiki '%s'...", wikiID))
+	command := fmt.Sprintf("mysql -h db -u root -p%s < %s",
+		env["MYSQL_PASSWORD"], dumpPath(wikiID))
+	_, restoreErr := orch.ExecWithError(instance.Path, "web", command)
+	if restoreErr != nil {
+		os.RemoveAll(filepath.Join(instance.Path, "config", "backup"))
+		return fmt.Errorf("Database restore failed for wiki '%s': %w", wikiID, restoreErr)
+	}
+
+	// Clean up
+	os.RemoveAll(filepath.Join(instance.Path, "config", "backup"))
+
+	logging.Print("Database restore completed")
+	fmt.Printf("Restore completed for wiki '%s'\n", wikiID)
+	return nil
+}
+
+// restoreFull performs a full restore of all files and databases from a backup.
+func restoreFull(env map[string]string) error {
 	logging.Print("Copying files from backup volume...")
 	paths := make(map[string]string)
 	for _, dir := range []string{"config", "extensions", "images", "skins", "public_assets"} {
@@ -83,7 +152,7 @@ func restoreSnapshot(snapshotId string, skipBeforeSnapshot bool) error {
 	for _, id := range wikiIDs {
 		logging.Print(fmt.Sprintf("Restoring database for wiki '%s'...", id))
 		command := fmt.Sprintf("mysql -h db -u root -p%s < %s",
-			EnvVariables["MYSQL_PASSWORD"], dumpPath(id))
+			env["MYSQL_PASSWORD"], dumpPath(id))
 		_, restoreErr := orch.ExecWithError(instance.Path, "web", command)
 		if restoreErr != nil {
 			return fmt.Errorf("Database restore failed for wiki '%s': %w", id, restoreErr)

--- a/docs/guide/backup.md
+++ b/docs/guide/backup.md
@@ -79,15 +79,17 @@ Replace `abc123` with the snapshot ID from `canasta backup list`. By default, a 
 canasta backup restore -i myinstance -s abc123 --skip-safety-backup
 ```
 
-### Restoring a single wiki's database
+### Restoring a single wiki
 
-To restore only one wiki's database from a backup without overwriting shared files (config, extensions, skins, images, etc.):
+To restore only one wiki from a backup without affecting the rest of the installation:
 
 ```bash
 canasta backup restore -i myinstance -s abc123 -w wiki2
 ```
 
-This is useful when you need to roll back a single wiki in a farm without affecting the rest of the installation. The wiki ID must exist in the current installation's `wikis.yaml`.
+This restores the wiki's database, per-wiki settings (`config/settings/wikis/{id}/`), images (`images/{id}/`), and public assets (`public_assets/{id}/`). Shared files like global config, extensions, and skins are left untouched.
+
+The wiki ID must exist in the current installation's `wikis.yaml`.
 
 ### Restoring a backup to a different instance
 

--- a/docs/guide/backup.md
+++ b/docs/guide/backup.md
@@ -79,6 +79,28 @@ Replace `abc123` with the snapshot ID from `canasta backup list`. By default, a 
 canasta backup restore -i myinstance -s abc123 --skip-safety-backup
 ```
 
+### Restoring a single wiki's database
+
+To restore only one wiki's database from a backup without overwriting shared files (config, extensions, skins, images, etc.):
+
+```bash
+canasta backup restore -i myinstance -s abc123 -w wiki2
+```
+
+This is useful when you need to roll back a single wiki in a farm without affecting the rest of the installation. The wiki ID must exist in the current installation's `wikis.yaml`.
+
+### Restoring a backup to a different instance
+
+You can restore a full backup to a different Canasta instance. This is useful for cloning an installation, migrating to a new server, or inspecting the contents of a backup without affecting your running instance.
+
+First, create a new instance and configure it with the same backup repository credentials in its `.env` file. Then restore:
+
+```bash
+canasta backup restore -i other-instance -s abc123
+```
+
+The target instance will receive all files and databases from the snapshot, replacing its current contents.
+
 ### Inspecting a backup
 
 To see what files are in a specific snapshot:


### PR DESCRIPTION
## Summary

- Adds `-w`/`--wiki` flag to `canasta backup restore` to restore only a single wiki from a backup snapshot
- Restores the wiki's database, per-wiki settings (`config/settings/wikis/{id}/`), images (`images/{id}/`), and public assets (`public_assets/{id}/`)
- Leaves shared files (global config, extensions, skins, .env, etc.) untouched
- Validates the wiki ID against the current installation's `wikis.yaml` and checks that the dump file exists in the backup
- Documents per-wiki restore and cross-instance restore in the backup guide

Closes #272

## Test plan

- [x] `go test ./...` passes
- [x] `canasta backup restore -i myfarm -s <id> -w wiki1` restores wiki1's database and per-wiki files
- [x] Per-wiki settings, images, and public_assets are restored from backup
- [x] Shared files (global config, extensions, .env) are not overwritten during per-wiki restore
- [x] `canasta backup restore -i myfarm -s <id> -w nonexistent` errors with "not found in wikis.yaml"
- [x] `canasta backup restore -i myfarm -s <id>` (no `-w`) still performs full restore as before