### PR TITLE
Improve docs: group visibility, upgrading guide, sitemaps guide, and rebranding

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -48,10 +48,10 @@ func NewCmdCreate() *cobra.Command {
 	createCmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a Canasta installation",
-		Long: `Create a new Canasta MediaWiki installation. This sets up the Docker Compose
-stack, generates configuration files, starts the containers, and runs the
-MediaWiki installer. You can optionally import an existing database dump
-instead of running the installer, or enable development mode with Xdebug.`,
+		Long: `Create a new Canasta MediaWiki installation. This generates configuration
+files, starts the containers, and runs the MediaWiki installer. You can
+optionally import an existing database dump instead of running the installer,
+or enable development mode with Xdebug (Compose only).`,
 		Example: `  # Create a basic single-wiki installation
   canasta create -i myinstance -w main -a admin -n example.com
 
@@ -191,20 +191,20 @@ instead of running the installer, or enable development mode with Xdebug.`,
 	createCmd.Flags().StringVarP(&canastaInfo.AdminPassword, "password", "s", "", "Initial wiki admin password (if not provided, auto-generates and saves to config/admin-password_{wikiid})")
 	createCmd.Flags().StringVarP(&yamlPath, "yamlfile", "f", "", "Initial wiki yaml file")
 	createCmd.Flags().BoolVarP(&keepConfig, "keep-config", "k", false, "Keep the config files on installation failure")
-	createCmd.Flags().StringVarP(&override, "override", "r", "", "Name of a file to copy to docker-compose.override.yml")
+	createCmd.Flags().StringVarP(&override, "override", "r", "", "Name of a file to copy to docker-compose.override.yml (Compose only)")
 	createCmd.Flags().StringVar(&canastaInfo.RootDBPassword, "rootdbpass", "", "Root database password (if not provided, auto-generates and saves to .env). Tip: Use --rootdbpass \"$ROOT_DB_PASS\" to avoid exposing password in shell history")
 	createCmd.Flags().StringVar(&canastaInfo.WikiDBUsername, "wikidbuser", "root", "The username of the wiki database user (default: \"root\")")
 	createCmd.Flags().StringVar(&canastaInfo.WikiDBPassword, "wikidbpass", "", "Wiki database password (if not provided, auto-generates and saves to .env). Tip: Use --wikidbpass \"$WIKI_DB_PASS\" to avoid exposing password in shell history")
 	createCmd.Flags().StringVarP(&envFile, "envfile", "e", "", "Path to .env file with password overrides (merged with default .env)")
-	createCmd.Flags().BoolVarP(&devModeFlag, "dev", "D", false, "Enable development mode with Xdebug and code extraction")
-	createCmd.Flags().StringVar(&devTag, "dev-tag", "latest", "Canasta image tag to use (e.g., latest, dev-branch)")
+	createCmd.Flags().BoolVarP(&devModeFlag, "dev", "D", false, "Enable development mode with Xdebug and code extraction (Compose only)")
+	createCmd.Flags().StringVar(&devTag, "dev-tag", "latest", "Canasta image tag to use (e.g., latest, dev-branch) (Compose only)")
 	createCmd.Flags().StringVar(&buildFromPath, "build-from", "", "Build a local Canasta and/or CanastaBase image from the specified local source directory")
 	createCmd.Flags().StringVarP(&databasePath, "database", "d", "", "Path to existing database dump (.sql or .sql.gz) to import instead of running install.php")
 	createCmd.Flags().StringVarP(&wikiSettingsPath, "wiki-settings", "l", "", "Path to per-wiki settings file to copy to config/settings/wikis/<wiki_id>/ (filename preserved)")
 	createCmd.Flags().StringVarP(&globalSettingsPath, "global-settings", "g", "", "Path to global settings file to copy to config/settings/global/ (filename preserved)")
 	createCmd.Flags().StringVar(&composerFile, "composer", "", "Path to custom composer.local.json to copy to config/")
 	createCmd.Flags().StringVar(&registry, "registry", "localhost:5000", "Container registry for pushing locally built images (used with --build-from on Kubernetes)")
-	createCmd.Flags().BoolVar(&createCluster, "create-cluster", false, "Create and manage a local Kubernetes cluster for this installation")
+	createCmd.Flags().BoolVar(&createCluster, "create-cluster", false, "Create and manage a local Kubernetes cluster for this installation (Kubernetes only)")
 
 	// Mark required flags
 	_ = createCmd.MarkFlagRequired("id")

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -198,7 +198,7 @@ instead of running the installer, or enable development mode with Xdebug.`,
 	createCmd.Flags().StringVarP(&envFile, "envfile", "e", "", "Path to .env file with password overrides (merged with default .env)")
 	createCmd.Flags().BoolVarP(&devModeFlag, "dev", "D", false, "Enable development mode with Xdebug and code extraction")
 	createCmd.Flags().StringVar(&devTag, "dev-tag", "latest", "Canasta image tag to use (e.g., latest, dev-branch)")
-	createCmd.Flags().StringVar(&buildFromPath, "build-from", "", "Build Canasta image from local source directory (expects Canasta/, optionally CanastaBase/)")
+	createCmd.Flags().StringVar(&buildFromPath, "build-from", "", "Build a local Canasta and/or CanastaBase image from the specified local source directory")
 	createCmd.Flags().StringVarP(&databasePath, "database", "d", "", "Path to existing database dump (.sql or .sql.gz) to import instead of running install.php")
 	createCmd.Flags().StringVarP(&wikiSettingsPath, "wiki-settings", "l", "", "Path to per-wiki settings file to copy to config/settings/wikis/<wiki_id>/ (filename preserved)")
 	createCmd.Flags().StringVarP(&globalSettingsPath, "global-settings", "g", "", "Path to global settings file to copy to config/settings/global/ (filename preserved)")

--- a/cmd/restart/restart.go
+++ b/cmd/restart/restart.go
@@ -56,8 +56,8 @@ restart. Use --dev or --no-dev to change the development mode setting.`,
 	}
 	restartCmd.Flags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
 	restartCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Verbose Output")
