### PR TITLE
Add orchestrator subcommands to canasta create

### DIFF
--- a/cmd/create/compose.go
+++ b/cmd/create/compose.go
@@ -1,0 +1,116 @@
+package create
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/devmode"
+	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
+	"github.com/CanastaWiki/Canasta-CLI/internal/spinner"
+)
+
+func newComposeCmd(opts *CreateOptions) *cobra.Command {
+	var (
+		override    string
+		devModeFlag bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "compose",
+		Short: "Create a Canasta installation using Docker Compose",
+		Long: `Create a new Canasta MediaWiki installation using Docker Compose. This sets
+up the Docker Compose stack, generates configuration files, starts the
+containers, and runs the MediaWiki installer. You can optionally import an
+existing database dump instead of running the installer, or enable
+development mode with Xdebug.`,
+		Example: `  # Create a basic single-wiki installation
+  canasta create compose -i myinstance -w main -a admin -n example.com
+
+  # Create with an existing database dump
+  canasta create compose -i myinstance -w main -d /path/to/dump.sql -n example.com
+
+  # Create with development mode enabled
+  canasta create compose -i myinstance -w main -a admin -n localhost -D`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateOpts(cmd, opts); err != nil {
+				return err
+			}
+			return createCompose(opts, override, devModeFlag)
+		},
+	}
+
+	cmd.Flags().StringVarP(&override, "override", "r", "", "Name of a file to copy to docker-compose.override.yml")
+	cmd.Flags().BoolVarP(&devModeFlag, "dev", "D", false, "Enable development mode with Xdebug and code extraction")
+
+	return cmd
+}
+
+func createCompose(opts *CreateOptions, override string, devMode bool) error {
+	description := "Creating Canasta installation '" + opts.CanastaInfo.Id + "'..."
+	if devMode {
+		description = "Creating Canasta installation '" + opts.CanastaInfo.Id + "' with dev mode..."
+	}
+	stopSpinner := spinner.New(description)
+
+	orch := &orchestrators.ComposeOrchestrator{}
+	if err := orch.CheckDependencies(); err != nil {
+		return err
+	}
+
+	baseImage, _, err := determineBaseImage(opts.BuildFromPath, opts.DevTag)
+	if err != nil {
+		return err
+	}
+
+	path, err := setupInstallation(opts, orch, baseImage)
+	if err != nil {
+		stopSpinner()
+		return err
+	}
+
+	// After this point, failure requires cleanup
+	fail := func(err error) error {
+		stopSpinner()
+		fmt.Println(err.Error())
+		if !opts.KeepConfig {
+			deleteConfigAndContainers(path, orch, "")
+			return fmt.Errorf("Installation failed and files were cleaned up")
+		}
+		return fmt.Errorf("Installation failed. Keeping all the containers and config files")
+	}
+
+	if err := orch.InitConfig(path); err != nil {
+		return fail(err)
+	}
+	if override != "" {
+		if err := orch.CopyOverrideFile(path, override, opts.WorkingDir); err != nil {
+			return fail(err)
+		}
+	}
+	if devMode {
+		if err := devmode.SetupFullDevMode(path, orch, baseImage); err != nil {
+			return fail(err)
+		}
+	}
+
+	instance := config.Installation{
+		Id:           opts.CanastaInfo.Id,
+		Path:         path,
+		Orchestrator: "compose",
+		DevMode:      devMode,
+	}
+	if err := installAndRegister(opts, path, orch, instance); err != nil {
+		return fail(err)
+	}
+
+	stopSpinner()
+	if devMode {
+		fmt.Println("\033[32mDevelopment mode enabled. Edit files in mediawiki-code/ - changes appear immediately.\033[0m")
+		fmt.Println("\033[32mVSCode: Open the installation directory, install PHP Debug extension, and start 'Listen for Xdebug'.\033[0m")
+	}
+	fmt.Println("\033[32mIf you need email enabled for this wiki, please set $wgSMTP; email will not work otherwise. See https://mediawiki.org/wiki/Manual:$wgSMTP for options.\033[0m")
+	fmt.Println("Done.")
+	return nil
+}

