### PR TITLE
Document www-data group requirement for running without sudo

### DIFF
--- a/docs/guide/best-practices.md
+++ b/docs/guide/best-practices.md
@@ -33,10 +33,11 @@ This page covers security considerations and best practices for managing Canasta
 Running Canasta CLI commands does **not** require `sudo`. However, your user account must have permission to run Docker commands:
 
 - **macOS** — Docker Desktop grants Docker access to the current user automatically. No additional setup is needed.
-- **Linux** — Add your user to the `docker` group, then log out and log back in:
+- **Linux** — Add your user to the `docker` and `www-data` groups, then log out and log back in:
   ```bash
-  sudo usermod -aG docker $USER
+  sudo usermod -aG docker,www-data $USER
   ```
+  The `docker` group grants permission to run Docker commands. The `www-data` group grants permission to manage files in the installation's `config/` directory, which is shared with the web container.
 - **Windows (WSL)** — Follow the Linux instructions within your WSL distribution.
 
 The only step that requires `sudo` is installing the CLI binary to `/usr/local/bin/` (see [Installation](../installation.md)).

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -126,5 +126,6 @@ docker compose exec web bash
   ```
 
 **Permission denied errors**
-- Ensure your user has Docker access (see above)
+- Ensure your user is in the `docker` and `www-data` groups (on Linux: `sudo usermod -aG docker,www-data $USER`, then log out and back in)
+- The `docker` group is needed for Docker access; the `www-data` group is needed because the web container runs as `www-data` and shares the `config/` directory
 - Ensure the installation directory has proper ownership

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -29,10 +29,10 @@ Essentially, preparing your Linux server to be a Canasta host by installing the 
 `sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin` once you've
 added the Docker repositories to your system.
 
-On Linux, you also need Docker access for your user account. Add your user to the `docker` group, then log out and log back in:
+On Linux, you also need Docker access and file permission for your user account. Add your user to the `docker` and `www-data` groups, then log out and log back in:
 
 ```bash
-sudo usermod -aG docker $USER
+sudo usermod -aG docker,www-data $USER
 ```
 
 ## Install


### PR DESCRIPTION
Closes #298

## Summary

- Add `www-data` group alongside `docker` group in Linux setup instructions (installation guide, best practices, troubleshooting)
- The web container runs as `www-data` and shares the `config/` directory; without group membership, the CLI cannot write admin passwords or clean up installer-generated files after containers start

## Test plan

- [x] Verify docs render correctly
- [x] Confirmed fix on Debian server: adding user to `www-data` group resolves permission denied errors during `canasta create`