### PR TITLE
Fix my.cnf breaking mysqladmin and mysqldump

### DIFF
--- a/internal/canasta/installation-template/my.cnf
+++ b/internal/canasta/installation-template/my.cnf
@@ -1,5 +1,2 @@
-[client]
-skip-binary-as-hex = true
-
 [mysql]
 skip-binary-as-hex = true


### PR DESCRIPTION
## Summary

- Removes `skip-binary-as-hex` from the `[client]` section in `my.cnf`, keeping it only under `[mysql]`
- The `[client]` section applies to all MySQL client tools, but `skip-binary-as-hex` is only recognized by the `mysql` interactive client — other tools like `mysqladmin` and `mysqldump` fail with "unknown variable"

Fixes #336
Fixes CanastaWiki/Canasta-DockerCompose#33 (open since Dec 1, 2022)

## Test plan

- [x] `go build ./...` compiles
- [x] `canasta create -i test -w main -a admin -n localhost` succeeds
- [x] `docker exec <db-container> mysqladmin ping -h localhost` runs without "unknown variable" error
- [x] `docker exec <db-container> mysqldump --help` runs without "unknown variable" error
- [x] `docker exec <db-container> cat /etc/my.cnf` shows only `[mysql]` section