### PR TITLE
Fix empty instance IDs and spinner output wrapping

### DIFF
--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -127,6 +127,11 @@ an existing database dump instead of running the installer.`,
 				fmt.Printf("Generated admin password for wiki '%s'\n", wikiID)
 			}
 
+			instance, err = canasta.CheckCanastaId(instance)
+			if err != nil {
+				return err
+			}
+
 			fmt.Printf("Adding wiki '%s' to Canasta instance '%s'...\n", wikiID, instance.Id)
 			err = AddWiki(instance, wikiID, siteName, domainName, wikiPath, databasePath, wikiSettingsPath, admin, adminPassword, wikidbuser, workingDir)
 			if err != nil {
@@ -156,14 +161,6 @@ an existing database dump instead of running the installer.`,
 
 // AddWiki accepts the Canasta instance info, wiki ID, site name, domain and path of the new wiki, database info, and the initial admin info, then creates a new wiki in the Canasta instance.
 func AddWiki(instance config.Installation, wikiID, siteName, domain, wikipath, databasePath, wikiSettingsPath, admin, adminPassword, wikidbuser, workingDir string) error {
-	var err error
-
-	//Checking Installation existence
-	instance, err = canasta.CheckCanastaId(instance)
-	if err != nil {
-		return err
-	}
-
 	orch, err := orchestrators.New(instance.Orchestrator)
 	if err != nil {
 		return err

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -153,6 +153,11 @@ instead of running the installer, or enable development mode with Xdebug.`,
 				}
 				return fmt.Errorf("Installation failed. Keeping all the containers and config files")
 			}
+			if devModeFlag {
+				fmt.Println("\033[32mDevelopment mode enabled. Edit files in mediawiki-code/ - changes appear immediately.\033[0m")
+				fmt.Println("\033[32mVSCode: Open the installation directory, install PHP Debug extension, and start 'Listen for Xdebug'.\033[0m")
+			}
+			fmt.Println("\033[32mIf you need email enabled for this wiki, please set $wgSMTP; email will not work otherwise. See https://mediawiki.org/wiki/Manual:$wgSMTP for options.\033[0m")
 			fmt.Println("Done.")
 			return nil
 		},
@@ -343,12 +348,6 @@ func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiI
 		return err
 	}
 
-	if devModeEnabled {
-		fmt.Println("\033[32mDevelopment mode enabled. Edit files in mediawiki-code/ - changes appear immediately.\033[0m")
-		fmt.Println("\033[32mVSCode: Open the installation directory, install PHP Debug extension, and start 'Listen for Xdebug'.\033[0m")
-	}
-
-	fmt.Println("\033[32mIf you need email enabled for this wiki, please set $wgSMTP; email will not work otherwise. See https://mediawiki.org/wiki/Manual:$wgSMTP for options.\033[0m")
 	return nil
 }
 

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -139,13 +139,14 @@ instead of running the installer, or enable development mode with Xdebug.`,
 			if devModeFlag {
 				description = "Creating Canasta installation '" + canastaInfo.Id + "' with dev mode..."
 			}
-			_, done := spinner.New(description)
+			stopSpinner := spinner.New(description)
 
 			orch, err := orchestrators.New(orchestrator)
 			if err != nil {
 				return err
 			}
-			if err = createCanasta(canastaInfo, workingDir, path, wikiID, siteName, domain, yamlPath, orch, orchestrator, override, envFile, composerFile, devModeFlag, devTag, buildFromPath, databasePath, wikiSettingsPath, globalSettingsPath, done); err != nil {
+			if err = createCanasta(canastaInfo, workingDir, path, wikiID, siteName, domain, yamlPath, orch, orchestrator, override, envFile, composerFile, devModeFlag, devTag, buildFromPath, databasePath, wikiSettingsPath, globalSettingsPath); err != nil {
+				stopSpinner()
 				fmt.Print(err.Error(), "\n")
 				if !keepConfig {
 					deleteConfigAndContainers(path+"/"+canastaInfo.Id, orch)
@@ -153,6 +154,7 @@ instead of running the installer, or enable development mode with Xdebug.`,
 				}
 				return fmt.Errorf("Installation failed. Keeping all the containers and config files")
 			}
+			stopSpinner()
 			if devModeFlag {
 				fmt.Println("\033[32mDevelopment mode enabled. Edit files in mediawiki-code/ - changes appear immediately.\033[0m")
 				fmt.Println("\033[32mVSCode: Open the installation directory, install PHP Debug extension, and start 'Listen for Xdebug'.\033[0m")
@@ -197,13 +199,7 @@ instead of running the installer, or enable development mode with Xdebug.`,
 }
 
 // createCanasta accepts all the keyword arguments and creates an installation of the latest Canasta.
-func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiID, siteName, domain, yamlPath string, orch orchestrators.Orchestrator, orchestrator, override, envFile, composerFile string, devModeEnabled bool, devTag, buildFromPath, databasePath, wikiSettingsPath, globalSettingsPath string, done chan struct{}) error {
-	// Pass a message to the "done" channel indicating the completion of createCanasta function.
-	// This signals the spinner to stop printing progress, regardless of success or failure.
-	defer func() {
-		done <- struct{}{}
-	}()
-
+func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiID, siteName, domain, yamlPath string, orch orchestrators.Orchestrator, orchestrator, override, envFile, composerFile string, devModeEnabled bool, devTag, buildFromPath, databasePath, wikiSettingsPath, globalSettingsPath string) error {
 	// Determine the base image to use
 	var baseImage string
 	if buildFromPath != "" {

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -44,6 +44,11 @@ prompted for confirmation before any data is deleted.`,
 			if instance.Id == "" && len(args) > 0 {
 				instance.Id = args[0]
 			}
+			var err error
+			instance, err = canasta.CheckCanastaId(instance)
+			if err != nil {
+				return err
+			}
 			if !yes {
 				reader := bufio.NewReader(os.Stdin)
 				fmt.Printf("This will permanently delete the Canasta installation '%s' and all its data. Continue? [y/N] ", instance.Id)
@@ -71,13 +76,6 @@ func Delete(instance config.Installation) error {
 	defer func() {
 		done <- struct{}{}
 	}()
-	var err error
-
-	//Checking Installation existence
-	instance, err = canasta.CheckCanastaId(instance)
-	if err != nil {
-		return err
-	}
 
 	orch, err := orchestrators.New(instance.Orchestrator)
 	if err != nil {

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -72,10 +72,8 @@ prompted for confirmation before any data is deleted.`,
 
 func Delete(instance config.Installation) error {
 	description := "Deleting Canasta installation '" + instance.Id + "'..."
-	_, done := spinner.New(description)
-	defer func() {
-		done <- struct{}{}
-	}()
+	stopSpinner := spinner.New(description)
+	defer stopSpinner() // ensure cleanup on error paths
 
 	orch, err := orchestrators.New(instance.Orchestrator)
 	if err != nil {
@@ -122,6 +120,7 @@ func Delete(instance config.Installation) error {
 		return err
 	}
 
+	stopSpinner()
 	fmt.Println("Deleted.")
 	return nil
 }

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -42,6 +42,11 @@ for confirmation before any data is deleted.`,
   # Remove without confirmation prompt
   canasta remove -i myinstance -w docs -y`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			instance, err = canasta.CheckCanastaId(instance)
+			if err != nil {
+				return err
+			}
+
 			fmt.Printf("Removing wiki '%s' from Canasta instance '%s'...\n", wikiID, instance.Id)
 			if err := RemoveWiki(instance, wikiID, yes); err != nil {
 				return err
@@ -59,13 +64,6 @@ for confirmation before any data is deleted.`,
 
 // RemoveWiki removes a wiki with the given wikiID from a Canasta instance
 func RemoveWiki(instance config.Installation, wikiID string, yes bool) error {
-	var err error
-	//Checking Installation existence
-	instance, err = canasta.CheckCanastaId(instance)
-	if err != nil {
-		return err
-	}
-
 	orch, err := orchestrators.New(instance.Orchestrator)
 	if err != nil {
 		return err

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -17,6 +17,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
 	"github.com/CanastaWiki/Canasta-CLI/internal/git"
 	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
+	"github.com/CanastaWiki/Canasta-CLI/internal/spinner"
 	"github.com/sethvargo/go-password/password"
 )
 
@@ -597,7 +598,7 @@ func GeneratePassword(purpose string) (string, error) {
 // SavePasswordToFile saves a password to a file in the specified directory
 func SavePasswordToFile(directory, filename, password string) error {
 	filePath := filepath.Join(directory, filename)
-	logging.Print(fmt.Sprintf("Saving password to %s\n", filePath))
+	spinner.Print(fmt.Sprintf("Saving password to %s\n", filePath))
 	file, err := os.Create(filePath)
 	if err != nil {
 		return err

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -597,7 +597,7 @@ func GeneratePassword(purpose string) (string, error) {
 // SavePasswordToFile saves a password to a file in the specified directory
 func SavePasswordToFile(directory, filename, password string) error {
 	filePath := filepath.Join(directory, filename)
-	fmt.Printf("Saving password to %s\n", filePath)
+	logging.Print(fmt.Sprintf("Saving password to %s\n", filePath))
 	file, err := os.Create(filePath)
 	if err != nil {
 		return err

--- a/internal/farmsettings/farmsettings.go
+++ b/internal/farmsettings/farmsettings.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	yaml "gopkg.in/yaml.v2"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 )
 
 type Wiki struct {
@@ -56,7 +58,7 @@ func GenerateWikisYaml(filePath, wikiID, domain, siteName string) (string, error
 		return "", err
 	}
 
-	fmt.Println("Successfully written to wikis.yaml")
+	logging.Print("Successfully written to wikis.yaml\n")
 	absPath, err := filepath.Abs(filePath)
 	if err != nil {
 		return "", err

--- a/internal/farmsettings/farmsettings.go
+++ b/internal/farmsettings/farmsettings.go
@@ -9,7 +9,7 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
+	"github.com/CanastaWiki/Canasta-CLI/internal/spinner"
 )
 
 type Wiki struct {
@@ -58,7 +58,7 @@ func GenerateWikisYaml(filePath, wikiID, domain, siteName string) (string, error
 		return "", err
 	}
 
-	logging.Print("Successfully written to wikis.yaml\n")
+	spinner.Print("Successfully written to wikis.yaml\n")
 	absPath, err := filepath.Abs(filePath)
 	if err != nil {
 		return "", err

--- a/internal/spinner/spinner.go
+++ b/internal/spinner/spinner.go
@@ -9,13 +9,19 @@ import (
 	"github.com/schollz/progressbar/v3"
 )
 
+// mu protects both the spinner's rendering (Add/Finish) and Print's
+// clear-and-write, so intermediate messages never collide with the spinner.
+var mu sync.Mutex
+
+// active is true while a spinner is running.
+var active bool
+
 // New creates a spinner that displays progress with the following structure:
 // ⠏ Description...
 // It returns a stop function. Call stop() to finish the spinner, clear the line,
 // and print a newline so subsequent output appears on its own line.
 // The stop function is idempotent and safe to call multiple times.
 func New(description string) func() {
-	// Create a spinner to show progress and time taken, to avoid the illusion of the CLI being hung.
 	s := progressbar.NewOptions(-1,
 		progressbar.OptionEnableColorCodes(true),
 		progressbar.OptionSetWriter(os.Stdout),
@@ -30,19 +36,26 @@ func New(description string) func() {
 		}),
 	)
 
-	// done signals the goroutine to stop. finished is closed after cleanup completes.
 	done := make(chan struct{})
 	finished := make(chan struct{})
+
+	mu.Lock()
+	active = true
+	mu.Unlock()
 
 	go func() {
 		defer close(finished)
 		for {
 			select {
 			case <-done:
+				mu.Lock()
 				_ = s.Finish()
+				mu.Unlock()
 				return
 			default:
+				mu.Lock()
 				_ = s.Add(1)
+				mu.Unlock()
 				time.Sleep(5 * time.Millisecond)
 			}
 		}
@@ -53,6 +66,23 @@ func New(description string) func() {
 		once.Do(func() {
 			done <- struct{}{}
 			<-finished
+			mu.Lock()
+			active = false
+			mu.Unlock()
 		})
 	}
+}
+
+// Print prints a message to stdout. If a spinner is active, it clears the
+// spinner line first so the message appears on its own line, then lets the
+// spinner continue rendering on the next line.
+// When no spinner is active, it behaves like fmt.Fprint(os.Stdout, msg).
+func Print(msg string) {
+	mu.Lock()
+	defer mu.Unlock()
+	if active {
+		// Clear the spinner line: move cursor to column 0 and erase to end of line.
+		fmt.Fprint(os.Stdout, "\r\033[K")
+	}
+	fmt.Fprint(os.Stdout, msg)
 }


### PR DESCRIPTION
Fixes #309

## Summary

- Resolve instance ID via `CheckCanastaId()` before printing user-facing messages in `delete`, `add`, and `remove` commands, so the ID is never empty when invoked from inside an installation directory without `-i`
- Refactor spinner to return an idempotent `stop()` function that calls `Finish()` and waits for the goroutine to clean up, replacing the raw channel API that never cleared the spinner line
- Add `spinner.Print()` that clears the spinner line before printing, so intermediate progress messages ("Successfully written to wikis.yaml", "Saving password to ...") appear on their own lines without wrapping onto the spinner

## Test plan

- [x] `canasta create -i test -w main -a admin -n localhost -p /tmp` — spinner runs cleanly; "Successfully written to wikis.yaml" and "Saving password to ..." appear on their own lines; email/SMTP message and "Done." appear after the spinner clears
- [x] From inside an installation directory (no `-i` flag):
  - [x] `canasta add -w wiki2 -u localhost/wiki2 -a admin` — "Adding wiki 'wiki2' to Canasta instance 'test'..." shows resolved instance name
  - [x] `canasta remove -w wiki2 -y` — "Removing wiki 'wiki2' from Canasta instance 'test'..." shows resolved instance name
  - [x] `canasta delete -y` — spinner shows "Deleting Canasta installation 'test'..." with resolved instance name; "Deleted." appears on its own line after spinner
- [x] `canasta delete -i test -y` (with `-i` flag) — still works as before
- [x] `go test ./...` passes