### PR TITLE
[3/7] Embed Kubernetes manifest files in CLI binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,10 @@
 *.so
 *.dylib
 
-# YAML files (except mkdocs.yml)
+# YAML files (except mkdocs.yml and embedded orchestrator files)
 *.yaml
 !mkdocs.yml
+!internal/orchestrators/**/files/**/*.yaml
 
 # Build output directory
 build/

--- a/internal/orchestrators/kubernetes/embed.go
+++ b/internal/orchestrators/kubernetes/embed.go
@@ -1,0 +1,6 @@
+package kubernetes
+
+import "embed"
+
+//go:embed all:files
+var StackFiles embed.FS

--- a/internal/orchestrators/kubernetes/files/argocd/ARGOCD_USAGE.md
+++ b/internal/orchestrators/kubernetes/files/argocd/ARGOCD_USAGE.md
@@ -1,0 +1,51 @@
+# ArgoCD Usage Guide
+
+This guide provides instructions on how to use ArgoCD with the Canasta Kubernetes stack for deployments, upgrades, and general management.
+
+## Initial Setup & Access
+
+### 1. Retrieve the Initial Admin Password
+By default, the initial password for the `admin` user is auto-generated and stored as a secret. Retrieve it with:
+
+```bash
+kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d; echo
+```
+
+### 2. Access the UI
+You can access the ArgoCD UI by port-forwarding the ArgoCD server service:
+
+```bash
+kubectl port-forward svc/argocd-server -n argocd LOCAL_PORT:443
+```
+
+Open your browser and navigate to `https://localhost:<LOCAL_PORT>`.
+- **Username**: `admin`
+- **Password**: (The password you retrieved in step 1)
+
+> **Note**: It is highly recommended to change the password after the first login.
+
+## Deployments
+
+ArgoCD operates on a GitOps model. This means the state of your cluster is defined by the files in this repository.
+
+### Triggering a Deployment
+1. **Commit & Push**: Make changes to your Kubernetes manifests (e.g., `Kubernetes/web.yaml`, `kustomization.yaml`) and push them to the repository branch that ArgoCD is tracking (usually `main` or `master`).
+2. **Auto-Sync**: If you have configured the Application to auto-sync (which is the default in our `argocd-app.yaml`), ArgoCD will automatically detect the changes and apply them to the cluster within a few minutes.
+3. **Manual Sync**: You can manually trigger a sync via the ArgoCD UI or CLI if you want changes applied immediately.
+
+## Upgrades
+
+To upgrade Canasta or any other component:
+
+1. **Update Image Tags**: Edit the `Kubernetes/web.yaml` (or other relevant files) to point to the new docker image version.
+   ```yaml
+   image: ghcr.io/canastawiki/canasta:x.y.z
+   ```
+2. **Update Configuration**: If the upgrade requires configuration changes (e.g., new `LocalSettings.php` parameters), update the files in `config/`.
+3. **Push Changes**: Commit and push these changes to your git repository.
+4. **Sync**: ArgoCD will pick up the changes and perform a rolling update of the deployments.
+
+## Troubleshooting
+
+- **OutOfSync**: If the application status is `OutOfSync`, click the "Sync" button in the UI to see the diff and force a synchronization.
+- **Health Status**: Check the "Health" status of the application in the UI. If it is "Degraded", inspect the individual resources (Pods, Services) for errors.

--- a/internal/orchestrators/kubernetes/files/argocd/argocd-app.yaml
+++ b/internal/orchestrators/kubernetes/files/argocd/argocd-app.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: canasta
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/CanastaWiki/Canasta-Kubernetes.git
+    targetRevision: HEAD
+    path: .
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true

