### PR TITLE
Use extensions/ and skins/ instead of canasta-extensions/ and canasta-skins/

### DIFF
--- a/cmd/extension/extension.go
+++ b/cmd/extension/extension.go
@@ -20,7 +20,7 @@ var (
 	err          error
 	verbose      bool
 	extensionCmd *cobra.Command
-	constants    = extensionsskins.Item{Name: "Canasta extension", RelativeInstallationPath: "canasta-extensions", PhpCommand: "wfLoadExtension"}
+	constants    = extensionsskins.Item{Name: "Canasta extension", RelativeInstallationPath: "extensions", PhpCommand: "wfLoadExtension"}
 )
 
 func NewCmdCreate() *cobra.Command {

--- a/cmd/skin/skin.go
+++ b/cmd/skin/skin.go
@@ -20,7 +20,7 @@ var (
 	err       error
 	verbose   bool
 	skinCmd   *cobra.Command
-	constants = extensionsskins.Item{Name: "Canasta skin", RelativeInstallationPath: "canasta-skins", PhpCommand: "wfLoadSkin"}
+	constants = extensionsskins.Item{Name: "Canasta skin", RelativeInstallationPath: "skins", PhpCommand: "wfLoadSkin"}
 )
 
 func NewCmdCreate() *cobra.Command {

--- a/internal/extensionsskins/extensionsskins.go
+++ b/internal/extensionsskins/extensionsskins.go
@@ -26,7 +26,7 @@ func Contains(list []string, element string) bool {
 
 func List(instance config.Installation, orch orchestrators.Orchestrator, constants Item) error {
 	log.Printf("Available %s:\n", constants.Name)
-	output, err := orch.ExecWithError(instance.Path, "web", "cd $MW_HOME/"+constants.RelativeInstallationPath+" && find * -maxdepth 0 -type d")
+	output, err := orch.ExecWithError(instance.Path, "web", "cd $MW_HOME/"+constants.RelativeInstallationPath+" && find -L * -maxdepth 0 -type d")
 	if err != nil {
 		return fmt.Errorf("%s", output)
 	}
@@ -35,7 +35,7 @@ func List(instance config.Installation, orch orchestrators.Orchestrator, constan
 }
 
 func CheckInstalled(name string, instance config.Installation, orch orchestrators.Orchestrator, constants Item) (string, error) {
-	output, err := orch.ExecWithError(instance.Path, "web", "cd $MW_HOME/"+constants.RelativeInstallationPath+" && find * -maxdepth 0 -type d")
+	output, err := orch.ExecWithError(instance.Path, "web", "cd $MW_HOME/"+constants.RelativeInstallationPath+" && find -L * -maxdepth 0 -type d")
 	if err != nil {
 		return "", fmt.Errorf("%s", output)
 	}


### PR DESCRIPTION
## Summary

- Changes `extension list`, `extension enable/disable`, `skin list`, and `skin enable/disable` to operate against the merged `extensions/` and `skins/` directories instead of the bundled-only `canasta-extensions/` and `canasta-skins/` directories
- Updates the `find` command to follow symlinks (`find -L`) since `extensions/` and `skins/` contain symlinks to both `canasta-extensions/` and `user-extensions/`
- This allows user extensions to appear in list output and be managed with enable/disable

Fixes #291

## Test plan

- [x] `go test ./...` passes
- [x] `canasta extension list` shows all extensions (bundled + user)
- [x] `canasta skin list` shows all skins
- [x] `canasta extension enable Cite` works
- [x] `canasta extension disable Cite` works