--- a/cmd/create/k8s.go
+++ b/cmd/create/k8s.go
@@ -1,0 +1,132 @@
+package create
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
+	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/imagebuild"
+	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
+	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
+	"github.com/CanastaWiki/Canasta-CLI/internal/spinner"
+)
+
+func newK8sCmd(opts *CreateOptions) *cobra.Command {
+	var (
+		registry      string
+		createCluster bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "k8s",
+		Short: "Create a Canasta installation using Kubernetes",
+		Long: `Create a new Canasta MediaWiki installation on Kubernetes. Use
+--create-cluster to have the CLI manage a local kind cluster, or omit it
+to deploy to an existing cluster.`,
+		Example: `  # Create with a managed kind cluster (recommended)
+  canasta create k8s --create-cluster -i my-wiki -w main -a admin -n localhost
+
+  # Deploy to an existing cluster
+  canasta create k8s -i my-wiki -w main -a admin -n my-wiki.example.com
+
+  # Build from source with a managed cluster
+  canasta create k8s --create-cluster --build-from /path/to/workspace -i my-wiki -w main -a admin -n localhost`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateOpts(cmd, opts); err != nil {
+				return err
+			}
+			return createK8s(opts, registry, createCluster)
+		},
+	}
+
+	cmd.Flags().StringVar(&registry, "registry", "localhost:5000", "Container registry for pushing locally built images (used with --build-from)")
+	cmd.Flags().BoolVar(&createCluster, "create-cluster", false, "Create and manage a local Kubernetes cluster for this installation")
+
+	return cmd
+}
+
+func createK8s(opts *CreateOptions, registry string, createCluster bool) error {
+	stopSpinner := spinner.New("Creating Canasta installation '" + opts.CanastaInfo.Id + "'...")
+
+	orch := &orchestrators.KubernetesOrchestrator{ManagedCluster: createCluster}
+	if err := orch.CheckDependencies(); err != nil {
+		return err
+	}
+
+	baseImage, localImageBuilt, err := determineBaseImage(opts.BuildFromPath, opts.DevTag)
+	if err != nil {
+		return err
+	}
+
+	path, err := setupInstallation(opts, orch, baseImage)
+	if err != nil {
+		stopSpinner()
+		return err
+	}
+
+	// After this point, failure requires cleanup.
+	// kindClusterName is captured by reference so the fail closure
+	// can clean up the cluster even if it's created later.
+	kindClusterName := ""
+	fail := func(err error) error {
+		stopSpinner()
+		fmt.Println(err.Error())
+		if !opts.KeepConfig {
+			deleteConfigAndContainers(path, orch, kindClusterName)
+			return fmt.Errorf("Installation failed and files were cleaned up")
+		}
+		return fmt.Errorf("Installation failed. Keeping all the containers and config files")
+	}
+
+	// Create kind cluster if requested
+	if createCluster {
+		httpPort, httpsPort := orchestrators.GetPortsFromEnv(path)
+		kindClusterName = orchestrators.KindClusterName(opts.CanastaInfo.Id)
+		if err := orchestrators.CreateKindCluster(kindClusterName, httpPort, httpsPort); err != nil {
+			return fail(fmt.Errorf("failed to create kind cluster: %w", err))
+		}
+	}
+
+	// Distribute locally built image before InitConfig so .env has the
+	// correct CANASTA_IMAGE when kustomization.yaml is generated.
+	if localImageBuilt {
+		if kindClusterName != "" {
+			logging.Print("Loading image into kind cluster...\n")
+			if err := orchestrators.LoadImageToKind(kindClusterName, baseImage); err != nil {
+				return fail(fmt.Errorf("failed to load image into kind: %w", err))
+			}
+		} else {
+			logging.Print("Pushing image to registry for Kubernetes...\n")
+			remoteTag, err := imagebuild.PushImage(baseImage, registry)
+			if err != nil {
+				return fail(fmt.Errorf("failed to push image to registry: %w", err))
+			}
+			if err := canasta.SaveEnvVariable(path+"/.env", "CANASTA_IMAGE", remoteTag); err != nil {
+				return fail(err)
+			}
+		}
+	}
+
+	if err := orch.InitConfig(path); err != nil {
+		return fail(err)
+	}
+
+	instance := config.Installation{
+		Id:             opts.CanastaInfo.Id,
+		Path:           path,
+		Orchestrator:   "kubernetes",
+		ManagedCluster: createCluster,
+		Registry:       registry,
+		KindCluster:    kindClusterName,
+	}
+	if err := installAndRegister(opts, path, orch, instance); err != nil {
+		return fail(err)
+	}
+
+	stopSpinner()
+	fmt.Println("\033[32mIf you need email enabled for this wiki, please set $wgSMTP; email will not work otherwise. See https://mediawiki.org/wiki/Manual:$wgSMTP for options.\033[0m")
+	fmt.Println("Done.")
+	return nil
+}

