### PR TITLE
Add database and service health checks

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -365,9 +365,8 @@ func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiI
 		logging.Print("Importing database instead of running install.php\n")
 
 		// Wait for database to be ready
-		command := "/wait-for-it.sh -t 60 db:3306"
-		if _, err := orch.ExecWithError(path, "web", command); err != nil {
-			return fmt.Errorf("database not ready: %w", err)
+		if err := mediawiki.WaitForDB(path, orch); err != nil {
+			return err
 		}
 
 		envVariables, envErr := canasta.GetEnvVariable(path + "/.env")

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -80,10 +80,10 @@ func Delete(instance config.Installation) error {
 		return err
 	}
 
-	// For kind-managed installations, set kubectl context before any kubectl commands
+	// For CLI-managed clusters, set the flag so CheckDependencies skips cluster-info
 	if instance.KindCluster != "" {
 		if k8s, ok := orch.(*orchestrators.KubernetesOrchestrator); ok {
-			k8s.LocalCluster = true
+			k8s.ManagedCluster = true
 		}
 	}
 

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -80,8 +80,9 @@ func Delete(instance config.Installation) error {
 		return err
 	}
 
-	// For CLI-managed clusters, set the flag so CheckDependencies skips cluster-info
-	if instance.KindCluster != "" {
+	// For CLI-managed clusters, set the flag so K8s-aware methods
+	// know this is a managed cluster (e.g., for dependency checks).
+	if instance.ManagedCluster {
 		if k8s, ok := orch.(*orchestrators.KubernetesOrchestrator); ok {
 			k8s.ManagedCluster = true
 		}

--- a/cmd/restart/restart.go
+++ b/cmd/restart/restart.go
@@ -71,9 +71,9 @@ func Restart(instance config.Installation, enableDev, disableDev bool) error {
 	if err != nil {
 		return err
 	}
-	if instance.LocalCluster {
+	if instance.ManagedCluster {
 		if k8s, ok := orch.(*orchestrators.KubernetesOrchestrator); ok {
-			k8s.LocalCluster = true
+			k8s.ManagedCluster = true
 		}
 	}
 

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -73,9 +73,9 @@ func Start(instance config.Installation, enableDev, disableDev bool) error {
 	if err != nil {
 		return err
 	}
-	if instance.LocalCluster {
+	if instance.ManagedCluster {
 		if k8s, ok := orch.(*orchestrators.KubernetesOrchestrator); ok {
-			k8s.LocalCluster = true
+			k8s.ManagedCluster = true
 		}
 	}
 	if (enableDev || disableDev) {

--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -52,9 +52,9 @@ func Stop(instance config.Installation) error {
 	if err != nil {
 		return err
 	}
-	if instance.LocalCluster {
+	if instance.ManagedCluster {
 		if k8s, ok := orch.(*orchestrators.KubernetesOrchestrator); ok {
-			k8s.LocalCluster = true
+			k8s.ManagedCluster = true
 		}
 	}
 	return orch.Stop(instance)

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -170,9 +170,9 @@ func Upgrade(instance config.Installation, dryRun bool) error {
 	k8s, isK8s := orch.(*orchestrators.KubernetesOrchestrator)
 	if !dryRun {
 		if isK8s {
-			// Restore LocalCluster flag so kustomization.yaml includes
-			// the NodePort patch when the installation was created with --local
-			k8s.LocalCluster = instance.LocalCluster
+			// Restore ManagedCluster flag so kustomization.yaml includes
+			// the NodePort patch when the installation was created with --create-cluster
+			k8s.ManagedCluster = instance.ManagedCluster
 			fmt.Println("Regenerating kustomization.yaml and re-applying manifests...")
 			if err := orch.InitConfig(instance.Path); err != nil {
 				return err

--- a/docs/guide/general-concepts.md
+++ b/docs/guide/general-concepts.md
@@ -488,7 +488,7 @@ canasta restart -i myinstance
 
 ### Example: multiple installations on the same machine
 
-Each installation must use unique ports. This applies to both Docker Compose and local Kubernetes (`--local`) installations — they can be mixed freely.
+Each installation must use unique ports. This applies to both Docker Compose and Kubernetes (`--create-cluster`) installations — they can be mixed freely.
 
 ```bash
 # Docker Compose installation on default ports (80/443)
@@ -498,7 +498,7 @@ canasta create -i production -w mainwiki -n localhost -a admin
 canasta create -i staging -w testwiki -n localhost:8443 -a admin -e custom.env
 
 # Local Kubernetes installation on different custom ports
-canasta create -o k8s --local -i dev-k8s -w devwiki -n localhost:9443 -a admin -e another.env
+canasta create -o k8s --create-cluster -i dev-k8s -w devwiki -n localhost:9443 -a admin -e another.env
 ```
 
 Access them at `https://localhost`, `https://localhost:8443`, and `https://localhost:9443`.

--- a/docs/guide/kubernetes.md
+++ b/docs/guide/kubernetes.md
@@ -73,7 +73,7 @@ canasta upgrade -i my-wiki   # Update stack files and restart
 
 **Delete** removes the entire kind cluster, all Kubernetes resources, and the installation directory.
 
-If the kind cluster is manually deleted (e.g., via `kind delete cluster`), `canasta start` will automatically recreate it. Note that persistent volume data will be lost in this case since it was stored inside the cluster.
+If the kind cluster is manually deleted (e.g., via `kind delete cluster`), `canasta start` will automatically recreate it. Note that persistent volume data will be lost in this case since it was stored inside the cluster. If the installation was created with `--build-from`, the locally built image will also need to be rebuilt and reloaded.
 
 ---
 

--- a/docs/guide/kubernetes.md
+++ b/docs/guide/kubernetes.md
@@ -1,0 +1,145 @@
+# Kubernetes (local)
+
+Canasta CLI can deploy to a local Kubernetes cluster using [kind](https://kind.sigs.k8s.io/) (Kubernetes in Docker). This provides a Kubernetes-based alternative to Docker Compose for local development and testing.
+
+## Contents
+
+- [Prerequisites](#prerequisites)
+- [Creating an installation](#creating-an-installation)
+- [Managing the installation](#managing-the-installation)
+- [How it works](#how-it-works)
+- [Non-standard ports](#non-standard-ports)
+- [Building from source](#building-from-source)
+- [Current limitations](#current-limitations)
+
+---
+
+## Prerequisites
+
+In addition to Docker (required for kind), you need:
+
+| Tool | Purpose | Install |
+|------|---------|---------|
+| [kubectl](https://kubernetes.io/docs/tasks/tools/) | Kubernetes CLI | `brew install kubectl` or [see docs](https://kubernetes.io/docs/tasks/tools/) |
+| [kind](https://kind.sigs.k8s.io/) | Local K8s clusters | `brew install kind` or [see docs](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) |
+
+On Linux, install kubectl and kind using your package manager or by downloading the binaries directly from the links above.
+
+The CLI checks for these tools at creation time and will report a clear error if either is missing.
+
+---
+
+## Creating an installation
+
+Use `-o k8s` with the `--local` flag:
+
+```bash
+canasta create -o k8s --local -i my-wiki -w main -a admin -n localhost
+```
+
+This automatically:
+1. Creates a kind cluster named `canasta-my-wiki` with port mappings
+2. Writes Kubernetes manifests and a `kustomization.yaml`
+3. Applies the manifests with `kubectl apply`
+4. Runs the MediaWiki installer
+
+Once complete, your wiki is accessible at `https://localhost/main/`.
+
+---
+
+## Managing the installation
+
+The same CLI commands work for both Compose and Kubernetes installations:
+
+```bash
+canasta stop -i my-wiki      # Scale deployments to 0 (cluster stays running)
+canasta start -i my-wiki     # Scale deployments back up
+canasta restart -i my-wiki   # Stop then start
+canasta delete -i my-wiki    # Delete the kind cluster and all data
+canasta upgrade -i my-wiki   # Update stack files and restart
+```
+
+**Stop** scales all Kubernetes deployments to zero replicas. The kind cluster and persistent volumes remain intact, so your data is preserved.
+
+**Delete** removes the entire kind cluster, all Kubernetes resources, and the installation directory.
+
+If the kind cluster is manually deleted (e.g., via `kind delete cluster`), `canasta start` will automatically recreate it. Note that persistent volume data will be lost in this case since it was stored inside the cluster.
+
+---
+
+## How it works
+
+The CLI creates a kind cluster with `extraPortMappings` that map host ports directly to Kubernetes NodePort services:
+
+```
+Browser -> localhost:443 -> kind node:443 -> NodePort 30443 -> caddy pod -> MediaWiki
+```
+
+Each installation gets its own kind cluster (`canasta-<id>`) and Kubernetes namespace. The cluster configuration, including port mappings, is stored in the CLI's configuration file so it survives restarts.
+
+### Directory structure
+
+The installation directory has the same structure as a Compose installation, with Kubernetes manifests added:
+
+```
+my-wiki/
+  .env                      # Environment variables (ports, passwords, image)
+  kustomization.yaml         # Auto-generated — ties everything together
+  kubernetes/                # Kubernetes manifests (namespace, deployments, services)
+  config/
+    wikis.yaml               # Wiki definitions
+    Caddyfile, Caddyfile.site, Caddyfile.global
+    settings/
+      global/                # Settings loaded for all wikis
+      wikis/<id>/            # Per-wiki settings
+```
+
+The `kustomization.yaml` is regenerated automatically by the CLI and should not be edited manually.
+
+---
+
+## Non-standard ports
+
+By default, Canasta uses ports 80 (HTTP) and 443 (HTTPS). To use different ports, pass an env file:
+
+```env
+HTTP_PORT=8080
+HTTPS_PORT=8443
+```
+
+```bash
+canasta create -o k8s --local -i my-wiki -w main -a admin -n localhost:8443 -e custom.env
+```
+
+Each installation must use unique ports. If two installations attempt to bind the same host port, kind will fail with a Docker port-binding error. See [Running on non-standard ports](general-concepts.md#running-on-non-standard-ports) for more details.
+
+---
+
+## Building from source
+
+To test a locally built Canasta image with a local K8s cluster, use `--build-from`:
+
+```bash
+canasta create -o k8s --local --build-from /path/to/workspace -i my-wiki -w main -a admin -n localhost
+```
+
+When `--local` is combined with `--build-from`, the CLI loads the built image directly into the kind cluster using `kind load docker-image`. No container registry is needed.
+
+Without `--local`, the CLI pushes the image to a registry (default `localhost:5000`, configurable with `--registry`) so the remote cluster can pull it.
+
+---
+
+## Current limitations
+
+Kubernetes support is focused on local development with kind. The following features are not yet available for Kubernetes installations:
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Development mode (Xdebug) | Not supported | Use Docker Compose for Xdebug debugging |
+| Backup create | Not supported | Use `kubectl exec` to run mysqldump manually |
+| Backup restore | Not supported | |
+| Backup scheduling | Not supported | Use a Kubernetes CronJob instead |
+| Remote clusters | Not tested | Manifests use `hostPath` volumes, which require a single-node cluster |
+| Horizontal scaling | Limited | HPA is defined but not tested with the current volume setup |
+
+For production deployments, Docker Compose remains the recommended orchestrator.

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ canasta create -i myinstance -w wiki1 -a admin -n localhost
 - [Extensions and skins](guide/extensions-and-skins.md) - Enabling, disabling, and adding extensions and skins
 - [Observability](guide/observability.md) - Log aggregation with OpenSearch and Dashboards
 - [Development mode](guide/devmode.md) - Live code editing and Xdebug debugging
-- [Kubernetes (local)](guide/kubernetes.md) - Deploying to a local Kubernetes cluster with kind
+- [Kubernetes](guide/kubernetes.md) - Deploying to Kubernetes with a CLI-managed kind cluster
 - [Backup and restore](guide/backup.md) - Setting up backups with restic
 - [Best practices](guide/best-practices.md) - Security considerations and best practices
 - [Troubleshooting](guide/troubleshooting.md) - Common issues and debugging

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ Welcome to the official documentation for **Canasta CLI**, the command-line inte
 
 ## What is Canasta CLI?
 
-Canasta CLI is a powerful tool that allows you to create, manage, and maintain multiple Canasta MediaWiki installations with ease. It supports Docker Compose orchestration and provides features for:
+Canasta CLI is a powerful tool that allows you to create, manage, and maintain multiple Canasta MediaWiki installations with ease. It supports Docker Compose and local Kubernetes orchestration and provides features for:
 
 - **Creating** new Canasta installations (single wikis or wiki farms)
 - **Managing** extensions and skins
@@ -42,6 +42,7 @@ canasta create -i myinstance -w wiki1 -a admin -n localhost
 - [Extensions and skins](guide/extensions-and-skins.md) - Enabling, disabling, and adding extensions and skins
 - [Observability](guide/observability.md) - Log aggregation with OpenSearch and Dashboards
 - [Development mode](guide/devmode.md) - Live code editing and Xdebug debugging
+- [Kubernetes (local)](guide/kubernetes.md) - Deploying to a local Kubernetes cluster with kind
 - [Backup and restore](guide/backup.md) - Setting up backups with restic
 - [Best practices](guide/best-practices.md) - Security considerations and best practices
 - [Troubleshooting](guide/troubleshooting.md) - Common issues and debugging

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,6 +15,8 @@ This guide covers installing and uninstalling the Canasta command line interface
 
 ## Prerequisites
 
+### Docker Compose (default)
+
 Before using the Canasta CLI, you must have both Docker Engine and Docker Compose installed.
 
 ### Windows and macOS
@@ -34,6 +36,19 @@ On Linux, you also need Docker access and file permission for your user account.
 ```bash
 sudo usermod -aG docker,www-data $USER
 ```
+
+### Kubernetes (local)
+
+To use Canasta with a local Kubernetes cluster (`canasta create -o k8s --local`), you also need:
+
+- **[kubectl](https://kubernetes.io/docs/tasks/tools/)** — the Kubernetes command-line tool
+- **[kind](https://kind.sigs.k8s.io/)** — runs Kubernetes clusters in Docker containers
+
+On macOS: `brew install kubectl kind`
+
+On Linux: download the binaries from the links above or use your package manager.
+
+Docker is still required since kind uses it to run cluster nodes. See the [Kubernetes guide](guide/kubernetes.md) for full details.
 
 ## Install
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,9 +37,9 @@ On Linux, you also need Docker access and file permission for your user account.
 sudo usermod -aG docker,www-data $USER
 ```
 
-### Kubernetes (local)
+### Kubernetes (managed cluster)
 
-To use Canasta with a local Kubernetes cluster (`canasta create -o k8s --local`), you also need:
+To use Canasta with a CLI-managed Kubernetes cluster (`canasta create -o k8s --create-cluster`), you also need:
 
 - **[kubectl](https://kubernetes.io/docs/tasks/tools/)** — the Kubernetes command-line tool
 - **[kind](https://kind.sigs.k8s.io/)** — runs Kubernetes clusters in Docker containers

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,7 +19,7 @@ type Installation struct {
 	Path         string `json:"path"`
 	Orchestrator string `json:"orchestrator"`
 	DevMode      bool   `json:"devMode,omitempty"`
-	LocalCluster bool   `json:"localCluster,omitempty"`
+	ManagedCluster bool   `json:"managedCluster,omitempty"`
 	Registry     string `json:"registry,omitempty"`
 	KindCluster  string `json:"kindCluster,omitempty"`
 }

--- a/internal/orchestrators/compose/files/docker-compose.yml
+++ b/internal/orchestrators/compose/files/docker-compose.yml
@@ -20,6 +20,12 @@ services:
     environment:
       - MYSQL_ROOT_HOST=%
       - MYSQL_ROOT_PASSWORD=${MYSQL_PASSWORD}
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
     volumes:
       - ./_initdb:/docker-entrypoint-initdb.d
       - mysql-data-volume:/var/lib/mysql
@@ -32,8 +38,10 @@ services:
     extra_hosts:
       - "gateway.docker.internal:host-gateway"
     depends_on:
-      - db
-      - elasticsearch
+      db:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     environment:
       # Sourced from .env
       - MW_SITE_SERVER=${MW_SITE_SERVER:-https://localhost}
@@ -61,6 +69,12 @@ services:
       memlock:
         soft: -1
         hard: -1
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
     volumes:
       - elasticsearch:/usr/share/elasticsearch/data
 

--- a/internal/orchestrators/kind.go
+++ b/internal/orchestrators/kind.go
@@ -9,6 +9,7 @@ import (
 	"text/template"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
+	"github.com/CanastaWiki/Canasta-CLI/internal/config"
 	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators/kubernetes"
 )
@@ -135,6 +136,24 @@ func EnsureKindCluster(clusterName string, httpPort, httpsPort int) (bool, error
 		return false, err
 	}
 	return true, nil
+}
+
+// ensureKindContext looks up the kind cluster name for the installation at
+// installPath and sets the kubectl context if it's a kind-managed cluster.
+// This is a no-op for non-kind installations or if the lookup fails.
+func ensureKindContext(installPath string) error {
+	id, err := config.GetCanastaID(installPath)
+	if err != nil {
+		return nil
+	}
+	inst, err := config.GetDetails(id)
+	if err != nil {
+		return nil
+	}
+	if inst.KindCluster != "" {
+		return setKindKubectlContext(inst.KindCluster)
+	}
+	return nil
 }
 
 // setKindKubectlContext switches the kubectl context to the given kind cluster.

--- a/internal/orchestrators/kubernetes/files/kubernetes/caddy.yaml
+++ b/internal/orchestrators/kubernetes/files/kubernetes/caddy.yaml
@@ -67,6 +67,15 @@ spec:
           containerPort: 80
         - name: https-caddy
           containerPort: 443
+        readinessProbe:
+          tcpSocket:
+            port: 80
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 80
+          initialDelaySeconds: 10
+          periodSeconds: 30
         volumeMounts:
           - name: caddy-data
             mountPath: /data

--- a/internal/orchestrators/kubernetes/files/kubernetes/db.yaml
+++ b/internal/orchestrators/kubernetes/files/kubernetes/db.yaml
@@ -61,6 +61,22 @@ spec:
             value: "mediawiki"
         ports:
         - containerPort: 3306
+        startupProbe:
+          exec:
+            command: ["mysqladmin", "ping", "-h", "localhost"]
+          failureThreshold: 30
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command: ["mysqladmin", "ping", "-h", "localhost"]
+          periodSeconds: 10
+          timeoutSeconds: 5
+        livenessProbe:
+          exec:
+            command: ["mysqladmin", "ping", "-h", "localhost"]
+          initialDelaySeconds: 60
+          periodSeconds: 30
+          timeoutSeconds: 5
         volumeMounts:
         - name: initdb-volume
           mountPath: /docker-entrypoint-initdb.d

--- a/internal/orchestrators/kubernetes/files/kubernetes/elasticsearch.yaml
+++ b/internal/orchestrators/kubernetes/files/kubernetes/elasticsearch.yaml
@@ -66,6 +66,25 @@ spec:
           name: http
         - containerPort: 9300
           name: transport
+        startupProbe:
+          httpGet:
+            path: /_cluster/health
+            port: 9200
+          failureThreshold: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /_cluster/health
+            port: 9200
+          periodSeconds: 10
+          timeoutSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /_cluster/health
+            port: 9200
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 5
         volumeMounts:
         - name: elasticsearch-data
           mountPath: /usr/share/elasticsearch/data

--- a/internal/orchestrators/kubernetes/files/kubernetes/varnish.yaml
+++ b/internal/orchestrators/kubernetes/files/kubernetes/varnish.yaml
@@ -37,6 +37,15 @@ spec:
             cpu: "200m"
         ports:
         - containerPort: 80
+        readinessProbe:
+          tcpSocket:
+            port: 80
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 80
+          initialDelaySeconds: 10
+          periodSeconds: 30
         volumeMounts:
           - name: default-vcl-config
             mountPath: /etc/varnish/default.vcl

--- a/internal/orchestrators/kubernetes/files/kubernetes/web.yaml
+++ b/internal/orchestrators/kubernetes/files/kubernetes/web.yaml
@@ -39,6 +39,13 @@ spec:
       labels:
         app: web
     spec:
+      initContainers:
+      - name: wait-for-db
+        image: busybox:1.36
+        command: ['sh', '-c', 'until nc -z db 3306; do echo "Waiting for db..."; sleep 5; done']
+      - name: wait-for-elasticsearch
+        image: busybox:1.36
+        command: ['sh', '-c', 'until nc -z elasticsearch 9200; do echo "Waiting for elasticsearch..."; sleep 5; done']
       containers:
       - name: web
         image: ghcr.io/canastawiki/canasta:latest
@@ -51,6 +58,23 @@ spec:
             cpu: "500m"
         ports:
         - containerPort: 80
+        startupProbe:
+          exec:
+            command: ["wget", "-q", "--method=HEAD", "http://127.0.0.1/server-status"]
+          failureThreshold: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command: ["wget", "-q", "--method=HEAD", "http://127.0.0.1/server-status"]
+          periodSeconds: 15
+          timeoutSeconds: 10
+        livenessProbe:
+          exec:
+            command: ["wget", "-q", "--method=HEAD", "http://127.0.0.1/server-status"]
+          initialDelaySeconds: 60
+          periodSeconds: 30
+          timeoutSeconds: 10
         envFrom:
         - configMapRef:
             name: canasta-env

--- a/internal/orchestrators/kubernetes_test.go
+++ b/internal/orchestrators/kubernetes_test.go
@@ -529,7 +529,7 @@ func TestGenerateKustomizationNodePort(t *testing.T) {
 
 	k := &KubernetesOrchestrator{}
 	if err := k.generateKustomization(dir, true); err != nil {
-		t.Fatalf("generateKustomization(localCluster=true) error = %v", err)
+		t.Fatalf("generateKustomization(managedCluster=true) error = %v", err)
 	}
 
 	content, err := os.ReadFile(filepath.Join(dir, "kustomization.yaml"))
@@ -539,7 +539,7 @@ func TestGenerateKustomizationNodePort(t *testing.T) {
 	text := string(content)
 
 	if !strings.Contains(text, "type: NodePort") {
-		t.Error("NodePort patch should be present when localCluster=true")
+		t.Error("NodePort patch should be present when managedCluster=true")
 	}
 	if !strings.Contains(text, "nodePort: 30080") {
 		t.Error("NodePort 30080 should be configured")
@@ -551,7 +551,7 @@ func TestGenerateKustomizationNoNodePort(t *testing.T) {
 
 	k := &KubernetesOrchestrator{}
 	if err := k.generateKustomization(dir, false); err != nil {
-		t.Fatalf("generateKustomization(localCluster=false) error = %v", err)
+		t.Fatalf("generateKustomization(managedCluster=false) error = %v", err)
 	}
 
 	content, err := os.ReadFile(filepath.Join(dir, "kustomization.yaml"))
@@ -561,7 +561,7 @@ func TestGenerateKustomizationNoNodePort(t *testing.T) {
 	text := string(content)
 
 	if strings.Contains(text, "NodePort") {
-		t.Error("NodePort patch should not be present when localCluster=false")
+		t.Error("NodePort patch should not be present when managedCluster=false")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds proper health checks to db and elasticsearch services in both Docker Compose and Kubernetes, so dependent services wait until the database is truly ready before starting
- Extracts a `WaitForDB()` helper in the CLI with a reduced 10-second timeout (down from 60s), since the orchestrator health checks now handle the real wait
- Adds readiness/liveness probes to all Kubernetes services (web, caddy, varnish) and init containers on web for startup ordering

Fixes #109

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./...` passes
- [x] **Docker Compose**: `canasta create -i test -w main -a admin -n localhost` — db and elasticsearch show healthy, web starts only after both are healthy
- [x] **Kubernetes**: `canasta create -o k8s --create-cluster -i test -w main -a admin -n localhost` — init containers complete before web starts, all pods reach 1/1 Running