-	restartCmd.Flags().BoolVarP(&devModeFlag, "dev", "D", false, "Restart in development mode with Xdebug")
-	restartCmd.Flags().BoolVar(&noDevFlag, "no-dev", false, "Restart without development mode (disable dev mode)")
+	restartCmd.Flags().BoolVarP(&devModeFlag, "dev", "D", false, "Restart in development mode with Xdebug (Compose only)")
+	restartCmd.Flags().BoolVar(&noDevFlag, "no-dev", false, "Restart without development mode (disable dev mode) (Compose only)")
 	return restartCmd
 }
 

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -58,8 +58,8 @@ Use --dev to enable or --no-dev to disable development mode at start time.`,
 		},
 	}
 	startCmd.Flags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
-	startCmd.Flags().BoolVarP(&devModeFlag, "dev", "D", false, "Start in development mode with Xdebug")
-	startCmd.Flags().BoolVar(&noDevFlag, "no-dev", false, "Start without development mode (disable dev mode)")
+	startCmd.Flags().BoolVarP(&devModeFlag, "dev", "D", false, "Start in development mode with Xdebug (Compose only)")
+	startCmd.Flags().BoolVar(&noDevFlag, "no-dev", false, "Start without development mode (disable dev mode) (Compose only)")
 	return startCmd
 }
 

--- a/docs/guide/best-practices.md
+++ b/docs/guide/best-practices.md
@@ -62,21 +62,7 @@ The only step that requires `sudo` is installing the CLI binary to `/usr/local/b
 
 ### Before upgrading
 
-1. Take a backup:
-   ```bash
-   canasta backup create -t "pre-upgrade-$(date +%Y%m%d)" -i myinstance
-   ```
-2. Review the Canasta release notes for any breaking changes
-3. Run the upgrade:
-   ```bash
-   canasta upgrade -i myinstance
-   ```
-
-To upgrade all installations at once:
-
-```bash
-canasta upgrade --all
-```
+See the [Upgrading guide](upgrading.md) for pre-upgrade steps and the full upgrade process.
 
 ### Managing multiple installations
 

