### PR TITLE
Add Observability guide to navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
     - Development mode: guide/devmode.md
     - Backup and restore: guide/backup.md
     - Best practices: guide/best-practices.md
+    - Observability: guide/observability.md
     - Troubleshooting: guide/troubleshooting.md
   - CLI Reference:
     - Overview: cli/canasta.md


### PR DESCRIPTION
Adds Observability guide to navigation in mkdocs.yml.
Fixes missing sidebar entry and resolves MkDocs warning.