### PR TITLE
Add persistent volume mount for K8s web deployment

### DIFF
--- a/internal/orchestrators/kubernetes/files/kubernetes/web.yaml
+++ b/internal/orchestrators/kubernetes/files/kubernetes/web.yaml
@@ -105,6 +105,9 @@ spec:
           subPath: my.cnf
         - mountPath: /mediawiki/config/settings/global
           name: canasta-settings-global
+        - mountPath: /mediawiki/config/persistent
+          name: config-volume
+          subPath: persistent
         - mountPath: /mediawiki/images
           name: config-volume
           subPath: images


### PR DESCRIPTION
## Summary
- Add a volume mount for `config/persistent` from the `config-volume` hostPath in the Kubernetes web deployment template
- This ensures internal state files (`.composer-deps-hash`, `.smw.json`) written by CanastaBase survive pod restarts

## Files changed
- `internal/orchestrators/kubernetes/files/kubernetes/web.yaml` — add `config/persistent` subPath mount

## Test plan
- [x] Kubernetes: first boot — hash rsynced to persistent volume, "Composer dependencies unchanged, skipping update"
- [x] Kubernetes: pod restart — hash persisted, composer update skipped

Fixes #345
Companion PR: CanastaWiki/CanastaBase#103