### PR TITLE
Add registry support for K8s image builds

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -282,6 +282,7 @@ func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiI
 	if err := orch.InitConfig(path); err != nil {
 		return err
 	}
+	isK8s := orchestrator == "kubernetes" || orchestrator == "k8s"
 	if override != "" {
 		compose, ok := orch.(*orchestrators.ComposeOrchestrator)
 		if !ok {
@@ -293,7 +294,6 @@ func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiI
 	}
 
 	// Dev mode: extract code and build xdebug image before starting
-	isK8s := orchestrator == "kubernetes" || orchestrator == "k8s"
 	if devModeEnabled && isK8s {
 		return fmt.Errorf("Development mode is only supported with Docker Compose")
 	}

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -282,7 +282,6 @@ func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiI
 	if err := orch.InitConfig(path); err != nil {
 		return err
 	}
-	isK8s := orchestrator == "kubernetes" || orchestrator == "k8s"
 	if override != "" {
 		compose, ok := orch.(*orchestrators.ComposeOrchestrator)
 		if !ok {
@@ -294,6 +293,7 @@ func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiI
 	}
 
 	// Dev mode: extract code and build xdebug image before starting
+	isK8s := orchestrator == "kubernetes" || orchestrator == "k8s"
 	if devModeEnabled && isK8s {
 		return fmt.Errorf("Development mode is only supported with Docker Compose")
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type Installation struct {
 	Orchestrator string `json:"orchestrator"`
 	DevMode      bool   `json:"devMode,omitempty"`
 	LocalCluster bool   `json:"localCluster,omitempty"`
+	Registry     string `json:"registry,omitempty"`
 }
 
 type Orchestrator struct {

--- a/internal/imagebuild/imagebuild.go
+++ b/internal/imagebuild/imagebuild.go
@@ -61,6 +61,25 @@ func BuildFromSource(workspacePath string) (string, error) {
 	return LocalCanastaTag, nil
 }
 
+// PushImage tags a local image and pushes it to a registry.
+// Returns the full registry image reference (e.g., "localhost:5000/canasta:local").
+func PushImage(localTag, registry string) (string, error) {
+	remoteTag := registry + "/" + localTag
+	logging.Print(fmt.Sprintf("Tagging %s as %s\n", localTag, remoteTag))
+	err, output := execute.Run("", "docker", "tag", localTag, remoteTag)
+	if err != nil {
+		return "", fmt.Errorf("failed to tag image: %s", output)
+	}
+
+	logging.Print(fmt.Sprintf("Pushing %s\n", remoteTag))
+	err, output = execute.Run("", "docker", "push", remoteTag)
+	if err != nil {
+		return "", fmt.Errorf("failed to push image: %s", output)
+	}
+
+	return remoteTag, nil
+}
+
 // buildImage builds a Docker image from a Dockerfile in the given path
 func buildImage(path, tag string) error {
 	err, output := execute.Run(path, "docker", "build", "-t", tag, ".")

--- a/internal/orchestrators/kubernetes_test.go
+++ b/internal/orchestrators/kubernetes_test.go
@@ -569,7 +569,7 @@ func TestRunBackupNotSupported(t *testing.T) {
 	k := &KubernetesOrchestrator{}
 	_, err := k.RunBackup("/tmp", "/tmp/.env", nil)
 	if err == nil {
-		t.Fatal("expected error from RunBackup")
+		t.Fatal("expected error from RunBackup without kustomization.yaml")
 	}
 	if !strings.Contains(err.Error(), "not yet supported") {
 		t.Errorf("RunBackup() error = %q, want 'not yet supported'", err.Error())


### PR DESCRIPTION
> **Kubernetes support PR chain (merge order: #320 → #314 → #316 → #321 → #317).** Part of #131.

## Summary

- Add `--registry` flag to `canasta create` (default `localhost:5000`) for pushing locally built images to a registry the K8s cluster can pull from
- Add `PushImage()` to `internal/imagebuild` for tagging and pushing to a registry
- Add kustomize `images` transformer in `generateKustomization()` that reads `CANASTA_IMAGE` from `.env` and overrides the default image in `web.yaml`
- Add `Registry` field to `config.Installation` for persistence

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./...` all tests pass
- [x] Compose workflows unaffected