### PR TITLE
Clean up temporary install directory after install.php

### DIFF
--- a/internal/mediawiki/mediawiki.go
+++ b/internal/mediawiki/mediawiki.go
@@ -123,6 +123,12 @@ func Install(path, yamlPath string, orch orchestrators.Orchestrator, canastaInfo
 		time.Sleep(time.Second)
 	}
 
+	// Clean up the temporary install directory
+	rmCmd := fmt.Sprintf("rm -rf %s", confPath)
+	if _, err := orch.ExecWithError(path, "web", rmCmd); err != nil {
+		return canastaInfo, fmt.Errorf("failed to remove install temp directory: %w", err)
+	}
+
 	return canastaInfo, nil
 }
 
@@ -242,12 +248,10 @@ func InstallOne(installPath, id, domain, admin, adminPassword, dbuser, workingDi
 		}
 	}
 
-	// Always remove the newly generated LocalSettings.php from inside the
-	// container (install.php writes to confPath which is a container-only
-	// temp directory, not a host-mounted path)
-	rmCmd := fmt.Sprintf("rm -f %s%s", confPath, localSettingsFile)
+	// Clean up the temporary install directory
+	rmCmd := fmt.Sprintf("rm -rf %s", confPath)
 	if _, rmErr := orch.ExecWithError(installPath, "web", rmCmd); rmErr != nil {
-		return fmt.Errorf("failed to remove generated LocalSettings.php: %w", rmErr)
+		return fmt.Errorf("failed to remove install temp directory: %w", rmErr)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- Replaces removal of individual `LocalSettings.php` with `rm -rf` of the entire `/tmp/canasta-install/` directory (inside the container, not on the host) after `install.php` completes
- Applies to both `Install` (multi-wiki creation) and `InstallOne` (adding a wiki)
- Works for all orchestrators (Docker Compose and Kubernetes)
- Prevents directory accumulation in long-running Kubernetes pods

Closes #327

## Test plan
- [x] Run `canasta create` and verify installation completes successfully
- [x] Run `canasta add` to add a wiki and verify it completes successfully
- [x] Exec into the web container after either operation and confirm `/tmp/canasta-install/` does not exist