### PR TITLE
Add Kubernetes backup support

### DIFF
--- a/cmd/backup/create.go
+++ b/cmd/backup/create.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
+	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
 func createBackupCmdCreate() *cobra.Command {
@@ -38,6 +39,9 @@ uploads the snapshot to the backup repository with the specified tag.`,
 }
 
 func takeSnapshot(tag string) error {
+	if _, ok := orch.(*orchestrators.KubernetesOrchestrator); ok {
+		return fmt.Errorf("backup create is not yet supported for Kubernetes installations")
+	}
 	fmt.Printf("Taking snapshot '%s'...\n", tag)
 	EnvVariables, err := canasta.GetEnvVariable(envPath)
 	if err != nil {

--- a/cmd/backup/restore.go
+++ b/cmd/backup/restore.go
@@ -10,6 +10,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
 	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
+	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
 func restoreCmdCreate() *cobra.Command {
@@ -51,6 +52,9 @@ images, and public assets from the backup, leaving shared files untouched.`,
 }
 
 func restoreSnapshot(snapshotId string, skipBeforeSnapshot bool, wikiID string) error {
+	if _, ok := orch.(*orchestrators.KubernetesOrchestrator); ok {
+		return fmt.Errorf("backup restore is not yet supported for Kubernetes installations")
+	}
 	EnvVariables, envErr := canasta.GetEnvVariable(envPath)
 	if envErr != nil {
 		return envErr

--- a/cmd/backup/schedule.go
+++ b/cmd/backup/schedule.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
+	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 	"github.com/spf13/cobra"
 )
 
@@ -112,6 +113,10 @@ func writeCrontab(lines []string) error {
 }
 
 func scheduleBackup(cronExpression string) error {
+	if _, ok := orch.(*orchestrators.KubernetesOrchestrator); ok {
+		return fmt.Errorf("Cron-based scheduling is not supported for Kubernetes installations; edit the backup CronJob in your kustomization.yaml instead")
+	}
+
 	if err := validateCron(cronExpression); err != nil {
 		return err
 	}

--- a/internal/orchestrators/kubernetes.go
+++ b/internal/orchestrators/kubernetes.go
@@ -328,7 +328,7 @@ func buildPodOverrides(volumes map[string]string) string {
 }
 
 func (k *KubernetesOrchestrator) RestoreFromBackupVolume(installPath string, dirs map[string]string) error {
-	return fmt.Errorf("backup is not yet supported for Kubernetes installations")
+	return fmt.Errorf("backup restore is not yet supported for Kubernetes installations")
 }
 
 func (k *KubernetesOrchestrator) InitConfig(installPath string) error {

--- a/internal/orchestrators/kubernetes_test.go
+++ b/internal/orchestrators/kubernetes_test.go
@@ -565,14 +565,15 @@ func TestGenerateKustomizationNoNodePort(t *testing.T) {
 	}
 }
 
-func TestRunBackupNotSupported(t *testing.T) {
+func TestRunBackupRequiresNamespace(t *testing.T) {
+	dir := t.TempDir()
 	k := &KubernetesOrchestrator{}
-	_, err := k.RunBackup("/tmp", "/tmp/.env", nil)
+	_, err := k.RunBackup(dir, filepath.Join(dir, ".env"), nil)
 	if err == nil {
 		t.Fatal("expected error from RunBackup")
 	}
-	if !strings.Contains(err.Error(), "not yet supported") {
-		t.Errorf("RunBackup() error = %q, want 'not yet supported'", err.Error())
+	if !strings.Contains(err.Error(), "kustomization.yaml") {
+		t.Errorf("RunBackup() error = %q, want error about kustomization.yaml", err.Error())
 	}
 }
 


### PR DESCRIPTION
> **Kubernetes support PR chain (merge order: #320 → #314 → #315 → #316 → #321 → #317).** Part of #131.

## Summary

- Implement `RunBackup()` for Kubernetes: launches an ephemeral restic pod via `kubectl run` with ConfigMap env injection
- Guard `backup create` and `backup restore` with clear "not yet supported" errors for K8s
- Guard `backup schedule set` for K8s: directs users to use a Kubernetes CronJob instead

Read-only restic subcommands (`init`, `list`, `check`, `delete`, `diff`, `files`, `unlock`) work for K8s installations today via the ephemeral pod.

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./...` all tests pass
- [x] Compose restic commands unaffected