### PR TITLE
Add CLI-managed kind cluster lifecycle

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -43,6 +43,7 @@ func NewCmdCreate() *cobra.Command {
 		globalSettingsPath string // path to existing global settings file
 		composerFile       string // path to custom composer.local.json
 		registry           string // container registry for K8s image push
+		localCluster       bool   // use NodePort for local K8s clusters
 	)
 	createCmd := &cobra.Command{
 		Use:   "create",
@@ -146,7 +147,14 @@ instead of running the installer, or enable development mode with Xdebug.`,
 			if err != nil {
 				return err
 			}
-			if err = createCanasta(canastaInfo, workingDir, path, wikiID, siteName, domain, yamlPath, orch, orchestrator, override, envFile, composerFile, devModeFlag, devTag, buildFromPath, registry, databasePath, wikiSettingsPath, globalSettingsPath); err != nil {
+			if localCluster {
+				if k8s, ok := orch.(*orchestrators.KubernetesOrchestrator); ok {
+					k8s.LocalCluster = true
+				} else {
+					return fmt.Errorf("--local is only supported with Kubernetes orchestrator")
+				}
+			}
+			if err = createCanasta(canastaInfo, workingDir, path, wikiID, siteName, domain, yamlPath, orch, orchestrator, override, envFile, composerFile, devModeFlag, devTag, buildFromPath, registry, localCluster, databasePath, wikiSettingsPath, globalSettingsPath); err != nil {
 				stopSpinner()
 				fmt.Print(err.Error(), "\n")
 				if !keepConfig {
@@ -193,6 +201,7 @@ instead of running the installer, or enable development mode with Xdebug.`,
 	createCmd.Flags().StringVarP(&globalSettingsPath, "global-settings", "g", "", "Path to global settings file to copy to config/settings/global/ (filename preserved)")
 	createCmd.Flags().StringVar(&composerFile, "composer", "", "Path to custom composer.local.json to copy to config/")
 	createCmd.Flags().StringVar(&registry, "registry", "localhost:5000", "Container registry for pushing locally built images (used with --build-from on Kubernetes)")
+	createCmd.Flags().BoolVar(&localCluster, "local", false, "Use NodePort instead of LoadBalancer for local Kubernetes clusters (kind, k3d, minikube)")
 
 	// Mark required flags
 	_ = createCmd.MarkFlagRequired("id")
@@ -201,7 +210,7 @@ instead of running the installer, or enable development mode with Xdebug.`,
 }
 
 // createCanasta accepts all the keyword arguments and creates an installation of the latest Canasta.
-func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiID, siteName, domain, yamlPath string, orch orchestrators.Orchestrator, orchestrator, override, envFile, composerFile string, devModeEnabled bool, devTag, buildFromPath, registry, databasePath, wikiSettingsPath, globalSettingsPath string) error {
+func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiID, siteName, domain, yamlPath string, orch orchestrators.Orchestrator, orchestrator, override, envFile, composerFile string, devModeEnabled bool, devTag, buildFromPath, registry string, localCluster bool, databasePath, wikiSettingsPath, globalSettingsPath string) error {
 	// Determine the base image to use
 	var baseImage string
 	var localImageBuilt bool
@@ -352,7 +361,7 @@ func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiI
 		}
 	}
 
-	instance := config.Installation{Id: canastaInfo.Id, Path: path, Orchestrator: orchestrator, DevMode: devModeEnabled, Registry: registry}
+	instance := config.Installation{Id: canastaInfo.Id, Path: path, Orchestrator: orchestrator, DevMode: devModeEnabled, LocalCluster: localCluster, Registry: registry}
 	if err := config.Add(instance); err != nil {
 		return err
 	}

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -80,6 +80,13 @@ func Delete(instance config.Installation) error {
 		return err
 	}
 
+	// For kind-managed installations, set kubectl context before any kubectl commands
+	if instance.KindCluster != "" {
+		if k8s, ok := orch.(*orchestrators.KubernetesOrchestrator); ok {
+			k8s.LocalCluster = true
+		}
+	}
+
 	// Ensure containers are running so we can clean up images from inside
 	// (needed on Linux where container-created files are owned by www-data)
 	ensureErr := orch.CheckRunningStatus(instance)

--- a/cmd/restart/restart.go
+++ b/cmd/restart/restart.go
@@ -71,6 +71,11 @@ func Restart(instance config.Installation, enableDev, disableDev bool) error {
 	if err != nil {
 		return err
 	}
+	if instance.LocalCluster {
+		if k8s, ok := orch.(*orchestrators.KubernetesOrchestrator); ok {
+			k8s.LocalCluster = true
+		}
+	}
 
 	// Migrate to the new version Canasta
 	if err = canasta.MigrateToNewVersion(instance.Path); err != nil {

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -73,6 +73,11 @@ func Start(instance config.Installation, enableDev, disableDev bool) error {
 	if err != nil {
 		return err
 	}
+	if instance.LocalCluster {
+		if k8s, ok := orch.(*orchestrators.KubernetesOrchestrator); ok {
+			k8s.LocalCluster = true
+		}
+	}
 	if (enableDev || disableDev) {
 		if _, ok := orch.(*orchestrators.KubernetesOrchestrator); ok {
 			return fmt.Errorf("Development mode is only supported with Docker Compose")

--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -52,5 +52,10 @@ func Stop(instance config.Installation) error {
 	if err != nil {
 		return err
 	}
+	if instance.LocalCluster {
+		if k8s, ok := orch.(*orchestrators.KubernetesOrchestrator); ok {
+			k8s.LocalCluster = true
+		}
+	}
 	return orch.Stop(instance)
 }

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -167,9 +167,12 @@ func Upgrade(instance config.Installation, dryRun bool) error {
 	canastaImage := envVars["CANASTA_IMAGE"]
 	isLocalBuild := strings.HasPrefix(canastaImage, "canasta:local")
 
-	_, isK8s := orch.(*orchestrators.KubernetesOrchestrator)
+	k8s, isK8s := orch.(*orchestrators.KubernetesOrchestrator)
 	if !dryRun {
 		if isK8s {
+			// Restore LocalCluster flag so kustomization.yaml includes
+			// the NodePort patch when the installation was created with --local
+			k8s.LocalCluster = instance.LocalCluster
 			fmt.Println("Regenerating kustomization.yaml and re-applying manifests...")
 			if err := orch.InitConfig(instance.Path); err != nil {
 				return err

--- a/docs/guide/general-concepts.md
+++ b/docs/guide/general-concepts.md
@@ -486,14 +486,19 @@ wikis:
 canasta restart -i myinstance
 ```
 
-### Example: two installations on the same server
+### Example: multiple installations on the same machine
+
+Each installation must use unique ports. This applies to both Docker Compose and local Kubernetes (`--local`) installations — they can be mixed freely.
 
 ```bash
-# First installation uses default ports (80/443)
+# Docker Compose installation on default ports (80/443)
 canasta create -i production -w mainwiki -n localhost -a admin
 
-# Second installation uses custom ports
+# Docker Compose installation on custom ports
 canasta create -i staging -w testwiki -n localhost:8443 -a admin -e custom.env
+
+# Local Kubernetes installation on different custom ports
+canasta create -o k8s --local -i dev-k8s -w devwiki -n localhost:9443 -a admin -e another.env
 ```
 
-Access them at `https://localhost` and `https://localhost:8443`.
+Access them at `https://localhost`, `https://localhost:8443`, and `https://localhost:9443`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type Installation struct {
 	DevMode      bool   `json:"devMode,omitempty"`
 	LocalCluster bool   `json:"localCluster,omitempty"`
 	Registry     string `json:"registry,omitempty"`
+	KindCluster  string `json:"kindCluster,omitempty"`
 }
 
 type Orchestrator struct {

--- a/internal/orchestrators/kind.go
+++ b/internal/orchestrators/kind.go
@@ -1,0 +1,186 @@
+package orchestrators
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"text/template"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
+	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
+	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators/kubernetes"
+)
+
+// Default NodePort values used in the caddy service patch.
+const (
+	defaultHTTPNodePort  = 30080
+	defaultHTTPSNodePort = 30443
+)
+
+// kindConfigData holds template values for kind cluster configuration.
+type kindConfigData struct {
+	ClusterName   string
+	HTTPNodePort  int
+	HTTPSNodePort int
+	HTTPPort      int
+	HTTPSPort     int
+}
+
+// KindClusterName returns the kind cluster name for a Canasta installation.
+func KindClusterName(canastaID string) string {
+	return "canasta-" + canastaID
+}
+
+// kindClusterExists checks whether a kind cluster with the given name exists.
+func kindClusterExists(clusterName string) (bool, error) {
+	cmd := exec.Command("kind", "get", "clusters")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("failed to list kind clusters: %s", strings.TrimSpace(string(output)))
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if strings.TrimSpace(line) == clusterName {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// renderKindConfig renders the kind cluster config template with the given parameters.
+func renderKindConfig(data kindConfigData) (string, error) {
+	tmplBytes, err := kubernetes.StackFiles.ReadFile("files/kind-config.yaml.tmpl")
+	if err != nil {
+		return "", fmt.Errorf("failed to read kind config template: %w", err)
+	}
+	tmpl, err := template.New("kind-config").Parse(string(tmplBytes))
+	if err != nil {
+		return "", fmt.Errorf("failed to parse kind config template: %w", err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("failed to render kind config template: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// CreateKindCluster creates a new kind cluster with port mappings.
+// Returns an error if a cluster with the same name already exists.
+func CreateKindCluster(clusterName string, httpPort, httpsPort int) error {
+	exists, err := kindClusterExists(clusterName)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return fmt.Errorf("kind cluster %q already exists", clusterName)
+	}
+
+	configYAML, err := renderKindConfig(kindConfigData{
+		ClusterName:   clusterName,
+		HTTPNodePort:  defaultHTTPNodePort,
+		HTTPSNodePort: defaultHTTPSNodePort,
+		HTTPPort:      httpPort,
+		HTTPSPort:     httpsPort,
+	})
+	if err != nil {
+		return err
+	}
+
+	logging.Print(fmt.Sprintf("Creating kind cluster %q...\n", clusterName))
+	cmd := exec.Command("kind", "create", "cluster", "--config", "-")
+	cmd.Stdin = strings.NewReader(configYAML)
+	output, err := cmd.CombinedOutput()
+	logging.Print(string(output))
+	if err != nil {
+		return fmt.Errorf("failed to create kind cluster: %s", strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// DeleteKindCluster deletes a kind cluster. No-op if the cluster doesn't exist.
+func DeleteKindCluster(clusterName string) error {
+	exists, err := kindClusterExists(clusterName)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+
+	logging.Print(fmt.Sprintf("Deleting kind cluster %q...\n", clusterName))
+	cmd := exec.Command("kind", "delete", "cluster", "--name", clusterName)
+	output, err := cmd.CombinedOutput()
+	logging.Print(string(output))
+	if err != nil {
+		return fmt.Errorf("failed to delete kind cluster: %s", strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// EnsureKindCluster creates the kind cluster if it doesn't exist, or sets the
+// kubectl context if it does. Returns true if the cluster was newly created.
+func EnsureKindCluster(clusterName string, httpPort, httpsPort int) (bool, error) {
+	exists, err := kindClusterExists(clusterName)
+	if err != nil {
+		return false, err
+	}
+	if exists {
+		if err := setKindKubectlContext(clusterName); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+	if err := CreateKindCluster(clusterName, httpPort, httpsPort); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// setKindKubectlContext switches the kubectl context to the given kind cluster.
+func setKindKubectlContext(clusterName string) error {
+	contextName := "kind-" + clusterName
+	cmd := exec.Command("kubectl", "config", "use-context", contextName)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to set kubectl context to %s: %s", contextName, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// LoadImageToKind loads a local Docker image into a kind cluster so that
+// pods can pull it without a registry.
+func LoadImageToKind(clusterName, imageTag string) error {
+	logging.Print(fmt.Sprintf("Loading image %s into kind cluster %s...\n", imageTag, clusterName))
+	cmd := exec.Command("kind", "load", "docker-image", imageTag, "--name", clusterName)
+	output, err := cmd.CombinedOutput()
+	logging.Print(string(output))
+	if err != nil {
+		return fmt.Errorf("failed to load image into kind: %s", strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// GetPortsFromEnv reads HTTP_PORT and HTTPS_PORT from the .env file at the
+// given installation path, returning defaults of 80 and 443 if not set.
+func GetPortsFromEnv(installPath string) (httpPort int, httpsPort int) {
+	httpPort = 80
+	httpsPort = 443
+
+	envPath := installPath + "/.env"
+	envVars, err := canasta.GetEnvVariable(envPath)
+	if err != nil {
+		return
+	}
+	if v, ok := envVars["HTTP_PORT"]; ok && v != "" {
+		if p, err := strconv.Atoi(v); err == nil {
+			httpPort = p
+		}
+	}
+	if v, ok := envVars["HTTPS_PORT"]; ok && v != "" {
+		if p, err := strconv.Atoi(v); err == nil {
+			httpsPort = p
+		}
+	}
+	return
+}

--- a/internal/orchestrators/kind_test.go
+++ b/internal/orchestrators/kind_test.go
@@ -1,0 +1,157 @@
+package orchestrators
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestKindClusterName(t *testing.T) {
+	tests := []struct {
+		canastaID string
+		want      string
+	}{
+		{"myinstance", "canasta-myinstance"},
+		{"test-k8s", "canasta-test-k8s"},
+		{"a", "canasta-a"},
+		{"wiki_prod", "canasta-wiki_prod"},
+	}
+	for _, tt := range tests {
+		got := KindClusterName(tt.canastaID)
+		if got != tt.want {
+			t.Errorf("KindClusterName(%q) = %q, want %q", tt.canastaID, got, tt.want)
+		}
+	}
+}
+
+func TestRenderKindConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		data kindConfigData
+		want []string // strings that must appear in the output
+	}{
+		{
+			name: "default ports",
+			data: kindConfigData{
+				ClusterName:   "canasta-test",
+				HTTPNodePort:  30080,
+				HTTPSNodePort: 30443,
+				HTTPPort:      80,
+				HTTPSPort:     443,
+			},
+			want: []string{
+				"name: canasta-test",
+				"hostPort: 80",
+				"hostPort: 443",
+				"containerPort: 30080",
+				"containerPort: 30443",
+			},
+		},
+		{
+			name: "custom ports",
+			data: kindConfigData{
+				ClusterName:   "canasta-dev",
+				HTTPNodePort:  30080,
+				HTTPSNodePort: 30443,
+				HTTPPort:      8080,
+				HTTPSPort:     8443,
+			},
+			want: []string{
+				"name: canasta-dev",
+				"hostPort: 8080",
+				"hostPort: 8443",
+				"containerPort: 30080",
+				"containerPort: 30443",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := renderKindConfig(tt.data)
+			if err != nil {
+				t.Fatalf("renderKindConfig() error = %v", err)
+			}
+			for _, s := range tt.want {
+				if !strings.Contains(got, s) {
+					t.Errorf("renderKindConfig() output missing %q, got:\n%s", s, got)
+				}
+			}
+			// Verify it's valid YAML-like content
+			if !strings.Contains(got, "kind: Cluster") {
+				t.Error("renderKindConfig() output missing 'kind: Cluster'")
+			}
+		})
+	}
+}
+
+func TestGetPortsFromEnv(t *testing.T) {
+	tests := []struct {
+		name      string
+		envContent string
+		wantHTTP  int
+		wantHTTPS int
+	}{
+		{
+			name:       "defaults when no env file",
+			envContent: "",
+			wantHTTP:   80,
+			wantHTTPS:  443,
+		},
+		{
+			name:       "custom ports",
+			envContent: "HTTP_PORT=8080\nHTTPS_PORT=8443\n",
+			wantHTTP:   8080,
+			wantHTTPS:  8443,
+		},
+		{
+			name:       "only HTTP_PORT set",
+			envContent: "HTTP_PORT=9090\n",
+			wantHTTP:   9090,
+			wantHTTPS:  443,
+		},
+		{
+			name:       "only HTTPS_PORT set",
+			envContent: "HTTPS_PORT=9443\n",
+			wantHTTP:   80,
+			wantHTTPS:  9443,
+		},
+		{
+			name:       "invalid port value falls back to default",
+			envContent: "HTTP_PORT=notanumber\nHTTPS_PORT=8443\n",
+			wantHTTP:   80,
+			wantHTTPS:  8443,
+		},
+		{
+			name:       "empty values fall back to default",
+			envContent: "HTTP_PORT=\nHTTPS_PORT=\n",
+			wantHTTP:   80,
+			wantHTTPS:  443,
+		},
+		{
+			name:       "ports with other env vars",
+			envContent: "MYSQL_PASSWORD=secret\nHTTP_PORT=8080\nHTTPS_PORT=8443\nMW_SECRET_KEY=abc123\n",
+			wantHTTP:   8080,
+			wantHTTPS:  8443,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tt.envContent != "" {
+				if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(tt.envContent), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			gotHTTP, gotHTTPS := GetPortsFromEnv(dir)
+			if gotHTTP != tt.wantHTTP {
+				t.Errorf("GetPortsFromEnv() httpPort = %d, want %d", gotHTTP, tt.wantHTTP)
+			}
+			if gotHTTPS != tt.wantHTTPS {
+				t.Errorf("GetPortsFromEnv() httpsPort = %d, want %d", gotHTTPS, tt.wantHTTPS)
+			}
+		})
+	}
+}

--- a/internal/orchestrators/kubernetes/files/kind-config.yaml.tmpl
+++ b/internal/orchestrators/kubernetes/files/kind-config.yaml.tmpl
@@ -1,0 +1,12 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: {{.ClusterName}}
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: {{.HTTPNodePort}}
+    hostPort: {{.HTTPPort}}
+    protocol: TCP
+  - containerPort: {{.HTTPSNodePort}}
+    hostPort: {{.HTTPSPort}}
+    protocol: TCP


### PR DESCRIPTION
> **Kubernetes support PR chain (merge order: #320 → #314 → #316 → #321 → #317).** Part of #131.

## Summary

Add CLI-managed kind cluster support for `canasta create -o k8s` (introduced as `--local`, renamed to `--create-cluster` in #317):

- Add kind lifecycle functions: `CreateKindCluster`, `DeleteKindCluster`, `EnsureKindCluster`, `LoadImageToKind`
- Embedded kind cluster config template with `extraPortMappings` for port forwarding
- On create: create kind cluster with HTTP/HTTPS port mappings from `.env`
- On start: recreate kind cluster if manually deleted (`EnsureKindCluster`)
- On delete: delete the kind cluster entirely
- For `--build-from`, load image directly into kind (no registry needed)
- Add `KindCluster` and `ManagedCluster` fields to `config.Installation`
- Propagate managed-cluster flag in start/stop/restart/delete/upgrade commands
- Add unit tests for `KindClusterName`, `renderKindConfig`, `GetPortsFromEnv`

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./...` passes
- [x] End-to-end create/stop/start/delete lifecycle tested with kind
- [x] Non-standard ports tested
- [x] Cluster recreation after manual `kind delete` tested