### PR TITLE
Preserve database passwords during full backup restore

### DIFF
--- a/cmd/backup/restore.go
+++ b/cmd/backup/restore.go
@@ -151,6 +151,15 @@ func restoreFull(env map[string]string) error {
 	}
 	logging.Print("Copied files...")
 
+	logging.Print("Preserving database passwords...")
+	for _, key := range []string{"MYSQL_PASSWORD", "WIKI_DB_PASSWORD"} {
+		if val, ok := env[key]; ok {
+			if err := canasta.SaveEnvVariable(filepath.Join(instance.Path, ".env"), key, val); err != nil {
+				return fmt.Errorf("failed to preserve %s in .env: %w", key, err)
+			}
+		}
+	}
+
 	logging.Print("Restoring database...")
 	wikiIDs, err := getWikiIDsForRestore(instance.Path)
 	if err != nil {


### PR DESCRIPTION
## Summary

- After a full `backup restore`, the `.env` file is overwritten with the backup's version, which may contain different `MYSQL_PASSWORD` and `WIKI_DB_PASSWORD` values. Since the database data volume is not part of the backup (only SQL dumps are), this leaves `.env` with passwords that don't match the running database, breaking subsequent operations.
- After restoring files from the backup volume, write back the current instance's `MYSQL_PASSWORD` and `WIKI_DB_PASSWORD` to `.env` using `SaveEnvVariable()`.
- Adds `TestRestorePreservesDBPasswords` to verify the preservation flow.

Fixes #292.

## Test plan

- [x] `go build` succeeds
- [x] `go test ./...` passes
- [x] Manual: restore a backup to an instance and verify `.env` retains the current DB passwords