### PR TITLE
fix(docs): correct CirrusSearch anchor in extensions and skins guide

### DIFF
--- a/docs/guide/extensions-and-skins.md
+++ b/docs/guide/extensions-and-skins.md
@@ -13,7 +13,7 @@
   - [Overriding a bundled extension](#overriding-a-bundled-extension)
   - [Composer dependencies](#composer-dependencies)
 - [Semantic MediaWiki](#semantic-mediawiki)
-- [CirrusSearch / Elasticsearch](#cirussearch--elasticsearch)
+- [CirrusSearch / Elasticsearch](#cirrussearch-elasticsearch)
 - [How it works under the hood](#how-it-works-under-the-hood)
 - [Important notes](#important-notes)
 


### PR DESCRIPTION
This PR fixes an incorrect anchor link for the “CirrusSearch / Elasticsearch” section in
`docs/guide/extensions-and-skins.md`, which caused a MkDocs warning during documentation builds.

The link was pointing to a non-existent anchor and has been corrected to match the
auto-generated MkDocs heading slug.

No code, tests, or workflow files are modified.