### PR TITLE
test(logging): add unit tests for internal/logging package

### DIFF
--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -50,6 +50,9 @@ func TestSetVerboseToggle(t *testing.T) {
 }
 
 func TestPrintWhenVerboseIsTrue(t *testing.T) {
+	originalFlags := log.Flags()
+	defer log.SetFlags(originalFlags)
+
 	var buf bytes.Buffer
 	oldOutput := log.Writer()
 	log.SetOutput(&buf)
@@ -68,6 +71,9 @@ func TestPrintWhenVerboseIsTrue(t *testing.T) {
 }
 
 func TestPrintWhenVerboseIsFalse(t *testing.T) {
+	originalFlags := log.Flags()
+	defer log.SetFlags(originalFlags)
+
 	var buf bytes.Buffer
 	oldOutput := log.Writer()
 	log.SetOutput(&buf)
@@ -83,6 +89,9 @@ func TestPrintWhenVerboseIsFalse(t *testing.T) {
 }
 
 func TestPrintEmptyString(t *testing.T) {
+	originalFlags := log.Flags()
+	defer log.SetFlags(originalFlags)
+
 	var buf bytes.Buffer
 	oldOutput := log.Writer()
 	log.SetOutput(&buf)
@@ -100,6 +109,9 @@ func TestPrintEmptyString(t *testing.T) {
 }
 
 func TestPrintMultipleCalls(t *testing.T) {
+	originalFlags := log.Flags()
+	defer log.SetFlags(originalFlags)
+
 	var buf bytes.Buffer
 	oldOutput := log.Writer()
 	log.SetOutput(&buf)

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestSetVerbose_True(t *testing.T) {
+func TestSetVerboseTrue(t *testing.T) {
 	SetVerbose(true)
 	defer SetVerbose(false)
 	if !GetVerbose() {
@@ -14,7 +14,7 @@ func TestSetVerbose_True(t *testing.T) {
 	}
 }
 
-func TestSetVerbose_False(t *testing.T) {
+func TestSetVerboseFalse(t *testing.T) {
 	SetVerbose(true)
 	SetVerbose(false)
 	defer SetVerbose(false)
@@ -23,7 +23,7 @@ func TestSetVerbose_False(t *testing.T) {
 	}
 }
 
-func TestGetVerbose_DefaultIsFalse(t *testing.T) {
+func TestGetVerboseDefaultIsFalse(t *testing.T) {
 	// Reset verbose to its zero value
 	SetVerbose(false)
 	defer SetVerbose(false)
@@ -32,7 +32,7 @@ func TestGetVerbose_DefaultIsFalse(t *testing.T) {
 	}
 }
 
-func TestSetVerbose_Toggle(t *testing.T) {
+func TestSetVerboseToggle(t *testing.T) {
 	SetVerbose(false)
 	defer SetVerbose(false)
 	SetVerbose(true)
@@ -49,7 +49,7 @@ func TestSetVerbose_Toggle(t *testing.T) {
 	}
 }
 
-func TestPrint_WhenVerboseIsTrue(t *testing.T) {
+func TestPrintWhenVerboseIsTrue(t *testing.T) {
 	var buf bytes.Buffer
 	oldOutput := log.Writer()
 	log.SetOutput(&buf)
@@ -67,7 +67,7 @@ func TestPrint_WhenVerboseIsTrue(t *testing.T) {
 	}
 }
 
-func TestPrint_WhenVerboseIsFalse(t *testing.T) {
+func TestPrintWhenVerboseIsFalse(t *testing.T) {
 	var buf bytes.Buffer
 	oldOutput := log.Writer()
 	log.SetOutput(&buf)
@@ -82,7 +82,7 @@ func TestPrint_WhenVerboseIsFalse(t *testing.T) {
 	}
 }
 
-func TestPrint_EmptyString(t *testing.T) {
+func TestPrintEmptyString(t *testing.T) {
 	var buf bytes.Buffer
 	oldOutput := log.Writer()
 	log.SetOutput(&buf)
@@ -99,7 +99,7 @@ func TestPrint_EmptyString(t *testing.T) {
 	}
 }
 
-func TestPrint_MultipleCalls(t *testing.T) {
+func TestPrintMultipleCalls(t *testing.T) {
 	var buf bytes.Buffer
 	oldOutput := log.Writer()
 	log.SetOutput(&buf)
@@ -117,7 +117,11 @@ func TestPrint_MultipleCalls(t *testing.T) {
 	}
 }
 
-func TestPrint_ClearsLogFlags(t *testing.T) {
+func TestPrintClearsLogFlags(t *testing.T) {
+	// Capture and restore original flags
+	originalFlags := log.Flags()
+	defer log.SetFlags(originalFlags)
+
 	// Set flags to something non-zero first
 	log.SetFlags(log.Ldate | log.Ltime)
 

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -8,13 +8,16 @@ import (
 
 func TestSetVerbose_True(t *testing.T) {
 	SetVerbose(true)
+	defer SetVerbose(false)
 	if !GetVerbose() {
 		t.Error("expected verbose to be true after SetVerbose(true)")
 	}
 }
 
 func TestSetVerbose_False(t *testing.T) {
+	SetVerbose(true)
 	SetVerbose(false)
+	defer SetVerbose(false)
 	if GetVerbose() {
 		t.Error("expected verbose to be false after SetVerbose(false)")
 	}
@@ -22,12 +25,16 @@ func TestSetVerbose_False(t *testing.T) {
 
 func TestGetVerbose_DefaultIsFalse(t *testing.T) {
 	// Reset verbose to its zero value
+	SetVerbose(false)
+	defer SetVerbose(false)
 	if GetVerbose() {
 		t.Error("expected default verbose to be false")
 	}
 }
 
 func TestSetVerbose_Toggle(t *testing.T) {
+	SetVerbose(false)
+	defer SetVerbose(false)
 	SetVerbose(true)
 	if !GetVerbose() {
 		t.Fatal("expected verbose=true")
@@ -49,6 +56,7 @@ func TestPrint_WhenVerboseIsTrue(t *testing.T) {
 	defer log.SetOutput(oldOutput)
 
 	SetVerbose(true)
+	defer SetVerbose(false)
 	Print("hello verbose")
 	if buf.Len() == 0 {
 		t.Error("expected output when verbose is true, got nothing")
@@ -66,6 +74,7 @@ func TestPrint_WhenVerboseIsFalse(t *testing.T) {
 	defer log.SetOutput(oldOutput)
 
 	SetVerbose(false)
+	defer SetVerbose(false)
 	Print("should not appear")
 
 	if buf.Len() != 0 {
@@ -75,10 +84,12 @@ func TestPrint_WhenVerboseIsFalse(t *testing.T) {
 
 func TestPrint_EmptyString(t *testing.T) {
 	var buf bytes.Buffer
+	oldOutput := log.Writer()
 	log.SetOutput(&buf)
-	defer log.SetOutput(nil)
+	defer log.SetOutput(oldOutput)
 
 	SetVerbose(true)
+	defer SetVerbose(false)
 	Print("")
 
 	got := buf.String()
@@ -90,10 +101,12 @@ func TestPrint_EmptyString(t *testing.T) {
 
 func TestPrint_MultipleCalls(t *testing.T) {
 	var buf bytes.Buffer
+	oldOutput := log.Writer()
 	log.SetOutput(&buf)
-	defer log.SetOutput(nil)
+	defer log.SetOutput(oldOutput)
 
 	SetVerbose(true)
+	defer SetVerbose(false)
 	Print("line1")
 	Print("line2")
 
@@ -108,12 +121,14 @@ func TestPrint_ClearsLogFlags(t *testing.T) {
 	// Set flags to something non-zero first
 	log.SetFlags(log.Ldate | log.Ltime)
 
-	SetVerbose(true)
-
 	var buf bytes.Buffer
-	log.SetOutput(&buf)
-	defer log.SetOutput(nil)
 
+	oldOutput := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(oldOutput)
+
+	SetVerbose(true)
+	defer SetVerbose(false)
 	Print("test")
 
 	// After Print, flags should be 0

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,123 @@
+package logging
+
+import (
+	"bytes"
+	"log"
+	"testing"
+)
+
+func TestSetVerbose_True(t *testing.T) {
+	SetVerbose(true)
+	if !GetVerbose() {
+		t.Error("expected verbose to be true after SetVerbose(true)")
+	}
+}
+
+func TestSetVerbose_False(t *testing.T) {
+	SetVerbose(false)
+	if GetVerbose() {
+		t.Error("expected verbose to be false after SetVerbose(false)")
+	}
+}
+
+func TestGetVerbose_DefaultIsFalse(t *testing.T) {
+	// Reset verbose to its zero value
+	if GetVerbose() {
+		t.Error("expected default verbose to be false")
+	}
+}
+
+func TestSetVerbose_Toggle(t *testing.T) {
+	SetVerbose(true)
+	if !GetVerbose() {
+		t.Fatal("expected verbose=true")
+	}
+	SetVerbose(false)
+	if GetVerbose() {
+		t.Fatal("expected verbose=false after toggle")
+	}
+	SetVerbose(true)
+	if !GetVerbose() {
+		t.Fatal("expected verbose=true after second toggle")
+	}
+}
+
+func TestPrint_WhenVerboseIsTrue(t *testing.T) {
+	var buf bytes.Buffer
+	oldOutput := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(oldOutput)
+
+	SetVerbose(true)
+	Print("hello verbose")
+	if buf.Len() == 0 {
+		t.Error("expected output when verbose is true, got nothing")
+	}
+	got := buf.String()
+	if got != "hello verbose\n" {
+		t.Errorf("expected %q, got %q", "hello verbose\n", got)
+	}
+}
+
+func TestPrint_WhenVerboseIsFalse(t *testing.T) {
+	var buf bytes.Buffer
+	oldOutput := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(oldOutput)
+
+	SetVerbose(false)
+	Print("should not appear")
+
+	if buf.Len() != 0 {
+		t.Errorf("expected no output when verbose is false, got %q", buf.String())
+	}
+}
+
+func TestPrint_EmptyString(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(nil)
+
+	SetVerbose(true)
+	Print("")
+
+	got := buf.String()
+	// log.Print("") still prints a newline
+	if got != "\n" {
+		t.Errorf("expected %q for empty Print, got %q", "\n", got)
+	}
+}
+
+func TestPrint_MultipleCalls(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(nil)
+
+	SetVerbose(true)
+	Print("line1")
+	Print("line2")
+
+	got := buf.String()
+	expected := "line1\nline2\n"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestPrint_ClearsLogFlags(t *testing.T) {
+	// Set flags to something non-zero first
+	log.SetFlags(log.Ldate | log.Ltime)
+
+	SetVerbose(true)
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(nil)
+
+	Print("test")
+
+	// After Print, flags should be 0
+	if log.Flags() != 0 {
+		t.Errorf("expected log flags to be 0 after Print, got %d", log.Flags())
+	}
+}


### PR DESCRIPTION
### Summary
This PR adds unit tests for the `internal/logging` package, which previously had no test coverage.

### Changes
- Added unit tests for `SetVerbose` and `GetVerbose`
- Verified `Print` behavior when verbose mode is enabled and disabled
- Ensured log output formatting and log flag handling are correct
- Covered edge cases such as empty strings and multiple print calls

### Context
This contribution aligns with the broader testing initiative outlined in issue #241, which aims to expand unit test coverage across internal packages.

### Testing
- Ran `go test` locally in the `internal/logging` package
- Verified all tests pass successfully
- Executed and validated tests using the VS Code Go test runner
- Confirmed results in the Go Test Results panel

### Local Testing Evidence
A screenshot has been attached showing all tests passing locally for the `internal/logging` package using both the `go test` command and the VS Code test results vie
<img width="1917" height="1056" alt="local testing screenshot" src="https://github.com/user-attachments/assets/308da10c-286d-4a01-ad9b-13e983caa131" />

### Note
This PR was created as part of familiarizing myself with the repository structure and existing testing patterns.
Starting with the `internal/logging` package allowed me to understand how unit tests are organized and integrated with the current CI setup.

Once this PR is merged, I plan to continue studying the remaining internal packages and contribute additional PRs to add test coverage for the other untested areas mentioned in the issue.