### PR TITLE
Wire Kubernetes into CLI commands

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -170,7 +170,7 @@ instead of running the installer, or enable development mode with Xdebug.`,
 	}
 
 	createCmd.Flags().StringVarP(&path, "path", "p", workingDir, "Canasta directory")
-	createCmd.Flags().StringVarP(&orchestrator, "orchestrator", "o", "compose", "Orchestrator to use for installation")
+	createCmd.Flags().StringVarP(&orchestrator, "orchestrator", "o", "compose", "Orchestrator to use (compose or kubernetes)")
 	createCmd.Flags().StringVarP(&canastaInfo.Id, "id", "i", "", "Canasta instance ID")
 	createCmd.Flags().StringVarP(&wikiID, "wiki", "w", "", "ID of the wiki")
 	createCmd.Flags().StringVarP(&siteName, "site-name", "t", "", "Display name of the wiki (optional, defaults to wiki ID)")
@@ -282,6 +282,12 @@ func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiI
 	if err := orch.InitConfig(path); err != nil {
 		return err
 	}
+	isK8s := orchestrator == "kubernetes" || orchestrator == "k8s"
+	if isK8s {
+		if err := canasta.GenerateKustomization(path, canastaInfo.Id); err != nil {
+			return err
+		}
+	}
 	if override != "" {
 		compose, ok := orch.(*orchestrators.ComposeOrchestrator)
 		if !ok {
@@ -293,6 +299,9 @@ func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiI
 	}
 
 	// Dev mode: extract code and build xdebug image before starting
+	if devModeEnabled && isK8s {
+		return fmt.Errorf("Development mode is only supported with Docker Compose")
+	}
 	if devModeEnabled {
 		if err := devmode.SetupFullDevMode(path, orch, baseImage); err != nil {
 			return err

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -282,12 +282,6 @@ func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiI
 	if err := orch.InitConfig(path); err != nil {
 		return err
 	}
-	isK8s := orchestrator == "kubernetes" || orchestrator == "k8s"
-	if isK8s {
-		if err := canasta.GenerateKustomization(path, canastaInfo.Id); err != nil {
-			return err
-		}
-	}
 	if override != "" {
 		compose, ok := orch.(*orchestrators.ComposeOrchestrator)
 		if !ok {
@@ -299,6 +293,7 @@ func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiI
 	}
 
 	// Dev mode: extract code and build xdebug image before starting
+	isK8s := orchestrator == "kubernetes" || orchestrator == "k8s"
 	if devModeEnabled && isK8s {
 		return fmt.Errorf("Development mode is only supported with Docker Compose")
 	}

--- a/cmd/restart/restart.go
+++ b/cmd/restart/restart.go
@@ -83,6 +83,11 @@ func Restart(instance config.Installation, enableDev, disableDev bool) error {
 	}
 
 	// Handle dev mode enable/disable
+	if (enableDev || disableDev) {
+		if _, ok := orch.(*orchestrators.KubernetesOrchestrator); ok {
+			return fmt.Errorf("Development mode is only supported with Docker Compose")
+		}
+	}
 	if enableDev {
 		// Enable dev mode using default registry image
 		baseImage := canasta.GetDefaultImage()

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -30,9 +30,10 @@ var verbose bool
 var rootCmd = &cobra.Command{
 	Use:   "canasta",
 	Short: "A CLI tool for Canasta installations.",
-	Long: `Canasta CLI manages Canasta MediaWiki installations using Docker Compose.
-It supports creating, importing, starting, stopping, upgrading, and backing up
-multiple Canasta instances, including wiki farms with multiple wikis per instance.`,
+	Long: `Canasta CLI manages Canasta MediaWiki installations using Docker Compose
+or Kubernetes. It supports creating, importing, starting, stopping, upgrading,
+and backing up multiple Canasta instances, including wiki farms with multiple
+wikis per instance.`,
 	SilenceErrors: true,
 	SilenceUsage:  true,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -73,6 +73,11 @@ func Start(instance config.Installation, enableDev, disableDev bool) error {
 	if err != nil {
 		return err
 	}
+	if (enableDev || disableDev) {
+		if _, ok := orch.(*orchestrators.KubernetesOrchestrator); ok {
+			return fmt.Errorf("Development mode is only supported with Docker Compose")
+		}
+	}
 	if enableDev {
 		// Enable dev mode using default registry image
 		baseImage := canasta.GetDefaultImage()

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -171,7 +171,7 @@ func Upgrade(instance config.Installation, dryRun bool) error {
 	if !dryRun {
 		if isK8s {
 			fmt.Println("Regenerating kustomization.yaml and re-applying manifests...")
-			if err := canasta.GenerateKustomization(instance.Path, instance.Id); err != nil {
+			if err := orch.InitConfig(instance.Path); err != nil {
 				return err
 			}
 			imagesUpdated = true

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -167,8 +167,15 @@ func Upgrade(instance config.Installation, dryRun bool) error {
 	canastaImage := envVars["CANASTA_IMAGE"]
 	isLocalBuild := strings.HasPrefix(canastaImage, "canasta:local")
 
+	_, isK8s := orch.(*orchestrators.KubernetesOrchestrator)
 	if !dryRun {
-		if isLocalBuild {
+		if isK8s {
+			fmt.Println("Regenerating kustomization.yaml and re-applying manifests...")
+			if err := canasta.GenerateKustomization(instance.Path, instance.Id); err != nil {
+				return err
+			}
+			imagesUpdated = true
+		} else if isLocalBuild {
 			fmt.Println("Skipping image pull: this instance uses a locally-built image.")
 		} else {
 			fmt.Println("Pulling Canasta container images...")

--- a/internal/canasta/installation-template/my.cnf
+++ b/internal/canasta/installation-template/my.cnf
@@ -1,5 +1,2 @@
-[client]
-skip-binary-as-hex = true
-
 [mysql]
 skip-binary-as-hex = true

--- a/internal/orchestrators/kubernetes.go
+++ b/internal/orchestrators/kubernetes.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
 	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators/kubernetes"
@@ -292,7 +293,16 @@ func (k *KubernetesOrchestrator) InitConfig(installPath string) error {
 	if err := tmpl.Execute(&buf, struct{ Namespace string }{namespace}); err != nil {
 		return fmt.Errorf("failed to execute kustomization template: %w", err)
 	}
-	return os.WriteFile(filepath.Join(installPath, "kustomization.yaml"), buf.Bytes(), 0644)
+	if err := os.WriteFile(filepath.Join(installPath, "kustomization.yaml"), buf.Bytes(), 0644); err != nil {
+		return err
+	}
+	if err := canasta.CreateCaddyfileSite(installPath); err != nil {
+		return err
+	}
+	if err := canasta.CreateCaddyfileGlobal(installPath); err != nil {
+		return err
+	}
+	return canasta.RewriteCaddy(installPath)
 }
 
 func (k *KubernetesOrchestrator) UpdateConfig(installPath string) error {

--- a/internal/orchestrators/kubernetes_test.go
+++ b/internal/orchestrators/kubernetes_test.go
@@ -225,8 +225,15 @@ func TestUpdateStackFilesDryRun(t *testing.T) {
 
 func TestInitConfigGeneratesKustomization(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "my-wiki")
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	configDir := filepath.Join(dir, "config")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
 		t.Fatalf("failed to create dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("COMPOSE_PROFILES=web\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "wikis.yaml"), []byte("wikis:\n  - id: main\n    url: example.com\n"), 0644); err != nil {
+		t.Fatal(err)
 	}
 
 	k := &KubernetesOrchestrator{}
@@ -277,8 +284,15 @@ func TestInitConfigGeneratesKustomization(t *testing.T) {
 func TestInitConfigNamespaceFromPath(t *testing.T) {
 	// Test that the namespace is derived from the directory name
 	dir := filepath.Join(t.TempDir(), "production-wiki")
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	configDir := filepath.Join(dir, "config")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
 		t.Fatalf("failed to create dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("COMPOSE_PROFILES=web\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "wikis.yaml"), []byte("wikis:\n  - id: main\n    url: example.com\n"), 0644); err != nil {
+		t.Fatal(err)
 	}
 
 	k := &KubernetesOrchestrator{}


### PR DESCRIPTION
> **Kubernetes support PR chain (merge order: #320 → #314 → #316 → #321 → #317).** Part of #131.

## Summary

Wire the Kubernetes orchestrator into the main CLI commands:

- Add K8s support to `canasta create`, `canasta start`, and `canasta restart`
- Add K8s-specific upgrade flow in `canasta upgrade` (regenerate kustomization + re-apply)
- Fix `install.php` to write to `/tmp/canasta-install/` (ConfigMap mounts are read-only in K8s)
- Fix `InstallOne()` temp directory and LocalSettings.php cleanup for K8s
- Update CLI description to mention Kubernetes support
- Add Caddyfile creation to K8s `InitConfig()`

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./...` passes
- [x] Docker Compose create/start/restart/upgrade still work (no regression)