--- a/docs/guide/best-practices.md
+++ b/docs/guide/best-practices.md
@@ -25,7 +25,7 @@ This page covers security considerations and best practices for managing Canasta
 - Ensure proper file permissions on the installation directory to restrict access to these files
 - Consider using environment variables when passing passwords on the command line to avoid exposing them in shell history:
   ```bash
-  canasta create -i myinstance -w main -a admin --rootdbpass "$ROOT_DB_PASS"
+  canasta create compose -i myinstance -w main -a admin --rootdbpass "$ROOT_DB_PASS"
   ```
 
 ### Docker access

--- a/docs/guide/devmode.md
+++ b/docs/guide/devmode.md
@@ -37,10 +37,10 @@ Development mode enables live code editing and step debugging with Xdebug for Ca
 
 ```bash
 # Use the default (latest) Canasta image
-canasta create -i mydev -w mywiki -n localhost -a admin --dev
+canasta create compose -i mydev -w mywiki -n localhost -a admin --dev
 
 # Or specify a specific Canasta image tag
-canasta create -i mydev -w mywiki -n localhost -a admin --dev --dev-tag dev-branch
+canasta create compose -i mydev -w mywiki -n localhost -a admin --dev --dev-tag dev-branch
 ```
 
 The `--dev` flag enables development mode with Xdebug. Use `--dev-tag` to specify which Canasta image tag to use:
@@ -66,7 +66,7 @@ This will:
 For testing changes to Canasta or CanastaBase before they're published, you can build from local source repositories:
 
 ```bash
-canasta create -i mydev -w mywiki -n localhost -a admin --build-from ~/canasta-repos
+canasta create compose -i mydev -w mywiki -n localhost -a admin --build-from ~/canasta-repos
 ```
 
 The `--build-from` flag expects a directory containing:
@@ -86,7 +86,7 @@ This will:
 You can combine `--build-from` with `--dev` to build from source and enable Xdebug:
 
 ```bash
-canasta create -i mydev -w mywiki -n localhost -a admin --dev --build-from ~/canasta-repos
+canasta create compose -i mydev -w mywiki -n localhost -a admin --dev --build-from ~/canasta-repos
 ```
 
 **Note:** `--dev-tag` and `--build-from` are mutually exclusive since `--build-from` builds its own image.
@@ -126,7 +126,7 @@ This will:
 
 **Note:** If `mediawiki-code/` already exists, it will NOT be overwritten. You'll see a warning message. To regenerate the code, delete the directory first and then restart with `--dev`.
 
-**Note:** When enabling dev mode on an existing installation, the default `latest` image tag is used. To use a specific image tag, recreate the installation with `canasta create --dev --dev-tag <tag>`.
+**Note:** When enabling dev mode on an existing installation, the default `latest` image tag is used. To use a specific image tag, recreate the installation with `canasta create compose --dev --dev-tag <tag>`.
 
 ---
 

--- a/docs/guide/general-concepts.md
+++ b/docs/guide/general-concepts.md
@@ -25,7 +25,7 @@ This page covers foundational concepts that apply to all Canasta installations, 
 Every Canasta installation has an **installation ID** — a name you choose when creating it with the `-i` flag:
 
 ```bash
-canasta create -i myinstance -w main -n localhost -a admin
+canasta create compose -i myinstance -w main -n localhost -a admin
 ```
 
 The installation ID is used to refer to the installation in all subsequent commands:
@@ -47,7 +47,7 @@ Installation IDs must start and end with an alphanumeric character and may conta
 Every wiki in a Canasta installation has a **wiki ID** — a short identifier set with the `-w` flag when creating or adding a wiki:
 
 ```bash
-canasta create -i myinstance -w main -n localhost -a admin
+canasta create compose -i myinstance -w main -n localhost -a admin
 ```
 
 Even a single-wiki installation requires a wiki ID. The wiki ID is used as:
@@ -141,7 +141,7 @@ The `url` field uses `domain/path` format without the protocol. The Caddyfile is
 The `name` field in `wikis.yaml` controls the wiki's display name (`$wgSitename` in MediaWiki). It defaults to the wiki ID if not set. The name is initially set with the `-t` (`--site-name`) flag of `canasta create` or `canasta add`:
 
 ```bash
-canasta create -i myinstance -w docs -n example.com -a admin -t "Project Documentation"
+canasta create compose -i myinstance -w docs -n example.com -a admin -t "Project Documentation"
 ```
 
 To change it later, edit the `name` field directly in `config/wikis.yaml`:
@@ -266,13 +266,13 @@ Use this option for fully private wikis where the logo should not be visible to 
 To migrate an existing MediaWiki installation into Canasta, prepare a database dump (`.sql` or `.sql.gz` file) and pass it with the `-d` flag:
 
 ```bash
-canasta create -i myinstance -w main -n localhost -d ./backup.sql.gz -a admin
+canasta create compose -i myinstance -w main -n localhost -d ./backup.sql.gz -a admin
 ```
 
 You can also provide a per-wiki settings file and an environment file with password overrides:
 
 ```bash
-canasta create -i myinstance -w main -n localhost -d ./backup.sql.gz -l ./my-settings.php -e ./custom.env -a admin
+canasta create compose -i myinstance -w main -n localhost -d ./backup.sql.gz -l ./my-settings.php -e ./custom.env -a admin
 ```
 
 The `-l` flag (`--wiki-settings`) copies the specified file to `config/settings/wikis/{wiki-id}/`, preserving the filename. Use it to bring over custom settings from an existing wiki.
@@ -439,7 +439,7 @@ CADDY_AUTO_HTTPS=off
 Pass this file when creating the installation:
 
 ```bash
-canasta create -i myinstance -w main -n example.com -a admin -e custom.env
+canasta create compose -i myinstance -w main -n example.com -a admin -e custom.env
 ```
 
 This generates a Caddyfile with `http://` site addresses so Caddy listens on port 80 only.
@@ -465,7 +465,7 @@ HTTPS_PORT=8443
 ```
 
 ```bash
-canasta create -i staging -w testwiki -n localhost:8443 -a admin -e custom.env
+canasta create compose -i staging -w testwiki -n localhost:8443 -a admin -e custom.env
 ```
 
 For an existing installation, edit `.env` to set the ports, update `config/wikis.yaml` to include the port in the URL, and restart:
@@ -492,13 +492,13 @@ Each installation must use unique ports. This applies to both Docker Compose and
 
 ```bash
 # Docker Compose installation on default ports (80/443)
-canasta create -i production -w mainwiki -n localhost -a admin
+canasta create compose -i production -w mainwiki -n localhost -a admin
 
 # Docker Compose installation on custom ports
-canasta create -i staging -w testwiki -n localhost:8443 -a admin -e custom.env
+canasta create compose -i staging -w testwiki -n localhost:8443 -a admin -e custom.env
 
 # Local Kubernetes installation on different custom ports
-canasta create -o k8s --create-cluster -i dev-k8s -w devwiki -n localhost:9443 -a admin -e another.env
+canasta create k8s --create-cluster -i dev-k8s -w devwiki -n localhost:9443 -a admin -e another.env
 ```
 
 Access them at `https://localhost`, `https://localhost:8443`, and `https://localhost:9443`.