--- a/internal/orchestrators/kubernetes/files/kubernetes/caddy.yaml
+++ b/internal/orchestrators/kubernetes/files/kubernetes/caddy.yaml
@@ -1,0 +1,102 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: caddy-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "200Mi"
+  volumeMode: Filesystem
+
+--- 
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: caddy-lb
+spec:
+  type: LoadBalancer
+  ports:
+  - name: http-caddy
+    port: 80
+    targetPort: 80
+  - name: https-caddy
+    port: 443
+    targetPort: 443
+  selector:
+    app: caddy
+
+---
+
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: caddy
+spec:
+  selector:
+    matchLabels:
+      app: caddy
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: caddy
+    spec:
+      containers:
+      - name: caddy
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+          limits:
+            memory: "128Mi"
+            cpu: "100m"
+        image: caddy:2.4.6-alpine
+        env:
+        - name: MW_SITE_FQDN
+          valueFrom:
+            configMapKeyRef:
+              name: canasta-env
+              key: MW_SITE_FQDN
+        command: 
+        - "caddy"
+        - "reverse-proxy"
+        - "--from"
+        - "$(MW_SITE_FQDN)"
+        - "--to"
+        - "varnish:80"
+        ports:
+        - name: http-caddy
+          containerPort: 80
+        - name: https-caddy
+          containerPort: 443
+        volumeMounts:
+          - name: caddy-data
+            mountPath: /data
+      volumes:
+        - name: caddy-data
+          persistentVolumeClaim:
+            claimName: caddy-data
+---
+
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: caddy-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: caddy
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50

--- a/internal/orchestrators/kubernetes/files/kubernetes/caddy.yaml
+++ b/internal/orchestrators/kubernetes/files/kubernetes/caddy.yaml
@@ -54,20 +54,14 @@ spec:
           limits:
             memory: "128Mi"
             cpu: "100m"
-        image: caddy:2.4.6-alpine
-        env:
-        - name: MW_SITE_FQDN
-          valueFrom:
-            configMapKeyRef:
-              name: canasta-env
-              key: MW_SITE_FQDN
-        command: 
+        image: caddy:2.8.4-alpine
+        command:
         - "caddy"
-        - "reverse-proxy"
-        - "--from"
-        - "$(MW_SITE_FQDN)"
-        - "--to"
-        - "varnish:80"
+        - "run"
+        - "--config"
+        - "/etc/caddy/Caddyfile"
+        - "--adapter"
+        - "caddyfile"
         ports:
         - name: http-caddy
           containerPort: 80
@@ -76,10 +70,22 @@ spec:
         volumeMounts:
           - name: caddy-data
             mountPath: /data
+          - name: canasta-config
+            mountPath: /etc/caddy/Caddyfile
+            subPath: Caddyfile
+          - name: canasta-config
+            mountPath: /etc/caddy/Caddyfile.site
+            subPath: Caddyfile.site
+          - name: canasta-config
+            mountPath: /etc/caddy/Caddyfile.global
+            subPath: Caddyfile.global
       volumes:
         - name: caddy-data
           persistentVolumeClaim:
             claimName: caddy-data
+        - name: canasta-config
+          configMap:
+            name: canasta-config
 ---
 
 apiVersion: autoscaling/v2

--- a/internal/orchestrators/kubernetes/files/kubernetes/db.yaml
+++ b/internal/orchestrators/kubernetes/files/kubernetes/db.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: db
+spec:
+  selector:
+      app: db
+  ports:
+    - protocol: TCP
+      port: 3306
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "200Mi"
+  volumeMode: Filesystem
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: db
+spec:
+  selector:
+    matchLabels:
+      app: db
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: db
+    spec:
+      containers:
+      - name: db
+        image: mysql:8.0
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "1Gi"
+            cpu: "500m"
+        env:
+          - name: MYSQL_ROOT_HOST
+            value: "%"
+          - name: MYSQL_ROOT_PASSWORD
+            valueFrom:
+              configMapKeyRef:
+                name: canasta-env
+                key: MYSQL_PASSWORD
+          - name: MYSQL_DATABASE
+            value: "mediawiki"
+        ports:
+        - containerPort: 3306
+        volumeMounts:
+        - name: initdb-volume
+          mountPath: /docker-entrypoint-initdb.d
+        - name: my-cnf-config
+          mountPath: /etc/my.cnf
+          subPath: my.cnf
+        - name: mysql-data
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: initdb-volume
+        hostPath:
+          path: /canasta/config-data/_initdb
+          type: DirectoryOrCreate
+      - name: my-cnf-config
+        configMap:
+          name: canasta-config
+          items:
+          - key: "my.cnf"
+            path: "my.cnf"
+      - name: mysql-data
+        persistentVolumeClaim:
+          claimName: mysql-data

