### PR TITLE
Add OpenSearch observability support to CLI

### DIFF
--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -1,0 +1,133 @@
+# Observability (OpenSearch + Logstash + Dashboards)
+
+Canasta includes an optional observability stack that collects logs from MediaWiki, Caddy, and MySQL and makes them searchable through OpenSearch Dashboards.
+
+## Contents
+
+- [Enabling observability](#enabling-observability)
+  - [New installations](#new-installations)
+  - [Existing installations](#existing-installations)
+- [Accessing OpenSearch Dashboards](#accessing-opensearch-dashboards)
+- [Viewing logs](#viewing-logs)
+- [Enabling MediaWiki logging](#enabling-mediawiki-logging)
+- [Index patterns](#index-patterns)
+- [Verifying logs are flowing](#verifying-logs-are-flowing)
+- [Security notes](#security-notes)
+
+---
+
+## Enabling observability
+
+The observability stack runs as an optional Docker Compose profile. To enable it, set `COMPOSE_PROFILES` to include `observable` in your `.env` file.
+
+### New installations
+
+Create an `.env` file with the profile enabled, then pass it to `canasta create`:
+
+```bash
+echo "COMPOSE_PROFILES=observable" > my.env
+canasta create -i myinstance -w mywiki -a admin -e my.env
+```
+
+Or append `observable` to an existing `.env` file that already sets `COMPOSE_PROFILES`:
+
+```
+COMPOSE_PROFILES=web,observable
+```
+
+### Existing installations
+
+Add `COMPOSE_PROFILES=observable` (or append `,observable`) to the `.env` file in your installation directory, then upgrade:
+
+```bash
+canasta upgrade -i myinstance
+```
+
+In both cases, the CLI automatically:
+- Generates `OS_USER`, `OS_PASSWORD`, and `OS_PASSWORD_HASH` in `.env`
+- Adds the OpenSearch Dashboards reverse proxy block to the Caddyfile
+
+---
+
+## Accessing OpenSearch Dashboards
+
+- **URL:** `https://<your-domain>/opensearch`
+- **Login:** Use the `OS_USER` and `OS_PASSWORD` values from your installation's `.env` file.
+
+---
+
+## Viewing logs
+
+1. Open OpenSearch Dashboards at `/opensearch`.
+2. Go to **Discover**.
+3. Select an index pattern from the top-left dropdown.
+4. Adjust the time range (top-right) to include recent activity.
+
+By default, two log sources are available immediately:
+
+| Index pattern | Source |
+|---------------|--------|
+| `caddy-logs-*` | Caddy reverse proxy access logs |
+| `mysql-logs-*` | MySQL error logs |
+
+The `mediawiki-logs-*` index pattern only appears if MediaWiki logging is enabled (see below).
+
+---
+
+## Enabling MediaWiki logging
+
+By default, MediaWiki does not write log files. To enable logging, add the following to `config/settings/global/Logging.php` (or a per-wiki settings file):
+
+```php
+<?php
+$wgDebugLogFile = "/var/log/mediawiki/debug.log";
+$wgDBerrorLog = "/var/log/mediawiki/dberror.log";
+$wgDebugLogGroups = [
+    'exception' => "/var/log/mediawiki/exception.log",
+    'error' => "/var/log/mediawiki/error.log",
+];
+```
+
+Then restart:
+
+```bash
+canasta restart -i myinstance
+```
+
+Once log files are created, the `mediawiki-logs-*` index pattern will appear automatically in Dashboards.
+
+---
+
+## Index patterns
+
+Index patterns are created automatically by an init container when the observability profile starts. It waits for OpenSearch Dashboards to be ready and for at least one log index to exist, then creates patterns for each available index. A second pass runs 60 seconds later to pick up any late-arriving indices.
+
+If automatic creation fails (check `docker logs <id>-observable-init-1`), you can create patterns manually:
+
+1. Open **OpenSearch Dashboards** > **Stack Management** > **Index Patterns**.
+2. Create patterns for the indices that exist:
+   - `caddy-logs-*`
+   - `mysql-logs-*`
+   - `mediawiki-logs-*` (only if MediaWiki logging is enabled)
+3. Select `@timestamp` as the time field.
+
+---
+
+## Verifying logs are flowing
+
+If you do not see logs in Dashboards:
+
+- Generate some activity (browse the wiki, log in, edit a page).
+- Ensure the observability containers are running: `canasta list` or `docker ps`.
+- Check container logs for errors:
+  ```bash
+  docker logs <id>-logstash-1
+  docker logs <id>-opensearch-1
+  ```
+
+---
+
+## Security notes
+
+- OpenSearch has its security plugin disabled (`plugins.security.disabled=true`). Access to OpenSearch Dashboards is protected by Caddy's basicauth. OpenSearch itself is only accessible within the Docker network (no ports exposed to the host).
+- OpenSearch Dashboards port 5601 is not exposed to the host; access is exclusively through the Caddy reverse proxy at `/opensearch`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,7 @@ canasta create -i myinstance -w wiki1 -a admin -n localhost
 - [General concepts](guide/general-concepts.md) - Installation IDs, wiki IDs, directory structure, settings, and configuration
 - [Wiki farms](guide/wiki-farms.md) - Running multiple wikis in one installation
 - [Extensions and skins](guide/extensions-and-skins.md) - Enabling, disabling, and adding extensions and skins
+- [Observability](guide/observability.md) - Log aggregation with OpenSearch and Dashboards
 - [Development mode](guide/devmode.md) - Live code editing and Xdebug debugging
 - [Backup and restore](guide/backup.md) - Setting up backups with restic
 - [Best practices](guide/best-practices.md) - Security considerations and best practices

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f
 	github.com/schollz/progressbar/v3 v3.13.1
 	github.com/spf13/cobra v1.4.0
+	golang.org/x/crypto v0.48.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -13,7 +14,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
-	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/term v0.40.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/CanastaWiki/Canasta-CLI
 
-go 1.18
+go 1.24.0
 
 require (
 	github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f
@@ -13,8 +13,9 @@ require (
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
-	golang.org/x/sys v0.6.0 // indirect
-	golang.org/x/term v0.6.0 // indirect
+	golang.org/x/crypto v0.48.0 // indirect
+	golang.org/x/sys v0.41.0 // indirect
+	golang.org/x/term v0.40.0 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -29,11 +29,15 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
+golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.6.0 h1:clScbb1cHjoCkyRbWwBEUZ5H/tIFu5TAXIqaZD0Gcjw=
+golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.6.0/go.mod h1:m6U89DPEgQRMq3DNkDClhWw02AUbt2daBVO4cn4Hv9U=
+golang.org/x/term v0.40.0 h1:36e4zGLqU4yhjlmxEaagx2KuYbJq3EwY8K943ZsHcvg=
+golang.org/x/term v0.40.0/go.mod h1:w2P8uVp06p2iyKKuvXIm7N/y0UCRt3UfJTfZ7oOpglM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -374,7 +374,7 @@ func EnsureObservabilityCredentials(installPath string) (bool, error) {
 		if err := SaveEnvVariable(envPath, "OS_USER", "admin"); err != nil {
 			return true, fmt.Errorf("failed to save OS_USER: %w", err)
 		}
-		fmt.Println("Set OS_USER=admin in .env")
+		logging.Print("Setting OS_USER=admin in .env\n")
 	}
 
 	// Generate OS_PASSWORD if not present
@@ -386,7 +386,7 @@ func EnsureObservabilityCredentials(installPath string) (bool, error) {
 		if err := SaveEnvVariable(envPath, "OS_PASSWORD", pw); err != nil {
 			return true, fmt.Errorf("failed to save OS_PASSWORD: %w", err)
 		}
-		fmt.Println("Generated OS_PASSWORD and saved to .env")
+		logging.Print("Generating OS_PASSWORD and saving to .env\n")
 		// Re-read so we can hash it below
 		envVars["OS_PASSWORD"] = pw
 	}
@@ -400,7 +400,7 @@ func EnsureObservabilityCredentials(installPath string) (bool, error) {
 		if err := SaveEnvVariable(envPath, "OS_PASSWORD_HASH", string(hash)); err != nil {
 			return true, fmt.Errorf("failed to save OS_PASSWORD_HASH: %w", err)
 		}
-		fmt.Println("Generated OS_PASSWORD_HASH and saved to .env")
+		logging.Print("Generating OS_PASSWORD_HASH and saving to .env\n")
 	}
 
 	return true, nil
@@ -500,7 +500,8 @@ func RewriteCaddy(installPath string) error {
 	writeLine("    import /etc/caddy/Caddyfile.site")
 	writeLine("")
 	if observable {
-		writeLine("    handle /opensearch/* {")
+		writeLine("    @opensearch path /opensearch /opensearch/*")
+		writeLine("    handle @opensearch {")
 		writeLine("        basicauth {")
 		writeLine("            " + envVars["OS_USER"] + " " + envVars["OS_PASSWORD_HASH"])
 		writeLine("        }")


### PR DESCRIPTION
## Summary

- When `COMPOSE_PROFILES` includes `observable`, `InitConfig` generates `OS_USER`, `OS_PASSWORD`, and a bcrypt `OS_PASSWORD_HASH` in `.env`
- `RewriteCaddy` adds a `basicauth`-protected `/opensearch` route proxying to `opensearch-dashboards:5601`
- `MigrateConfig` detects missing credentials on existing installations during `canasta upgrade` and generates them
- Adds user-facing observability guide in `docs/guide/observability.md`

Companion PR: CanastaWiki/Canasta-DockerCompose#74

Closes #302. Builds on #301.