--- a/docs/guide/general-concepts.md
+++ b/docs/guide/general-concepts.md
@@ -386,43 +386,7 @@ See the [CLI Reference](../cli/canasta_maintenance.md) for more details.
 
 ## Sitemaps
 
-XML sitemaps help search engines discover and index pages on your wiki. Canasta provides commands to generate and remove sitemaps, and a background process to keep them up to date.
-
-### Generating sitemaps
-
-Use `canasta sitemap generate` to create sitemaps. You can generate for a specific wiki or for all wikis in the installation:
-
-```bash
-# Generate sitemap for a specific wiki
-canasta sitemap generate -i myinstance -w mywiki
-
-# Generate sitemaps for all wikis
-canasta sitemap generate -i myinstance
-```
-
-Sitemap files are stored in the `public_assets/{wiki-id}/sitemap/` directory and served at `/public_assets/sitemap/`. Once generated, a background process automatically refreshes the sitemaps on a regular schedule (controlled by the `MW_SITEMAP_PAUSE_DAYS` environment variable, which defaults to 1 day).
-
-The sitemap URL is automatically advertised in the wiki's `robots.txt` when sitemap files exist.
-
-### Removing sitemaps
-
-Use `canasta sitemap remove` to delete sitemap files. Once removed, the background generator will skip those wikis until sitemaps are generated again:
-
-```bash
-# Remove sitemap for a specific wiki
-canasta sitemap remove -i myinstance -w mywiki
-
-# Remove sitemaps for all wikis (prompts for confirmation)
-canasta sitemap remove -i myinstance
-```
-
-### How it works
-
-The presence of sitemap files is the sole signal that controls sitemap behavior:
-
-- **Background refresh**: The generator only refreshes sitemaps for wikis that already have sitemap files. Generating sitemaps for a wiki opts it in; removing them opts it out.
-- **robots.txt**: The sitemap URL is advertised in `robots.txt` only when sitemap files exist for the wiki.
-- **No configuration needed**: There are no YAML fields or environment variables to set — just generate or remove.
+XML sitemaps help search engines discover and index pages on your wiki. See the [Sitemaps guide](sitemaps.md) for full details on generating, removing, and troubleshooting sitemaps.
 
 ---
 

--- a/docs/guide/kubernetes.md
+++ b/docs/guide/kubernetes.md
@@ -24,12 +24,10 @@ Canasta CLI can deploy to Kubernetes in two ways:
 
 In addition to Docker (required for kind), you need:
 
