### PR TITLE
Add Kubernetes guide to mkdocs navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
     - Extensions and skins: guide/extensions-and-skins.md
     - Development mode: guide/devmode.md
     - Backup and restore: guide/backup.md
+    - Kubernetes: guide/kubernetes.md
     - Best practices: guide/best-practices.md
     - Observability: guide/observability.md
     - Troubleshooting: guide/troubleshooting.md


### PR DESCRIPTION
## Summary

- Adds the Kubernetes guide (`docs/guide/kubernetes.md`) to the mkdocs navigation, which was missed when #317 was merged

Fixes #338

## Test plan

- [x] `mkdocs.yml` includes `Kubernetes: guide/kubernetes.md` in the nav