--- a/docs/guide/kubernetes.md
+++ b/docs/guide/kubernetes.md
@@ -41,10 +41,10 @@ You need `kubectl` installed and configured to connect to your cluster (`kubectl
 
 ## Creating an installation (managed cluster)
 
-Use `-o k8s` with the `--create-cluster` flag:
+Use `canasta create k8s` with the `--create-cluster` flag:
 
 ```bash
-canasta create -o k8s --create-cluster -i my-wiki -w main -a admin -n localhost
+canasta create k8s --create-cluster -i my-wiki -w main -a admin -n localhost
 ```
 
 This automatically:
@@ -118,7 +118,7 @@ HTTPS_PORT=8443
 ```
 
 ```bash
-canasta create -o k8s --create-cluster -i my-wiki -w main -a admin -n localhost:8443 -e custom.env
+canasta create k8s --create-cluster -i my-wiki -w main -a admin -n localhost:8443 -e custom.env
 ```
 
 Each installation must use unique ports. If two installations attempt to bind the same host port, kind will fail with a Docker port-binding error. See [Running on non-standard ports](general-concepts.md#running-on-non-standard-ports) for more details.
@@ -130,7 +130,7 @@ Each installation must use unique ports. If two installations attempt to bind th
 To test a locally built Canasta image with a managed K8s cluster, use `--build-from`:
 
 ```bash
-canasta create -o k8s --create-cluster --build-from /path/to/workspace -i my-wiki -w main -a admin -n localhost
+canasta create k8s --create-cluster --build-from /path/to/workspace -i my-wiki -w main -a admin -n localhost
 ```
 
 When `--create-cluster` is combined with `--build-from`, the CLI loads the built image directly into the kind cluster using `kind load docker-image`. No container registry is needed.
@@ -144,7 +144,7 @@ Without `--create-cluster`, the CLI pushes the image to a registry (default `loc
 To deploy to a pre-existing Kubernetes cluster without `--create-cluster`:
 
 ```bash
-canasta create -o k8s -i my-wiki -w main -a admin -n my-wiki.example.com
+canasta create k8s -i my-wiki -w main -a admin -n my-wiki.example.com
 ```
 
 This mode is **experimental** and has significant limitations:

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -26,7 +26,7 @@ Create an `.env` file with the profile enabled, then pass it to `canasta create`
 
 ```bash
 echo "COMPOSE_PROFILES=observable" > my.env
-canasta create -i myinstance -w mywiki -a admin -e my.env
+canasta create compose -i myinstance -w mywiki -a admin -e my.env
 ```
 
 Or append `observable` to an existing `.env` file that already sets `COMPOSE_PROFILES`:

--- a/docs/guide/wiki-farms.md
+++ b/docs/guide/wiki-farms.md
@@ -40,7 +40,7 @@ Multiple wikis share the same domain, distinguished by URL path. The first wiki 
 
 ```bash
 # Create the farm with the first wiki at the root
-canasta create -i myfarm -w mainwiki -n example.com -a admin
+canasta create compose -i myfarm -w mainwiki -n example.com -a admin
 
 # Add a second wiki at example.com/docs
 canasta add -i myfarm -w docs -u example.com/docs -a admin
@@ -56,7 +56,7 @@ Users access these at `https://example.com`, `https://example.com/docs`, and `ht
 Each wiki uses a different subdomain. This requires DNS records pointing each subdomain to your Canasta server. Caddy handles SSL/HTTPS automatically for all configured domains.
 
 ```bash
-canasta create -i myfarm -w mainwiki -n wiki.example.com -a admin
+canasta create compose -i myfarm -w mainwiki -n wiki.example.com -a admin
 canasta add -i myfarm -w docs -u docs.example.com -a admin
 canasta add -i myfarm -w community -u community.example.com -a admin
 ```
@@ -66,7 +66,7 @@ canasta add -i myfarm -w community -u community.example.com -a admin
 You can combine both approaches:
 
 ```bash
-canasta create -i myfarm -w mainwiki -n example.com -a admin
+canasta create compose -i myfarm -w mainwiki -n example.com -a admin
 canasta add -i myfarm -w docs -u example.com/docs -a admin
 canasta add -i myfarm -w community -u community.example.com -a admin
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ Canasta CLI is a powerful tool that allows you to create, manage, and maintain m
 curl -fsSL https://raw.githubusercontent.com/CanastaWiki/Canasta-CLI/main/install.sh | sudo bash
 
 # Create a new Canasta installation
-canasta create -i myinstance -w wiki1 -a admin -n localhost
+canasta create compose -i myinstance -w wiki1 -a admin -n localhost
 ```
 
 ## Next steps

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -39,7 +39,7 @@ sudo usermod -aG docker,www-data $USER
 
 ### Kubernetes (managed cluster)
 
-To use Canasta with a CLI-managed Kubernetes cluster (`canasta create -o k8s --create-cluster`), you also need:
+To use Canasta with a CLI-managed Kubernetes cluster (`canasta create k8s --create-cluster`), you also need:
 
 - **[kubectl](https://kubernetes.io/docs/tasks/tools/)** — the Kubernetes command-line tool
 - **[kind](https://kind.sigs.k8s.io/)** — runs Kubernetes clusters in Docker containers


### PR DESCRIPTION
## Summary

- Split `canasta create` into `canasta create compose` and `canasta create k8s` subcommands with orchestrator-specific flags, removing all `isK8s` checks and the `-o`/`--orchestrator` flag
- Extract shared `newFailHandler()` and `printCompletionMessages()` helpers to reduce duplication between compose and k8s create paths
- Update all documentation examples to use the new subcommand syntax

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./...` passes
- [x] `canasta create` shows help with compose/k8s subcommands
- [x] `canasta create compose -i test -w wiki1 -a admin -n localhost` works
- [x] `canasta create k8s --create-cluster -i test -w wiki1 -a admin -n localhost` works

Fixes #311