### PR TITLE
Move Compose-specific config behind Orchestrator interface

### DIFF
--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -239,7 +239,7 @@ func AddWiki(instance config.Installation, wikiID, siteName, domain, wikipath, d
 	}
 
 	//Rewrite the Caddyfile (only after adding to wikis.yaml)
-	err = canasta.RewriteCaddy(instance.Path)
+	err = orch.UpdateConfig(instance.Path)
 	if err != nil {
 		return err
 	}

--- a/cmd/maintenanceUpdate/extension_test.go
+++ b/cmd/maintenanceUpdate/extension_test.go
@@ -64,6 +64,15 @@ func (m *extMockOrchestrator) RunBackup(installPath, envPath string, volumes map
 func (m *extMockOrchestrator) RestoreFromBackupVolume(installPath string, dirs map[string]string) error {
 	return nil
 }
+func (m *extMockOrchestrator) InitConfig(installPath string) error {
+	return nil
+}
+func (m *extMockOrchestrator) UpdateConfig(installPath string) error {
+	return nil
+}
+func (m *extMockOrchestrator) MigrateConfig(installPath string, dryRun bool) (bool, error) {
+	return false, nil
+}
 func (m *extMockOrchestrator) StopAndStart(inst config.Installation) error {
 	return nil
 }

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -144,7 +144,7 @@ func RemoveWiki(instance config.Installation, wikiID string, yes bool) error {
 	}
 
 	//Rewrite the Caddyfile
-	err = canasta.RewriteCaddy(instance.Path)
+	err = orch.UpdateConfig(instance.Path)
 	if err != nil {
 		return err
 	}

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -188,7 +188,7 @@ func Upgrade(instance config.Installation, dryRun bool) error {
 	}
 
 	// Run migration steps (before restart so config is correct when containers come up)
-	migrationsNeeded, err := runMigration(instance.Path, dryRun)
+	migrationsNeeded, err := runMigration(instance.Path, orch, dryRun)
 	if err != nil {
 		return err
 	}
@@ -235,7 +235,7 @@ func Upgrade(instance config.Installation, dryRun bool) error {
 }
 
 // runMigration orchestrates all migration steps
-func runMigration(installPath string, dryRun bool) (bool, error) {
+func runMigration(installPath string, orch orchestrators.Orchestrator, dryRun bool) (bool, error) {
 	fmt.Println("Checking for config migrations...")
 
 	changed := false
@@ -267,12 +267,12 @@ func runMigration(installPath string, dryRun bool) (bool, error) {
 		changed = true
 	}
 
-	// Step 4: Create Caddyfile.site and update Caddyfile with import directive
-	caddyChanged, err := createCaddyfileSite(installPath, dryRun)
+	// Step 4: Orchestrator-specific config migrations (Caddyfiles, etc.)
+	orchChanged, err := orch.MigrateConfig(installPath, dryRun)
 	if err != nil {
 		return false, err
 	}
-	if caddyChanged {
+	if orchChanged {
 		changed = true
 	}
 
@@ -453,49 +453,6 @@ func migrateDirectoryStructure(installPath string, dryRun bool) (bool, error) {
 	}
 
 	return changed, nil
-}
-
-// createCaddyfileSite creates Caddyfile.site and Caddyfile.global if they don't exist
-// and rewrites the Caddyfile to include the import directives
-func createCaddyfileSite(installPath string, dryRun bool) (bool, error) {
-	customPath := filepath.Join(installPath, "config", "Caddyfile.site")
-	globalPath := filepath.Join(installPath, "config", "Caddyfile.global")
-
-	// Check if both files already exist
-	_, customErr := os.Stat(customPath)
-	_, globalErr := os.Stat(globalPath)
-	if customErr == nil && globalErr == nil {
-		return false, nil
-	}
-
-	if dryRun {
-		if customErr != nil {
-			fmt.Println("  Would create config/Caddyfile.site")
-		}
-		if globalErr != nil {
-			fmt.Println("  Would create config/Caddyfile.global")
-		}
-		fmt.Println("  Would update config/Caddyfile with import directives")
-	} else {
-		if customErr != nil {
-			fmt.Println("  Creating config/Caddyfile.site")
-			if err := canasta.CreateCaddyfileSite(installPath); err != nil {
-				return false, fmt.Errorf("failed to create Caddyfile.site: %w", err)
-			}
-		}
-		if globalErr != nil {
-			fmt.Println("  Creating config/Caddyfile.global")
-			if err := canasta.CreateCaddyfileGlobal(installPath); err != nil {
-				return false, fmt.Errorf("failed to create Caddyfile.global: %w", err)
-			}
-		}
-		fmt.Println("  Updating config/Caddyfile with import directives")
-		if err := canasta.RewriteCaddy(installPath); err != nil {
-			return false, fmt.Errorf("failed to rewrite Caddyfile: %w", err)
-		}
-	}
-
-	return true, nil
 }
 
 // removeEmptyComposerLocal removes config/composer.local.json if it exists with

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -17,7 +17,6 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
 	"github.com/CanastaWiki/Canasta-CLI/internal/git"
 	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
-	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 	"github.com/sethvargo/go-password/password"
 )
 
@@ -63,12 +62,10 @@ func GetImageWithTag(tag string) string {
 	return fmt.Sprintf("%s/%s:%s", DefaultImageRegistry, DefaultImageName, tag)
 }
 
-// CloneStackRepo() accepts the orchestrator from the CLI,
-// passes the corresponding repository link,
-// and clones the repo to a new folder in the specified path.
+// CloneStackRepo clones the stack repository to a new folder in the specified path.
 // If localSourcePath is provided and contains a Canasta-DockerCompose directory, it copies from there instead.
 // Returns true if a local Canasta-DockerCompose was used, false if cloned from GitHub.
-func CloneStackRepo(orch orchestrators.Orchestrator, canastaId string, path *string, localSourcePath string) (bool, error) {
+func CloneStackRepo(repoLink string, canastaId string, path *string, localSourcePath string) (bool, error) {
 	*path += "/" + canastaId
 
 	// Check if local Canasta-DockerCompose exists (only when building from source)
@@ -90,7 +87,7 @@ func CloneStackRepo(orch orchestrators.Orchestrator, canastaId string, path *str
 	}
 
 	// Fall back to cloning from GitHub
-	repo := orch.GetRepoLink()
+	repo := repoLink
 	logging.Print(fmt.Sprintf("Cloning the stack repo to %s \n", *path))
 	err := git.Clone(repo, *path)
 	return false, err
@@ -680,14 +677,6 @@ func CheckCanastaId(instance config.Installation) (config.Installation, error) {
 		}
 	}
 	return instance, nil
-}
-
-func DeleteConfigAndContainers(keepConfig bool, installationDir string, orch orchestrators.Orchestrator) {
-	fmt.Println("Removing containers")
-	_, _ = orch.Destroy(installationDir)
-	fmt.Println("Deleting config files")
-	_, _ = orchestrators.DeleteConfig(installationDir)
-	fmt.Println("Deleted all containers and config files")
 }
 
 func RemoveSettings(installPath, id string) error {

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -431,6 +431,9 @@ func RewriteCaddy(installPath string) error {
 	writeLine(siteAddress.String() + " {")
 	writeLine("    import /etc/caddy/Caddyfile.site")
 	writeLine("    reverse_proxy varnish:80")
+	writeLine("    log {")
+	writeLine("        output file /var/log/caddy/access.log")
+	writeLine("    }")
 	writeLine("}")
 
 	if writeErr != nil {

--- a/internal/orchestrators/compose_config_test.go
+++ b/internal/orchestrators/compose_config_test.go
@@ -1,0 +1,129 @@
+package orchestrators
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setupTestInstall creates a minimal installation directory with .env and wikis.yaml
+func setupTestInstall(t *testing.T, envContent, wikisYaml string) string {
+	t.Helper()
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "config")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(envContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "wikis.yaml"), []byte(wikisYaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestComposeInitConfig(t *testing.T) {
+	dir := setupTestInstall(t, "COMPOSE_PROFILES=web\n", "wikis:\n  - id: main\n    url: example.com\n")
+
+	c := &ComposeOrchestrator{}
+	if err := c.InitConfig(dir); err != nil {
+		t.Fatalf("InitConfig() error = %v", err)
+	}
+
+	// Caddyfile.site should exist
+	if _, err := os.Stat(filepath.Join(dir, "config", "Caddyfile.site")); err != nil {
+		t.Error("expected Caddyfile.site to be created")
+	}
+
+	// Caddyfile.global should exist
+	if _, err := os.Stat(filepath.Join(dir, "config", "Caddyfile.global")); err != nil {
+		t.Error("expected Caddyfile.global to be created")
+	}
+
+	// Caddyfile should exist and contain the site address
+	content, err := os.ReadFile(filepath.Join(dir, "config", "Caddyfile"))
+	if err != nil {
+		t.Fatalf("expected Caddyfile to be created: %v", err)
+	}
+	if !strings.Contains(string(content), "example.com") {
+		t.Error("Caddyfile should contain server name")
+	}
+}
+
+func TestComposeUpdateConfig(t *testing.T) {
+	dir := setupTestInstall(t, "COMPOSE_PROFILES=web\n", "wikis:\n  - id: main\n    url: example.com\n  - id: wiki2\n    url: wiki2.example.com\n")
+
+	c := &ComposeOrchestrator{}
+	if err := c.UpdateConfig(dir); err != nil {
+		t.Fatalf("UpdateConfig() error = %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "config", "Caddyfile"))
+	if err != nil {
+		t.Fatalf("expected Caddyfile to be created: %v", err)
+	}
+	caddy := string(content)
+	if !strings.Contains(caddy, "example.com") {
+		t.Error("Caddyfile should contain example.com")
+	}
+	if !strings.Contains(caddy, "wiki2.example.com") {
+		t.Error("Caddyfile should contain wiki2.example.com")
+	}
+}
+
+func TestComposeMigrateConfig_NothingToMigrate(t *testing.T) {
+	dir := setupTestInstall(t, "COMPOSE_PROFILES=web\n", "wikis:\n  - id: main\n    url: example.com\n")
+
+	// Create both Caddyfiles so no migration is needed
+	os.WriteFile(filepath.Join(dir, "config", "Caddyfile.site"), []byte("# site"), 0644)
+	os.WriteFile(filepath.Join(dir, "config", "Caddyfile.global"), []byte("# global"), 0644)
+
+	c := &ComposeOrchestrator{}
+	changed, err := c.MigrateConfig(dir, false)
+	if err != nil {
+		t.Fatalf("MigrateConfig() error = %v", err)
+	}
+	if changed {
+		t.Error("expected no changes when files already exist")
+	}
+}
+
+func TestComposeMigrateConfig_CreatesCaddyfiles(t *testing.T) {
+	dir := setupTestInstall(t, "COMPOSE_PROFILES=web\n", "wikis:\n  - id: main\n    url: example.com\n")
+
+	c := &ComposeOrchestrator{}
+	changed, err := c.MigrateConfig(dir, false)
+	if err != nil {
+		t.Fatalf("MigrateConfig() error = %v", err)
+	}
+	if !changed {
+		t.Error("expected changes when Caddyfiles are missing")
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "config", "Caddyfile.site")); err != nil {
+		t.Error("expected Caddyfile.site to be created")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "config", "Caddyfile.global")); err != nil {
+		t.Error("expected Caddyfile.global to be created")
+	}
+}
+
+func TestComposeMigrateConfig_DryRun(t *testing.T) {
+	dir := setupTestInstall(t, "COMPOSE_PROFILES=web\n", "wikis:\n  - id: main\n    url: example.com\n")
+
+	c := &ComposeOrchestrator{}
+	changed, err := c.MigrateConfig(dir, true)
+	if err != nil {
+		t.Fatalf("MigrateConfig() error = %v", err)
+	}
+	if !changed {
+		t.Error("expected changes to be reported in dry-run")
+	}
+
+	// Files should NOT be created in dry-run
+	if _, err := os.Stat(filepath.Join(dir, "config", "Caddyfile.site")); err == nil {
+		t.Error("Caddyfile.site should not be created in dry-run")
+	}
+}

--- a/internal/orchestrators/kubernetes.go
+++ b/internal/orchestrators/kubernetes.go
@@ -227,6 +227,18 @@ func (k *KubernetesOrchestrator) RestoreFromBackupVolume(installPath string, dir
 	return fmt.Errorf("backup is not yet supported for Kubernetes installations")
 }
 
+func (k *KubernetesOrchestrator) InitConfig(installPath string) error {
+	return nil // K8s config is managed via kustomization overlays
+}
+
+func (k *KubernetesOrchestrator) UpdateConfig(installPath string) error {
+	return nil // K8s config is managed via kustomization overlays
+}
+
+func (k *KubernetesOrchestrator) MigrateConfig(installPath string, dryRun bool) (bool, error) {
+	return false, nil // No Compose-specific migrations needed for K8s
+}
+
 // getRunningPod finds a running pod for the given service label in a namespace.
 func getRunningPod(namespace, service string) (string, error) {
 	labelSelector := fmt.Sprintf("%s=%s", podLabelKey, service)

--- a/internal/orchestrators/orchestrator.go
+++ b/internal/orchestrators/orchestrator.go
@@ -27,6 +27,18 @@ type Orchestrator interface {
 	CopyTo(installPath, service, hostPath, containerPath string) error
 	RunBackup(installPath, envPath string, volumes map[string]string, args ...string) (string, error)
 	RestoreFromBackupVolume(installPath string, dirs map[string]string) error
+
+	// InitConfig sets up orchestrator-specific configuration for a new installation.
+	// Called once during "canasta create" after wikis.yaml and .env are in place.
+	InitConfig(installPath string) error
+
+	// UpdateConfig regenerates orchestrator-specific configuration after
+	// changes to wikis.yaml (e.g., adding or removing a wiki).
+	UpdateConfig(installPath string) error
+
+	// MigrateConfig applies orchestrator-specific migration steps during
+	// "canasta upgrade". Returns true if any changes were made.
+	MigrateConfig(installPath string, dryRun bool) (bool, error)
 }
 
 // ImageInfo holds information about a Docker image

--- a/internal/orchestrators/orchestrator_test.go
+++ b/internal/orchestrators/orchestrator_test.go
@@ -72,6 +72,21 @@ func (m *mockOrchestrator) RestoreFromBackupVolume(installPath string, dirs map[
 	return nil
 }
 
+func (m *mockOrchestrator) InitConfig(installPath string) error {
+	m.calls = append(m.calls, "InitConfig")
+	return nil
+}
+
+func (m *mockOrchestrator) UpdateConfig(installPath string) error {
+	m.calls = append(m.calls, "UpdateConfig")
+	return nil
+}
+
+func (m *mockOrchestrator) MigrateConfig(installPath string, dryRun bool) (bool, error) {
+	m.calls = append(m.calls, "MigrateConfig")
+	return false, nil
+}
+
 func TestNew(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary

- Add `InitConfig`, `UpdateConfig`, and `MigrateConfig` methods to the `Orchestrator` interface so each backend handles its own configuration artifacts
- Implement the three methods on `ComposeOrchestrator`, delegating to existing `canasta` package functions (`CreateCaddyfileSite`, `CreateCaddyfileGlobal`, `RewriteCaddy`)
- Add no-op stubs on `KubernetesOrchestrator` (K8s config is managed via kustomization overlays)
- Break the `canasta` → `orchestrators` import cycle by changing `CloneStackRepo` to accept a repo URL string and moving `DeleteConfigAndContainers` to `cmd/create` as a local helper
- Update command code (`create`, `add`, `remove`, `upgrade`) to call the interface methods instead of `canasta.*` directly
- Also includes Caddy access logging (closes #213) which is a standalone improvement

Closes #300. Related to #131.

## Test plan

- [x] `go build -o /dev/null ./...` compiles cleanly
- [x] `go test ./...` all tests pass
- [x] `internal/canasta/canasta.go` no longer imports `internal/orchestrators`
- [x] `internal/orchestrators/compose.go` imports `internal/canasta`
- [x] New `compose_config_test.go` covers `InitConfig`, `UpdateConfig`, and `MigrateConfig` (including dry-run mode)
- [x] Manual test: `canasta create` produces correct Caddyfile, Caddyfile.site, Caddyfile.global
- [x] Manual test: `canasta add` / `canasta remove` regenerates Caddyfile
- [x] Manual test: `canasta upgrade --dry-run` reports Compose migrations correctly