-| Tool | Purpose | Install |
-|------|---------|---------|
-| [kubectl](https://kubernetes.io/docs/tasks/tools/) | Kubernetes CLI | `brew install kubectl` or [see docs](https://kubernetes.io/docs/tasks/tools/) |
-| [kind](https://kind.sigs.k8s.io/) | Local K8s clusters | `brew install kind` or [see docs](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) |
-
-On Linux, install kubectl and kind using your package manager or by downloading the binaries directly from the links above.
+| Tool | Purpose | Install (macOS) | Install (Linux) |
+|------|---------|-----------------|-----------------|
+| [kubectl](https://kubernetes.io/docs/tasks/tools/) | Kubernetes CLI | `brew install kubectl` | [See docs](https://kubernetes.io/docs/tasks/tools/) |
+| [kind](https://kind.sigs.k8s.io/) | Local K8s clusters | `brew install kind` | [See docs](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) |
 
 The CLI checks for these tools at creation time and will report a clear error if either is missing.
 

--- a/docs/guide/sitemaps.md
+++ b/docs/guide/sitemaps.md
@@ -93,7 +93,7 @@ myinstance/
         sitemap-index-mywiki.xml
 ```
 
-The files are compressed (`.xml.gz`) for efficiency, with an index file that lists all the individual sitemap files.
+The file(s) are compressed (`.xml.gz`) for efficiency, with an index file that lists all the individual sitemap files.
 
 ---
 

--- a/docs/guide/sitemaps.md
+++ b/docs/guide/sitemaps.md
@@ -1,0 +1,154 @@
+# Sitemaps
+
+XML sitemaps help search engines discover and index pages on your wiki. Canasta provides commands to generate and remove sitemaps, and a background process to keep them up to date.
+
+## Contents
+
+- [Why sitemaps matter](#why-sitemaps-matter)
+- [Generating sitemaps](#generating-sitemaps)
+- [Removing sitemaps](#removing-sitemaps)
+- [Background refresh](#background-refresh)
+- [File storage](#file-storage)
+- [robots.txt integration](#robotstxt-integration)
+- [Verifying sitemaps](#verifying-sitemaps)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Why sitemaps matter
+
+Search engines like Google and Bing use [XML sitemaps](https://www.sitemaps.org/) to discover pages on your site. Without a sitemap, crawlers rely on following links from your main page, which can miss pages that are poorly linked or deeply nested. Providing a sitemap ensures that all your wiki's content is discoverable.
+
+---
+
+## Generating sitemaps
+
+Use `canasta sitemap generate` to create sitemaps for your wikis.
+
+Generate a sitemap for a specific wiki:
+
+```bash
+canasta sitemap generate -i myinstance -w mywiki
+```
+
+Generate sitemaps for all wikis in the installation:
+
+```bash
+canasta sitemap generate -i myinstance
+```
+
+Once generated, a [background process](#background-refresh) automatically keeps the sitemaps up to date.
+
+---
+
+## Removing sitemaps
+
+Use `canasta sitemap remove` to delete sitemap files. Once removed, the background generator will skip those wikis until sitemaps are generated again.
+
+Remove the sitemap for a specific wiki:
+
+```bash
+canasta sitemap remove -i myinstance -w mywiki
+```
+
+Remove sitemaps for all wikis (prompts for confirmation):
+
+```bash
+canasta sitemap remove -i myinstance
+```
+
+To skip the confirmation prompt, use `-y`:
+
+```bash
+canasta sitemap remove -i myinstance -y
+```
+
+---
+
+## Background refresh
+
+After sitemaps are generated for a wiki, a background process inside the container automatically refreshes them on a regular schedule. The refresh interval is controlled by the `MW_SITEMAP_PAUSE_DAYS` environment variable in your `.env` file:
+
+```env
+MW_SITEMAP_PAUSE_DAYS=1
+```
+
+The default is 1 day (values less than 1 are treated as 1). The background generator runs continuously inside the container — it starts after a 30-second delay and loops indefinitely, sleeping for the configured interval between runs. It only refreshes sitemaps for wikis that already have sitemap files — generating sitemaps for a wiki opts it in, and removing them opts it out.
+
+The generator writes daily-rotating log files inside the container at `/var/log/mediawiki/mwsitemapgen_log_YYYYMMDD`.
+
+---
+
+## File storage
+
+Sitemap files are stored in the `public_assets/<wiki-id>/sitemap/` directory within your installation. They are served at the URL path `/public_assets/sitemap/`.
+
+```
+myinstance/
+  public_assets/
+    mywiki/
+      sitemap/
+        sitemap-mywiki-NS_0-0.xml.gz
+        sitemap-mywiki-NS_6-0.xml.gz
+        sitemap-index-mywiki.xml
+```
+
+The files are compressed (`.xml.gz`) for efficiency, with an index file that lists all the individual sitemap files.
+
+---
+
+## robots.txt integration
+
+Canasta dynamically generates `robots.txt` for each wiki. When sitemap files exist for a wiki, the sitemap index URL is automatically included in the response:
+
+```
+Sitemap: https://example.com/public_assets/sitemap/sitemap-index-mywiki.xml
+```
+
+No configuration is needed — the presence of sitemap files is the sole signal. When sitemaps are removed, the `robots.txt` entry is removed as well.
+
+### Disabling robots
+
+To tell all search engines not to crawl any of your wikis, set `ROBOTS_DISALLOWED=true` in your `.env` file. This causes `robots.txt` to return `Disallow: /` for all user agents.
+
+---
+
+## Verifying sitemaps
+
+After generating sitemaps, verify they are accessible:
+
+1. Check the sitemap index URL in your browser:
+   ```
+   https://example.com/public_assets/sitemap/sitemap-index-mywiki.xml
+   ```
+
+2. Verify `robots.txt` includes the sitemap URL:
+   ```
+   https://example.com/robots.txt
+   ```
+
+3. Submit the sitemap URL to search engine webmaster tools for faster indexing:
+   - [Google Search Console](https://search.google.com/search-console)
+   - [Bing Webmaster Tools](https://www.bing.com/webmasters)
+
+---
+
+## Troubleshooting
+
+### Sitemaps not updating
+
+- Verify the containers are running: `canasta start -i myinstance`
+- Check the `MW_SITEMAP_PAUSE_DAYS` value in your `.env` file — a high value means less frequent refreshes
+- Check the generator log inside the container for errors: `/var/log/mediawiki/mwsitemapgen_log_YYYYMMDD`
+- Regenerate manually: `canasta sitemap generate -i myinstance -w mywiki`
+
+### Search engines not finding sitemaps
+
+- Confirm the sitemap URL is present in `robots.txt` (visit `https://yourwiki/robots.txt`)
+- If sitemap files exist but `robots.txt` does not list them, restart the installation: `canasta restart -i myinstance`
+- Submit the sitemap URL directly in your search engine's webmaster tools
+
+### Permission errors
+
+- Ensure your user is in the `www-data` group (see [Installation guide](../installation.md#linux))
+- The sitemap directory must be writable by the `www-data` user inside the container — `canasta sitemap generate` handles this automatically

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -1,0 +1,136 @@
+# Upgrading
+
+This guide covers upgrading Canasta installations and migrating from legacy (non-CLI) setups.
+
+## Contents
+
+- [How upgrading works](#how-upgrading-works)
+- [Pre-upgrade checklist](#pre-upgrade-checklist)
+- [Version notes](#version-notes)
+- [Migrating from a legacy installation](#migrating-from-a-legacy-installation)
+
+---
+
+## How upgrading works
+
+The `canasta upgrade` command performs the following steps:
+
+1. Pulls the latest Canasta Docker image (or rebuilds it if the installation was created with `--build-from`)
+2. Restarts the containers with the new image
+3. Runs `maintenance/update.php` automatically to apply any database schema changes
+
+To upgrade a single installation:
+
+```bash
+canasta upgrade -i myinstance
+```
+
+To upgrade all installations at once:
+
+```bash
+canasta upgrade --all
+```
+
+The CLI also updates itself during the upgrade process, so you always have the latest CLI version.
+
+## Pre-upgrade checklist
+
+1. **Back up your data** before every upgrade:
+   ```bash
+   canasta backup create -t "pre-upgrade-$(date +%Y%m%d)" -i myinstance
+   ```
+2. Review the [Canasta release notes](https://github.com/CanastaWiki/Canasta/releases) for any breaking changes.
+3. Ensure your user has the required group memberships (see [Version notes](#version-notes) below if upgrading from an older release).
+
+## Version notes
+
+The CLI's relationship with `sudo` changed over several releases:
+
+| Version | Change |
+|---------|--------|
+| **v1.48.0** | CLI began handling `www-data` file ownership internally, enabling commands to run without `sudo`. |
+| **v1.65.0** | `sudo` removed from installer messages and documentation examples. |
+| **v1.127.0** | `www-data` group requirement formally documented. |
+
+### Upgrading from pre-v1.48.0
+
+If you previously ran commands with `sudo canasta ...`, you should:
+
+1. Add your user to the `docker` and `www-data` groups:
+   ```bash
+   sudo usermod -aG docker,www-data $USER
+   ```
+2. Log out and log back in for the group changes to take effect.
+3. Stop using `sudo` with Canasta CLI commands.
+
+See the [installation guide](../installation.md#linux) for full details on Linux group requirements.
+
+## Migrating from a legacy installation
+
+If you have an existing MediaWiki installation that was **not** created with the Canasta CLI (for example, a manual Docker Compose setup or a bare-metal install), you can migrate it to a CLI-managed Canasta installation.
+
+### 1. Export your database
+
+Use `mysqldump` (or the equivalent for your database engine) to create a SQL dump of your wiki database:
+
+```bash
+mysqldump -u root -p wikidb > wikidb.sql
+```
+
+### 2. Create a new Canasta installation with the database dump
+
+```bash
+canasta create -i myinstance -w mywiki -a admin -n example.com -d wikidb.sql
+```
+
+The `-d` flag imports the SQL dump during installation. The `admin` account will be created only if it does not already exist in the imported database.
+
+### 3. Copy your settings files
+
+Copy your existing PHP settings files (e.g., `LocalSettings.php` customizations) into the new installation's settings directory:
+
+```bash
+cp MySettings.php /path/to/myinstance/config/settings/
+```
+
+If you are running a wiki farm, place per-wiki settings in `config/settings/wikis/<wikiid>/`.
+
+### 4. Copy uploaded images
+
+Copy your uploaded files into the installation's `images/` directory:
+
+```bash
+cp -r /old/wiki/images/* /path/to/myinstance/images/
+```
+
+### 5. Copy Caddyfile customizations
+
+If you had custom web server rules, copy them to the Canasta Caddyfile locations:
+
+- `config/Caddyfile.site` — per-site directives (headers, redirects, etc.)
+- `config/Caddyfile.global` — global Caddy options
+
+Do **not** edit `config/Caddyfile` directly, as it is regenerated when wikis change.
+
+### 6. Copy custom extensions and skins
+
+If you have extensions or skins that are **not** bundled with Canasta, copy them into the installation:
+
+```bash
+cp -r /old/wiki/extensions/MyExtension /path/to/myinstance/extensions/
+cp -r /old/wiki/skins/MySkin /path/to/myinstance/skins/
+```
+
+### 7. Carry over `.env` settings
+
+Review your old configuration and carry over any custom environment variables (database credentials, `MW_SITE_SERVER`, etc.) into the new installation's `.env` file at the root of the installation directory.
+
+### 8. Restart and verify
+
+Restart the installation and verify that everything is working:
+
+```bash
+canasta restart -i myinstance
+```
+
+The `update.php` maintenance script runs automatically on container startup, so database schema migrations will be applied.

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -87,20 +87,20 @@ The `-d` flag imports the SQL dump during installation. The `admin` account will
 
 ### 3. Copy your settings files
 
-Copy your existing PHP settings files (e.g., `LocalSettings.php` customizations) into the new installation's settings directory:
+Copy your existing PHP settings files (e.g., `LocalSettings.php` customizations) into the new installation's global settings directory:
 
 ```bash
-cp MySettings.php /path/to/myinstance/config/settings/
+cp MySettings.php /path/to/myinstance/config/settings/global/
 ```
 
 If you are running a wiki farm, place per-wiki settings in `config/settings/wikis/<wikiid>/`.
 
 ### 4. Copy uploaded images
 
-Copy your uploaded files into the installation's `images/` directory:
+Copy your uploaded files into the installation's `images/<wiki-id>/` directory:
 
 ```bash
-cp -r /old/wiki/images/* /path/to/myinstance/images/
+cp -r /old/wiki/images/* /path/to/myinstance/images/<wiki-id>/
 ```
 
 ### 5. Copy Caddyfile customizations

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,8 +30,9 @@ curl -fsSL https://raw.githubusercontent.com/CanastaWiki/Canasta-CLI/main/instal
 canasta create -i myinstance -w wiki1 -a admin -n localhost
 ```
 
-!!! note "Linux users"
-    Before running CLI commands, add your user to the `docker` and `www-data` groups. See the [installation guide](installation.md#linux) for details.
+> **Note: Linux users**
+>
+> Before running CLI commands, add your user to the `docker` and `www-data` groups. See the [installation guide](installation.md#linux) for details.
 
 ## Next steps
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,9 @@ curl -fsSL https://raw.githubusercontent.com/CanastaWiki/Canasta-CLI/main/instal
 canasta create -i myinstance -w wiki1 -a admin -n localhost
 ```
 
+!!! note "Linux users"
+    Before running CLI commands, add your user to the `docker` and `www-data` groups. See the [installation guide](installation.md#linux) for details.
+
 ## Next steps
 
 - [Installation guide](installation.md) - Detailed installation instructions
@@ -44,5 +47,6 @@ canasta create -i myinstance -w wiki1 -a admin -n localhost
 - [Development mode](guide/devmode.md) - Live code editing and Xdebug debugging
 - [Kubernetes](guide/kubernetes.md) - Deploying to Kubernetes with a CLI-managed kind cluster
 - [Backup and restore](guide/backup.md) - Setting up backups with restic
+- [Upgrading](guide/upgrading.md) - Upgrade process, version notes, and legacy migration
 - [Best practices](guide/best-practices.md) - Security considerations and best practices
 - [Troubleshooting](guide/troubleshooting.md) - Common issues and debugging

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
-# Canasta CLI
+# Canasta Documentation
 
-Welcome to the official documentation for **Canasta CLI**, the command-line interface tool for managing [Canasta](https://canasta.wiki/) MediaWiki installations.
+[Canasta](https://canasta.wiki/) is a fully featured MediaWiki distribution that bundles MediaWiki with over 170 extensions and skins, a database server, a web server, and a caching layer into a single containerized package supporting both Docker Compose and Kubernetes. It is designed to make it easy to set up, manage, and maintain enterprise-grade wikis without needing deep knowledge of MediaWiki's internals.
 
-## What is Canasta CLI?
+## Canasta CLI
 
-Canasta CLI is a powerful tool that allows you to create, manage, and maintain multiple Canasta MediaWiki installations with ease. It supports Docker Compose and local Kubernetes orchestration and provides features for:
+The **Canasta CLI** is the command-line tool for managing Canasta installations. It supports Docker Compose and local Kubernetes orchestration and provides features for:
 
 - **Creating** new Canasta installations (single wikis or wiki farms)
 - **Managing** extensions and skins

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,5 +48,6 @@ canasta create -i myinstance -w wiki1 -a admin -n localhost
 - [Kubernetes](guide/kubernetes.md) - Deploying to Kubernetes with a CLI-managed kind cluster
 - [Backup and restore](guide/backup.md) - Setting up backups with restic
 - [Upgrading](guide/upgrading.md) - Upgrade process, version notes, and legacy migration
+- [Sitemaps](guide/sitemaps.md) - XML sitemap generation for search engine indexing
 - [Best practices](guide/best-practices.md) - Security considerations and best practices
 - [Troubleshooting](guide/troubleshooting.md) - Common issues and debugging

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,11 +31,17 @@ Essentially, preparing your Linux server to be a Canasta host by installing the 
 `sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin` once you've
 added the Docker repositories to your system.
 
-On Linux, you also need Docker access and file permission for your user account. Add your user to the `docker` and `www-data` groups, then log out and log back in:
+!!! warning "Linux: required group membership"
+    Add your user to the `docker` and `www-data` groups, then **log out and log back in**:
 
-```bash
-sudo usermod -aG docker,www-data $USER
-```
+    ```bash
+    sudo usermod -aG docker,www-data $USER
+    ```
+
+    - `docker` — permission to run Docker commands (replaces the need for `sudo`)
+    - `www-data` — permission to manage files in the installation's `config/` directory (shared with the web container)
+
+    Without these groups, you will get "permission denied" errors when running CLI commands or editing configuration files.
 
 ### Kubernetes (managed cluster)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,17 +31,18 @@ Essentially, preparing your Linux server to be a Canasta host by installing the 
 `sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin` once you've
 added the Docker repositories to your system.
 
-!!! warning "Linux: required group membership"
-    Add your user to the `docker` and `www-data` groups, then **log out and log back in**:
-
-    ```bash
-    sudo usermod -aG docker,www-data $USER
-    ```
-
-    - `docker` — permission to run Docker commands (replaces the need for `sudo`)
-    - `www-data` — permission to manage files in the installation's `config/` directory (shared with the web container)
-
-    Without these groups, you will get "permission denied" errors when running CLI commands or editing configuration files.
+> **Warning: Linux required group membership**
+>
+> Add your user to the `docker` and `www-data` groups, then **log out and log back in**:
+>
+> ```bash
+> sudo usermod -aG docker,www-data $USER
+> ```
+>
+> - `docker` — permission to run Docker commands (replaces the need for `sudo`)
+> - `www-data` — permission to manage files in the installation's `config/` directory (shared with the web container)
+>
+> Without these groups, you will get "permission denied" errors when running CLI commands or editing configuration files.
 
 ### Kubernetes (managed cluster)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
     - Extensions and skins: guide/extensions-and-skins.md
     - Development mode: guide/devmode.md
     - Backup and restore: guide/backup.md
+    - Upgrading: guide/upgrading.md
     - Kubernetes: guide/kubernetes.md
     - Best practices: guide/best-practices.md
     - Observability: guide/observability.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
     - Development mode: guide/devmode.md
     - Backup and restore: guide/backup.md
     - Upgrading: guide/upgrading.md
+    - Sitemaps: guide/sitemaps.md
     - Kubernetes: guide/kubernetes.md
     - Best practices: guide/best-practices.md
     - Observability: guide/observability.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
-site_name: Canasta CLI Documentation
-site_description: Official documentation for the Canasta CLI tool
+site_name: Canasta Documentation
+site_description: Official documentation for the Canasta MediaWiki distribution
 site_url: https://canastawiki.github.io/Canasta-CLI/
 repo_url: https://github.com/CanastaWiki/Canasta-CLI
 repo_name: CanastaWiki/Canasta-CLI


### PR DESCRIPTION
## Summary

- Replace plain Linux group paragraph in installation page with a blockquote callout explaining both groups, their purposes, and consequences of missing them
- Add a Linux note to the quick start section on the home page
- Create a dedicated upgrading guide covering the upgrade process, version notes on the sudo-to-groups transition (v1.48.0, v1.65.0, v1.127.0), and a step-by-step legacy migration guide
- Replace the "Before upgrading" section in best-practices.md with a cross-reference to the new guide
- Fix k8s docs: split brew install into separate macOS/Linux columns
- Update `--build-from` flag description in `canasta create`
- Create dedicated sitemaps guide with generation, removal, background refresh (`MW_SITEMAP_PAUSE_DAYS`), file storage, robots.txt integration (`ROBOTS_DISALLOWED`), verification, and troubleshooting
- Replace inline sitemap content in general-concepts.md with cross-reference to the new guide
- Rebrand site from "Canasta CLI Documentation" to "Canasta Documentation" with an introductory paragraph about Canasta on the home page
- Label orchestrator-specific flags as "(Compose only)" or "(Kubernetes only)" in `create`, `start`, and `restart` help text

Addresses #331, #332, #344.

## Test plan

- [x] Run `mkdocs build` and verify blockquote callouts render correctly on installation page and index page
- [x] Verify the new upgrading guide appears in the nav and renders correctly
- [x] Verify the new sitemaps guide appears in the nav and renders correctly
- [x] Verify cross-reference links from best-practices.md and general-concepts.md resolve
- [x] Verify all existing links still resolve (only pre-existing warnings from auto-generated CLI docs)
- [x] Verify `canasta create --help` shows updated `--build-from` description
- [x] Verify site title shows "Canasta Documentation"
- [x] Verify orchestrator-specific flags are labeled in `create`, `start`, and `restart` help text