### PR TITLE
Add --cleanup flag to canasta list

### DIFF
--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -1,30 +1,59 @@
 package list
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-var instance config.Installation
+var (
+	instance config.Installation
+	cleanup  bool
+)
 
 func NewCmdCreate() *cobra.Command {
 	var listCmd = &cobra.Command{
 		Use:   "list",
 		Short: "List all Canasta installations",
 		Long: `List all registered Canasta installations. Displays each installation's
-ID, path, and orchestrator as recorded in the Canasta configuration file.`,
-		Example: `  canasta list`,
+ID, path, and orchestrator as recorded in the Canasta configuration file.
+
+Use --cleanup to remove stale entries whose installation directories no longer exist.`,
+		Example: `  canasta list
+  canasta list --cleanup`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := List(instance); err != nil {
-				return err
-			}
-			return nil
+			return List(instance, cleanup)
 		},
 	}
+	listCmd.Flags().BoolVar(&cleanup, "cleanup", false, "Remove stale entries whose installation directories no longer exist")
 	return listCmd
 }
 
-func List(instance config.Installation) error {
+func List(instance config.Installation, cleanup bool) error {
+	if cleanup {
+		installations, err := config.GetAll()
+		if err != nil {
+			return err
+		}
+		for id, installation := range installations {
+			if _, err := os.Stat(installation.Path); os.IsNotExist(err) {
+				if installation.KindCluster != "" {
+					if err := orchestrators.DeleteKindCluster(installation.KindCluster); err != nil {
+						fmt.Printf("Warning: failed to delete kind cluster '%s': %s\n", installation.KindCluster, err)
+					} else {
+						fmt.Printf("Deleted kind cluster '%s'\n", installation.KindCluster)
+					}
+				}
+				if err := config.Delete(id); err != nil {
+					return fmt.Errorf("error removing stale entry '%s': %w", id, err)
+				}
+				fmt.Printf("Removed stale entry '%s' (directory not found)\n", id)
+			}
+		}
+	}
 	return config.ListAll()
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,10 +131,33 @@ func ListAll() error {
 		return err
 	}
 
+	if len(existingInstallations.Installations) == 0 {
+		fmt.Println("No instances found.")
+		return nil
+	}
+
 	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(writer, "Canasta ID\tWiki ID\tServer Name\tServer Path\tInstallation Path\tOrchestrator")
 
 	for _, installation := range existingInstallations.Installations {
+		installPath := installation.Path
+		pathMissing := false
+		if _, err := os.Stat(installation.Path); os.IsNotExist(err) {
+			installPath = installation.Path + " [not found]"
+			pathMissing = true
+		}
+
+		if pathMissing {
+			fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\n",
+				installation.Id,
+				"N/A",
+				"N/A",
+				"N/A",
+				installPath,
+				installation.Orchestrator)
+			continue
+		}
+
 		if _, err := os.Stat(installation.Path + "/config/wikis.yaml"); os.IsNotExist(err) {
 			// File does not exist, print only installation info
 			fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\n",
@@ -142,7 +165,7 @@ func ListAll() error {
 				"N/A", // Placeholder
 				"N/A", // Placeholder
 				"N/A", // Placeholder
-				installation.Path,
+				installPath,
 				installation.Orchestrator)
 			continue
 		}
@@ -160,7 +183,7 @@ func ListAll() error {
 					ids[i],
 					serverNames[i],
 					paths[i],
-					installation.Path,
+					installPath,
 					installation.Orchestrator)
 			} else {
 				fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\n",
@@ -168,7 +191,7 @@ func ListAll() error {
 					ids[i],
 					serverNames[i],
 					paths[i],
-					installation.Path,
+					installPath,
 					installation.Orchestrator)
 			}
 


### PR DESCRIPTION
## Summary
- Adds `--cleanup` flag to `canasta list` that removes stale config entries whose installation directories no longer exist
- For Kubernetes installations with managed kind clusters, `--cleanup` also deletes the orphaned kind cluster
- Without `--cleanup`, stale entries are marked with `[not found]` in the Installation Path column
- When no installations exist, prints "No instances found." instead of an empty table header

Closes #330

## Test plan
- [x] Add a fake entry to conf.json, run `canasta list` — should show `[not found]` marker
- [x] Run `canasta list --cleanup` — should remove the stale entry and print removal message
- [x] For a stale k8s entry with a kind cluster, verify the cluster is also deleted
- [x] Run `canasta list` again — stale entry should be gone
- [x] Run `canasta list` with no installations — should print "No instances found."