--- a/internal/orchestrators/kubernetes/files/kubernetes/elasticsearch.yaml
+++ b/internal/orchestrators/kubernetes/files/kubernetes/elasticsearch.yaml
@@ -1,0 +1,75 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch
+spec:
+  selector:
+      app: elasticsearch
+  ports:
+    - name: elasticsearch-http
+      protocol: TCP
+      port: 9200
+      targetPort: 9200
+    - name: elasticsearch-transport
+      protocol: TCP
+      port: 9300
+      targetPort: 9300
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: elasticsearch-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "1Gi"
+  volumeMode: Filesystem
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: elasticsearch
+spec:
+  selector:
+    matchLabels:
+      app: elasticsearch
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: elasticsearch
+    spec:
+      containers:
+      - name: elasticsearch
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+        resources:
+          limits:
+            memory: "1Gi"
+          requests:
+            memory: "256Mi"
+            cpu: "200m"
+        env:
+          - name: discovery.type
+            value: "single-node"
+          - name: bootstrap.memory_lock
+            value: "true"
+          - name: ES_JAVA_OPTS
+            value: "-Xms512m -Xmx512m"
+        ports:
+        - containerPort: 9200
+          name: http
+        - containerPort: 9300
+          name: transport
+        volumeMounts:
+        - name: elasticsearch-data
+          mountPath: /usr/share/elasticsearch/data
+      volumes:
+      - name: elasticsearch-data
+        persistentVolumeClaim:
+          claimName: elasticsearch-data

--- a/internal/orchestrators/kubernetes/files/kubernetes/namespace.yaml
+++ b/internal/orchestrators/kubernetes/files/kubernetes/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: canasta
+  labels:
+    name: canasta

--- a/internal/orchestrators/kubernetes/files/kubernetes/varnish.yaml
+++ b/internal/orchestrators/kubernetes/files/kubernetes/varnish.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: varnish
+spec:
+  selector:
+      app: varnish
+  ports:
+    - protocol: TCP
+      port: 80
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: varnish
+spec:
+  selector:
+    matchLabels:
+      app: varnish
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: varnish
+    spec:
+      containers:
+      - name: varnish
+        image: varnish:7.0.2-alpine
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "200m"
+        ports:
+        - containerPort: 80
+        volumeMounts:
+          - name: default-vcl-config
+            mountPath: /etc/varnish/default.vcl
+            subPath: ./default.vcl
+      volumes:
+          - name: default-vcl-config
+            configMap:
+              name: canasta-config
+              items:
+              - key: "default.vcl"
+                path: "default.vcl"
+---
+
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: varnish-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: varnish
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50

--- a/internal/orchestrators/kubernetes/files/kubernetes/web.yaml
+++ b/internal/orchestrators/kubernetes/files/kubernetes/web.yaml
@@ -79,12 +79,8 @@ spec:
         - mountPath: /mediawiki/config/my.cnf
           name: canasta-config
           subPath: my.cnf
-        - mountPath: /mediawiki/config/settings/global/Vector.php
-          name: canasta-settings
-          subPath: Vector.php
-        - mountPath: /mediawiki/config/settings/global/CanastaFooterIcon.php
-          name: canasta-settings
-          subPath: CanastaFooterIcon.php
+        - mountPath: /mediawiki/config/settings/global
+          name: canasta-settings-global
         - mountPath: /mediawiki/images
           name: config-volume
           subPath: images
@@ -94,9 +90,9 @@ spec:
           - name: canasta-config
             configMap:
               name: canasta-config
-          - name: canasta-settings
+          - name: canasta-settings-global
             configMap:
-              name: canasta-settings
+              name: canasta-settings-global
           - name: config-volume
             hostPath:
               path: /canasta/config-data

