### PR TITLE
Add orchestrator interface methods and NewFromInstance factory

### DIFF
--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -75,17 +75,9 @@ func Delete(instance config.Installation) error {
 	stopSpinner := spinner.New(description)
 	defer stopSpinner() // ensure cleanup on error paths
 
-	orch, err := orchestrators.New(instance.Orchestrator)
+	orch, err := orchestrators.NewFromInstance(instance)
 	if err != nil {
 		return err
-	}
-
-	// For CLI-managed clusters, set the flag so K8s-aware methods
-	// know this is a managed cluster (e.g., for dependency checks).
-	if instance.ManagedCluster {
-		if k8s, ok := orch.(*orchestrators.KubernetesOrchestrator); ok {
-			k8s.ManagedCluster = true
-		}
 	}
 
 	// Ensure containers are running so we can clean up images from inside

--- a/cmd/maintenanceUpdate/extension_test.go
+++ b/cmd/maintenanceUpdate/extension_test.go
@@ -76,6 +76,10 @@ func (m *extMockOrchestrator) UpdateConfig(installPath string) error {
 func (m *extMockOrchestrator) MigrateConfig(installPath string, dryRun bool) (bool, error) {
 	return false, nil
 }
+
+func (m *extMockOrchestrator) Name() string              { return "Mock" }
+func (m *extMockOrchestrator) SupportsDevMode() bool     { return true }
+func (m *extMockOrchestrator) SupportsImagePull() bool   { return true }
 func (m *extMockOrchestrator) StopAndStart(inst config.Installation) error {
 	return nil
 }

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -69,19 +69,12 @@ func Start(instance config.Installation, enableDev, disableDev bool) error {
 		return fmt.Errorf("cannot specify both --dev and --no-dev")
 	}
 
-	orch, err := orchestrators.New(instance.Orchestrator)
+	orch, err := orchestrators.NewFromInstance(instance)
 	if err != nil {
 		return err
 	}
-	if instance.ManagedCluster {
-		if k8s, ok := orch.(*orchestrators.KubernetesOrchestrator); ok {
-			k8s.ManagedCluster = true
-		}
-	}
-	if (enableDev || disableDev) {
-		if _, ok := orch.(*orchestrators.KubernetesOrchestrator); ok {
-			return fmt.Errorf("Development mode is only supported with Docker Compose")
-		}
+	if (enableDev || disableDev) && !orch.SupportsDevMode() {
+		return fmt.Errorf("development mode is not supported with %s", orch.Name())
 	}
 	if enableDev {
 		// Enable dev mode using default registry image

--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -48,14 +48,9 @@ are stopped gracefully, preserving all data in Docker volumes.`,
 }
 
 func Stop(instance config.Installation) error {
-	orch, err := orchestrators.New(instance.Orchestrator)
+	orch, err := orchestrators.NewFromInstance(instance)
 	if err != nil {
 		return err
-	}
-	if instance.ManagedCluster {
-		if k8s, ok := orch.(*orchestrators.KubernetesOrchestrator); ok {
-			k8s.ManagedCluster = true
-		}
 	}
 	return orch.Stop(instance)
 }

--- a/internal/devmode/devmode.go
+++ b/internal/devmode/devmode.go
@@ -279,10 +279,10 @@ func SetupDevEnvironment(installPath, baseImage string) error {
 // BuildXdebugImage builds the xdebug-enabled image.
 // Dev mode requires Docker Compose for Build and GetDevFiles.
 func BuildXdebugImage(installPath string, orch orchestrators.Orchestrator) error {
-	compose, ok := orch.(*orchestrators.ComposeOrchestrator)
-	if !ok {
-		return fmt.Errorf("dev mode is only supported with Docker Compose")
+	if !orch.SupportsDevMode() {
+		return fmt.Errorf("development mode is not supported with %s", orch.Name())
 	}
+	compose := orch.(*orchestrators.ComposeOrchestrator)
 
 	logging.Print("Building xdebug-enabled image...\n")
 

--- a/internal/orchestrators/compose.go
+++ b/internal/orchestrators/compose.go
@@ -25,6 +25,10 @@ const (
 // ComposeOrchestrator implements Orchestrator using Docker Compose.
 type ComposeOrchestrator struct{}
 
+func (c *ComposeOrchestrator) Name() string              { return "Docker Compose" }
+func (c *ComposeOrchestrator) SupportsDevMode() bool     { return true }
+func (c *ComposeOrchestrator) SupportsImagePull() bool   { return true }
+
 // getCompose returns the configured compose orchestrator path.
 func (c *ComposeOrchestrator) getCompose() (config.Orchestrator, error) {
 	return config.GetOrchestrator("compose")

--- a/internal/orchestrators/kubernetes.go
+++ b/internal/orchestrators/kubernetes.go
@@ -33,6 +33,10 @@ type KubernetesOrchestrator struct {
 	ManagedCluster bool
 }
 
+func (k *KubernetesOrchestrator) Name() string              { return "Kubernetes" }
+func (k *KubernetesOrchestrator) SupportsDevMode() bool     { return false }
+func (k *KubernetesOrchestrator) SupportsImagePull() bool   { return false }
+
 func (k *KubernetesOrchestrator) CheckDependencies() error {
 	if _, err := exec.LookPath("kubectl"); err != nil {
 		return fmt.Errorf("kubectl must be installed and in PATH")

--- a/internal/orchestrators/orchestrator.go
+++ b/internal/orchestrators/orchestrator.go
@@ -40,6 +40,15 @@ type Orchestrator interface {
 	// MigrateConfig applies orchestrator-specific migration steps during
 	// "canasta upgrade". Returns true if any changes were made.
 	MigrateConfig(installPath string, dryRun bool) (bool, error)
+
+	// Name returns a human-readable name for the orchestrator (e.g. "Docker Compose").
+	Name() string
+
+	// SupportsDevMode reports whether this orchestrator supports development mode (Xdebug).
+	SupportsDevMode() bool
+
+	// SupportsImagePull reports whether this orchestrator supports pulling container images.
+	SupportsImagePull() bool
 }
 
 // ImageInfo holds information about a Docker image

--- a/internal/orchestrators/orchestrator_test.go
+++ b/internal/orchestrators/orchestrator_test.go
@@ -90,6 +90,10 @@ func (m *mockOrchestrator) MigrateConfig(installPath string, dryRun bool) (bool,
 	return false, nil
 }
 
+func (m *mockOrchestrator) Name() string              { return "Mock" }
+func (m *mockOrchestrator) SupportsDevMode() bool     { return true }
+func (m *mockOrchestrator) SupportsImagePull() bool   { return true }
+
 func TestNew(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/orchestrators/registry.go
+++ b/internal/orchestrators/registry.go
@@ -2,6 +2,8 @@ package orchestrators
 
 import (
 	"fmt"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/config"
 )
 
 // New creates an Orchestrator implementation for the given orchestrator ID.
@@ -15,4 +17,17 @@ func New(orchestratorID string) (Orchestrator, error) {
 	default:
 		return nil, fmt.Errorf("orchestrator: %s is not available", orchestratorID)
 	}
+}
+
+// NewFromInstance creates an Orchestrator from a config.Installation, restoring
+// any orchestrator-specific state (e.g. ManagedCluster for Kubernetes).
+func NewFromInstance(instance config.Installation) (Orchestrator, error) {
+	orch, err := New(instance.Orchestrator)
+	if err != nil {
+		return nil, err
+	}
+	if k8s, ok := orch.(*KubernetesOrchestrator); ok {
+		k8s.ManagedCluster = instance.ManagedCluster
+	}
+	return orch, nil
 }


### PR DESCRIPTION
## Summary

- Add `Name()`, `SupportsDevMode()`, and `SupportsImagePull()` to the `Orchestrator` interface, replacing type assertions scattered across command packages with polymorphic calls
- Add `NewFromInstance()` factory that creates an orchestrator from a `config.Installation`, automatically restoring `ManagedCluster` state — eliminates a 5-command boilerplate pattern
- Fix upgrade using `InitConfig` instead of `UpdateConfig` for Kubernetes installations (#325)

Extracted from #323 (k8s-encapsulate) — these improvements are independent of the subcommands decision (#311).

Closes #342
Fixes #325

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all mocks updated)
- [x] `canasta upgrade -i <instance>` still works for Docker Compose installations
- [x] `canasta start/stop/restart/delete` still work with `--create-cluster` Kubernetes installations