### PR TITLE
Auto-rebuild local images during upgrade

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -392,7 +392,7 @@ func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiI
 	if isK8s {
 		reg = registry
 	}
-	instance := config.Installation{Id: canastaInfo.Id, Path: path, Orchestrator: orchestrator, DevMode: devModeEnabled, ManagedCluster: createCluster, Registry: reg, KindCluster: kindClusterName}
+	instance := config.Installation{Id: canastaInfo.Id, Path: path, Orchestrator: orchestrator, DevMode: devModeEnabled, ManagedCluster: createCluster, Registry: reg, KindCluster: kindClusterName, BuildFrom: buildFromPath}
 	if err := config.Add(instance); err != nil {
 		return err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type Installation struct {
 	ManagedCluster bool   `json:"managedCluster,omitempty"`
 	Registry     string `json:"registry,omitempty"`
 	KindCluster  string `json:"kindCluster,omitempty"`
+	BuildFrom    string `json:"buildFrom,omitempty"`
 }
 
 type Orchestrator struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -196,6 +196,59 @@ func TestAddOrchestratorSupported(t *testing.T) {
 	}
 }
 
+func TestBuildFromRoundTrip(t *testing.T) {
+	dir := setupTestDir(t)
+
+	inst := Installation{
+		Id:           "bf1",
+		Path:         "/tmp/bf1",
+		Orchestrator: "compose",
+		BuildFrom:    "/home/user/workspace",
+	}
+	if err := Add(inst); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+
+	got, err := GetDetails("bf1")
+	if err != nil {
+		t.Fatalf("GetDetails() error = %v", err)
+	}
+	if got.BuildFrom != "/home/user/workspace" {
+		t.Errorf("expected BuildFrom '/home/user/workspace', got %q", got.BuildFrom)
+	}
+
+	// Verify the JSON file contains the buildFrom key
+	data, err := os.ReadFile(filepath.Join(dir, "conf.json"))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if !strings.Contains(string(data), `"buildFrom"`) {
+		t.Error("expected conf.json to contain 'buildFrom' key")
+	}
+}
+
+func TestBuildFromOmittedWhenEmpty(t *testing.T) {
+	dir := setupTestDir(t)
+
+	inst := Installation{
+		Id:           "nobf1",
+		Path:         "/tmp/nobf1",
+		Orchestrator: "compose",
+	}
+	if err := Add(inst); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+
+	// Verify the JSON file does NOT contain buildFrom when empty
+	data, err := os.ReadFile(filepath.Join(dir, "conf.json"))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if strings.Contains(string(data), `"buildFrom"`) {
+		t.Error("expected conf.json to omit 'buildFrom' when empty")
+	}
+}
+
 func TestConfFileCreated(t *testing.T) {
 	dir := setupTestDir(t)
 


### PR DESCRIPTION
## Summary

- Persists the `--build-from` workspace path in the installation config (`buildFrom` field) during `canasta create`
- `canasta upgrade` now automatically rebuilds the local image from the stored path — no `--build-from` flag needed
- Removes the `--build-from` flag from `canasta upgrade` and the dead-end "recreate the instance" message for local builds
- For K8s: rebuilt images are distributed via kind-load or registry-push using stored `KindCluster`/`Registry` config

Closes #326

## Test plan

- [x] `canasta create --build-from /path/to/workspace -i test` persists `buildFrom` in `conf.json` (Compose + K8s)
- [x] `canasta upgrade -i test` auto-rebuilds the image without needing `--build-from` (Compose + K8s)
- [x] `canasta upgrade --help` no longer shows `--build-from`
- [x] For K8s with kind cluster: verify image is reloaded into the kind cluster during upgrade
- [x] Regular (non-build-from) installations still pull remote images normally