--- a/internal/orchestrators/kubernetes/files/kubernetes/web.yaml
+++ b/internal/orchestrators/kubernetes/files/kubernetes/web.yaml
@@ -1,0 +1,126 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  selector:
+      app: web
+  ports:
+    - protocol: TCP
+      port: 80
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sitemap-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "200Mi"
+  volumeMode: Filesystem
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  selector:
+    matchLabels:
+      app: web
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+      - name: web
+        image: ghcr.io/canastawiki/canasta:latest
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        ports:
+        - containerPort: 80
+        envFrom:
+        - configMapRef:
+            name: canasta-env
+        volumeMounts:
+        - mountPath: /var/www/mediawiki/w/user-extensions
+          name: config-volume
+          subPath: extensions
+        - mountPath: /var/www/mediawiki/w/user-skins
+          name: config-volume
+          subPath: skins
+        - mountPath: /mediawiki/config/wikis.yaml
+          name: canasta-config
+          subPath: wikis.yaml
+        - mountPath: /mediawiki/config/Caddyfile
+          name: canasta-config
+          subPath: Caddyfile
+        - mountPath: /mediawiki/config/Caddyfile.site
+          name: canasta-config
+          subPath: Caddyfile.site
+        - mountPath: /mediawiki/config/Caddyfile.global
+          name: canasta-config
+          subPath: Caddyfile.global
+        - mountPath: /mediawiki/config/default.vcl
+          name: canasta-config
+          subPath: default.vcl
+        - mountPath: /mediawiki/config/my.cnf
+          name: canasta-config
+          subPath: my.cnf
+        - mountPath: /mediawiki/config/settings/global/Vector.php
+          name: canasta-settings
+          subPath: Vector.php
+        - mountPath: /mediawiki/config/settings/global/CanastaFooterIcon.php
+          name: canasta-settings
+          subPath: CanastaFooterIcon.php
+        - mountPath: /mediawiki/images
+          name: config-volume
+          subPath: images
+        - name: sitemap-data
+          mountPath: /mediawiki/sitemap
+      volumes:
+          - name: canasta-config
+            configMap:
+              name: canasta-config
+          - name: canasta-settings
+            configMap:
+              name: canasta-settings
+          - name: config-volume
+            hostPath:
+              path: /canasta/config-data
+              type: DirectoryOrCreate
+          - name: sitemap-data
+            persistentVolumeClaim:
+              claimName: sitemap-data
+---
+
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: web-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: web
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50

--- a/internal/orchestrators/kubernetes/files/kustomization.yaml.tmpl
+++ b/internal/orchestrators/kubernetes/files/kustomization.yaml.tmpl
@@ -11,7 +11,7 @@ resources:
 - kubernetes/web.yaml
 
 configMapGenerator:
-- name: canasta-settings
+- name: canasta-settings-global
   files:
   - config/settings/global/CanastaFooterIcon.php
   - config/settings/global/Vector.php

--- a/internal/orchestrators/kubernetes/files/kustomization.yaml.tmpl
+++ b/internal/orchestrators/kubernetes/files/kustomization.yaml.tmpl
@@ -1,0 +1,30 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: {{.Namespace}}
+
+resources:
+- kubernetes/namespace.yaml
+- kubernetes/caddy.yaml
+- kubernetes/db.yaml
+- kubernetes/elasticsearch.yaml
+- kubernetes/varnish.yaml
+- kubernetes/web.yaml
+
+configMapGenerator:
+- name: canasta-settings
+  files:
+  - config/settings/global/CanastaFooterIcon.php
+  - config/settings/global/Vector.php
+- name: canasta-config
+  files:
+  - config/wikis.yaml
+  - config/Caddyfile
+  - config/Caddyfile.site
+  - config/Caddyfile.global
+  - config/default.vcl
+  - my.cnf
+  # Uncomment the following line once you have a LocalSettings.php file
+  # - config/LocalSettings.php
+- name: canasta-env
+  envs:
+  - .env


### PR DESCRIPTION
## Summary

**[3/7]** in the embed + K8s stack. Depends on #308.

- Embed 6 Kubernetes manifest YAMLs (namespace, web, db, caddy, varnish, elasticsearch) and a `kustomization.yaml.tmpl` Go template in the CLI binary
- Implement `WriteStackFiles()` / `UpdateStackFiles()` for the Kubernetes orchestrator
- Implement `InitConfig()` to generate `kustomization.yaml` with namespace injection from installation ID
- Add comprehensive tests for manifest writing, no-clobber semantics, update detection, and kustomization generation

Closes #312.

## Design

Follows the same pattern as #308 for Compose: a sub-package `internal/orchestrators/kubernetes/` with `//go:embed all:files` and a `files/` directory containing the static manifests and a Go template. The 6 manifest YAMLs are copied from the Canasta-Kubernetes repo as-is; kustomize handles namespace substitution via the generated `kustomization.yaml`.

~464 of the ~784 added lines are static YAML manifests.

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./...` all tests pass (9 new K8s tests)
- [x] Existing Compose tests unaffected