### PR TITLE
Extend observability to Kubernetes and rename env var

### DIFF
--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -1,4 +1,4 @@
-# Observability (OpenSearch + Log Shipping + Dashboards)
+# Observability (OpenSearch + Dashboards)
 
 Canasta includes an optional observability stack that collects logs from MediaWiki, Caddy, and MySQL and makes them searchable through OpenSearch Dashboards.
 
@@ -42,7 +42,7 @@ In both cases, the CLI automatically:
 - Generates `OS_USER`, `OS_PASSWORD`, and `OS_PASSWORD_HASH` in `.env`
 - Adds the OpenSearch Dashboards reverse proxy block to the Caddyfile
 - For Docker Compose: syncs `COMPOSE_PROFILES` to include `observable`
-- For Kubernetes: adds OpenSearch, Dashboards, and Fluent Bit sidecar resources to the kustomization
+- For Kubernetes: adds OpenSearch, Dashboards, and Fluent Bit resources to the kustomization
 
 > **Note:** If you are migrating from an older Canasta installation that used `COMPOSE_PROFILES=observable`, running `canasta upgrade` will automatically add `CANASTA_ENABLE_OBSERVABILITY=true` to your `.env` file.
 
@@ -99,7 +99,7 @@ Once log files are created, the `mediawiki-logs-*` index pattern will appear aut
 
 ## Index patterns
 
-Index patterns are created automatically by an init container (Docker Compose) or init job (Kubernetes) when the observability stack starts. It waits for OpenSearch Dashboards to be ready and for at least one log index to exist, then creates patterns for each available index. A second pass runs 60 seconds later to pick up any late-arriving indices.
+Index patterns are created automatically by an init container (Docker Compose) or init job (Kubernetes) when the observability stack starts.
 
 If automatic creation fails, you can create patterns manually:
 
@@ -132,7 +132,7 @@ If you do not see logs in Dashboards:
   - **Kubernetes:**
     ```bash
     kubectl logs deployment/opensearch -n <namespace>
-    kubectl logs deployment/web -n <namespace> -c fluent-bit
+    kubectl logs deployment/fluent-bit -n <namespace>
     ```
 
 ---
@@ -142,7 +142,7 @@ If you do not see logs in Dashboards:
 The observability stack uses different log shipping approaches depending on the orchestrator:
 
 - **Docker Compose:** Uses Logstash to read log files from shared Docker volumes and ship them to OpenSearch.
-- **Kubernetes:** Uses Fluent Bit sidecar containers attached to the web, caddy, and db deployments. Each sidecar reads logs from a shared `emptyDir` volume and ships them to OpenSearch.
+- **Kubernetes:** Uses a standalone Fluent Bit Deployment that reads log files from PVC volumes shared with the web, caddy, and db pods.
 
 Both approaches ship logs to the same OpenSearch indices and Dashboards is accessible at `/opensearch` on both orchestrators.
 

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -1,4 +1,4 @@
-# Observability (OpenSearch + Dashboards)
+# Observability (OpenSearch + Logstash + Dashboards)
 
 Canasta includes an optional observability stack that collects logs from MediaWiki, Caddy, and MySQL and makes them searchable through OpenSearch Dashboards.
 

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -379,9 +379,15 @@ func ContainsProfile(profiles, target string) bool {
 	return false
 }
 
-// EnsureObservabilityCredentials checks if COMPOSE_PROFILES contains "observable" in .env.
+// IsObservabilityEnabled returns true when CANASTA_ENABLE_OBSERVABILITY is set
+// to "true" (case-insensitive) in the given env vars map.
+func IsObservabilityEnabled(envVars map[string]string) bool {
+	return strings.EqualFold(envVars["CANASTA_ENABLE_OBSERVABILITY"], "true")
+}
+
+// EnsureObservabilityCredentials checks if CANASTA_ENABLE_OBSERVABILITY=true in .env.
 // If active, it ensures OS_USER, OS_PASSWORD, and OS_PASSWORD_HASH are set.
-// Returns true if the observable profile is active.
+// Returns true if observability is enabled.
 func EnsureObservabilityCredentials(installPath string) (bool, error) {
 	envPath := installPath + "/.env"
 	envVars, err := GetEnvVariable(envPath)
@@ -389,7 +395,7 @@ func EnsureObservabilityCredentials(installPath string) (bool, error) {
 		return false, err
 	}
 
-	if !ContainsProfile(envVars["COMPOSE_PROFILES"], "observable") {
+	if !IsObservabilityEnabled(envVars) {
 		return false, nil
 	}
 
@@ -459,11 +465,11 @@ func RewriteCaddy(installPath string) error {
 	}
 	httpOnly := strings.ToLower(envVars["CADDY_AUTO_HTTPS"]) == "off"
 
-	// Check if observable profile is active
-	observable := ContainsProfile(envVars["COMPOSE_PROFILES"], "observable")
+	// Check if observability is enabled
+	observable := IsObservabilityEnabled(envVars)
 	if observable {
 		if envVars["OS_USER"] == "" || envVars["OS_PASSWORD_HASH"] == "" {
-			return fmt.Errorf("observable profile is active but OS_USER or OS_PASSWORD_HASH is missing from .env; run 'canasta upgrade' to generate credentials")
+			return fmt.Errorf("observability is enabled but OS_USER or OS_PASSWORD_HASH is missing from .env; run 'canasta upgrade' to generate credentials")
 		}
 	}
 

--- a/internal/orchestrators/compose/files/config/logstash/pipeline/mediawiki.conf
+++ b/internal/orchestrators/compose/files/config/logstash/pipeline/mediawiki.conf
@@ -1,6 +1,6 @@
 input {
   file {
-    path => "/var/log/mediawiki/*.log"
+    path => "/var/log/mediawiki/*"
     start_position => "beginning"
     sincedb_path => "/usr/share/logstash/data/sincedb/mediawiki"
     type => "mediawiki"

--- a/internal/orchestrators/kubernetes/files/kubernetes/fluent-bit-config.yaml
+++ b/internal/orchestrators/kubernetes/files/kubernetes/fluent-bit-config.yaml
@@ -1,0 +1,81 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluent-bit-config
+data:
+  fluent-bit.conf: |
+    [SERVICE]
+        Flush        5
+        Log_Level    info
+        Parsers_File /fluent-bit/etc/parsers.conf
+
+    [INPUT]
+        Name         tail
+        Path         /var/log/mediawiki/*
+        Tag          mediawiki.*
+        Mem_Buf_Limit 5MB
+        Skip_Long_Lines On
+        Refresh_Interval 10
+
+    [INPUT]
+        Name         tail
+        Path         /var/log/caddy/access.log
+        Tag          caddy.access
+        Parser       json
+        Mem_Buf_Limit 5MB
+        Skip_Long_Lines On
+        Refresh_Interval 10
+
+    [INPUT]
+        Name         tail
+        Path         /var/log/mysql/error.log
+        Tag          mysql.error
+        Mem_Buf_Limit 5MB
+        Skip_Long_Lines On
+        Refresh_Interval 10
+
+    [OUTPUT]
+        Name            opensearch
+        Match           mediawiki.*
+        Host            opensearch
+        Port            9200
+        Logstash_Format On
+        Logstash_Prefix mediawiki-logs
+        Suppress_Type_Name On
+        tls             Off
+
+    [OUTPUT]
+        Name            opensearch
+        Match           caddy.*
+        Host            opensearch
+        Port            9200
+        Logstash_Format On
+        Logstash_Prefix caddy-logs
+        Suppress_Type_Name On
+        tls             Off
+
+    [OUTPUT]
+        Name            opensearch
+        Match           mysql.*
+        Host            opensearch
+        Port            9200
+        Logstash_Format On
+        Logstash_Prefix mysql-logs
+        Suppress_Type_Name On
+        tls             Off
+
+  parsers.conf: |
+    [PARSER]
+        Name         json
+        Format       json
+        Time_Key     time
+        Time_Format  %Y-%m-%dT%H:%M:%S.%L
+        Time_Keep    On
+
+    [PARSER]
+        Name         mysql_error
+        Format       regex
+        Regex        ^(?<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)\s+(?<thread_id>\d+)\s+\[(?<level>\w+)\]\s+(?:\[(?<error_code>\w+)\]\s+)?(?:\[(?<subsystem>\w+)\]\s+)?(?<message>.*)$
+        Time_Key     timestamp
+        Time_Format  %Y-%m-%dT%H:%M:%S.%LZ
+        Time_Keep    On

--- a/internal/orchestrators/kubernetes/files/kubernetes/fluent-bit.yaml
+++ b/internal/orchestrators/kubernetes/files/kubernetes/fluent-bit.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fluent-bit
+spec:
+  selector:
+    matchLabels:
+      app: fluent-bit
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: fluent-bit
+    spec:
+      containers:
+      - name: fluent-bit
+        image: fluent/fluent-bit:3.0
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+          limits:
+            memory: "128Mi"
+            cpu: "100m"
+        volumeMounts:
+        - mountPath: /var/log/mediawiki
+          name: mediawiki-logs
+          readOnly: true
+        - mountPath: /var/log/caddy
+          name: caddy-logs
+          readOnly: true
+        - mountPath: /var/log/mysql
+          name: mysql-logs
+          readOnly: true
+        - mountPath: /fluent-bit/etc/fluent-bit.conf
+          name: fluent-bit-conf
+          subPath: fluent-bit.conf
+        - mountPath: /fluent-bit/etc/parsers.conf
+          name: fluent-bit-conf
+          subPath: parsers.conf
+      volumes:
+      - name: mediawiki-logs
+        persistentVolumeClaim:
+          claimName: mediawiki-logs
+          readOnly: true
+      - name: caddy-logs
+        persistentVolumeClaim:
+          claimName: caddy-logs
+          readOnly: true
+      - name: mysql-logs
+        persistentVolumeClaim:
+          claimName: mysql-logs
+          readOnly: true
+      - name: fluent-bit-conf
+        configMap:
+          name: fluent-bit-config

--- a/internal/orchestrators/kubernetes/files/kubernetes/log-pvcs.yaml
+++ b/internal/orchestrators/kubernetes/files/kubernetes/log-pvcs.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mediawiki-logs
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "200Mi"
+  volumeMode: Filesystem
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: caddy-logs
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "200Mi"
+  volumeMode: Filesystem
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-logs
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "200Mi"
+  volumeMode: Filesystem

--- a/internal/orchestrators/kubernetes/files/kubernetes/observable-init.yaml
+++ b/internal/orchestrators/kubernetes/files/kubernetes/observable-init.yaml
@@ -1,0 +1,117 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: observable-init-script
+data:
+  observable-init.sh: |
+    #!/bin/sh
+    # One-shot init job: fixes .kibana mapping, creates OpenSearch Dashboards
+    # index patterns, and configures default settings.
+    set -eu
+
+    OPENSEARCH_URL="http://opensearch:9200"
+    DASHBOARDS_URL="http://opensearch-dashboards:5601/opensearch"
+    RETRY_INTERVAL=5
+
+    PATTERNS="mediawiki-logs-* caddy-logs-* mysql-logs-*"
+
+    # Wait indefinitely for Dashboards to report green. On a fresh install
+    # this can take several minutes while images are pulled and pods start.
+    echo "Waiting for OpenSearch Dashboards to become ready..."
+    while true; do
+      if curl -sf "${DASHBOARDS_URL}/api/status" 2>/dev/null | grep -q '"state":"green"'; then
+        echo "OpenSearch Dashboards is ready."
+        break
+      fi
+      sleep "$RETRY_INTERVAL"
+    done
+
+    # Create index patterns unconditionally; they work even before matching
+    # indices exist and will show data once logs start flowing.
+    echo "Creating index patterns..."
+    for pattern in $PATTERNS; do
+      echo "Creating index pattern: ${pattern}"
+      response="$(curl -sf -X POST \
+        -H 'Content-Type: application/json' \
+        -H 'osd-xsrf: true' \
+        -d "{\"attributes\":{\"title\":\"${pattern}\",\"timeFieldName\":\"@timestamp\"}}" \
+        "${DASHBOARDS_URL}/api/saved_objects/index-pattern/${pattern}" 2>&1 || true)"
+      if echo "$response" | grep -q '"type":"index-pattern"'; then
+        echo "  Created ${pattern}"
+      elif echo "$response" | grep -qi 'already exists\|409 Conflict'; then
+        echo "  ${pattern} already exists, skipping."
+      else
+        echo "  Unexpected response for ${pattern}: ${response}"
+      fi
+    done
+
+    # Fix .kibana mapping: with DISABLE_SECURITY_DASHBOARDS_PLUGIN=true,
+    # Dashboards creates .kibana with dynamic mapping where "type" is text
+    # instead of keyword. The _find API uses term queries that require
+    # keyword, making index patterns invisible in the UI. The mapping fix
+    # must run AFTER creating index patterns, because the "type" field
+    # only appears in the mapping once the first document with that field
+    # is saved.
+    echo "Checking .kibana index mapping..."
+    mapping="$(curl -sf "${OPENSEARCH_URL}/.kibana/_mapping" 2>/dev/null || true)"
+    if echo "$mapping" | grep -q '"type":{"type":"text"'; then
+      echo "  Detected text mapping for type field, reindexing to fix..."
+      curl -sf -X PUT "${OPENSEARCH_URL}/.kibana_fixed" \
+        -H 'Content-Type: application/json' \
+        -d '{"mappings":{"properties":{"type":{"type":"keyword"},"updated_at":{"type":"date"}}}}' > /dev/null
+      curl -sf -X POST "${OPENSEARCH_URL}/_reindex" \
+        -H 'Content-Type: application/json' \
+        -d '{"source":{"index":".kibana"},"dest":{"index":".kibana_fixed"}}' > /dev/null
+      curl -sf -X POST "${OPENSEARCH_URL}/_aliases" \
+        -H 'Content-Type: application/json' \
+        -d '{"actions":[{"remove_index":{"index":".kibana"}},{"add":{"index":".kibana_fixed","alias":".kibana"}}]}' > /dev/null
+      echo "  Done — .kibana reindexed with correct mapping."
+    else
+      echo "  Mapping is OK, skipping reindex."
+    fi
+
+    echo "Setting default index pattern to mediawiki-logs-*..."
+    curl -sf -X POST \
+      -H 'Content-Type: application/json' \
+      -H 'osd-xsrf: true' \
+      -d '{"value":"mediawiki-logs-*"}' \
+      "${DASHBOARDS_URL}/api/opensearch-dashboards/settings/defaultIndex" > /dev/null 2>&1 || true
+
+    echo "Configuring Dashboards settings..."
+    echo "  Setting Discover as homepage..."
+    curl -sf -X POST \
+      -H 'Content-Type: application/json' \
+      -H 'osd-xsrf: true' \
+      -d '{"value":"/app/discover"}' \
+      "${DASHBOARDS_URL}/api/opensearch-dashboards/settings/defaultRoute" > /dev/null 2>&1 || true
+
+---
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: observable-init
+spec:
+  backoffLimit: 6
+  activeDeadlineSeconds: 900
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: observable-init
+        image: curlimages/curl:8.11.1
+        command: ["/bin/sh", "/scripts/observable-init.sh"]
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "50m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+        volumeMounts:
+        - name: init-script
+          mountPath: /scripts
+      volumes:
+      - name: init-script
+        configMap:
+          name: observable-init-script

--- a/internal/orchestrators/kubernetes/files/kubernetes/opensearch-dashboards.yaml
+++ b/internal/orchestrators/kubernetes/files/kubernetes/opensearch-dashboards.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: opensearch-dashboards
+spec:
+  selector:
+    app: opensearch-dashboards
+  ports:
+    - protocol: TCP
+      port: 5601
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opensearch-dashboards
+spec:
+  selector:
+    matchLabels:
+      app: opensearch-dashboards
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: opensearch-dashboards
+    spec:
+      containers:
+      - name: opensearch-dashboards
+        image: opensearchproject/opensearch-dashboards:2.11.1
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "300m"
+        env:
+          - name: OPENSEARCH_HOSTS
+            value: "http://opensearch:9200"
+          - name: SERVER_BASEPATH
+            value: "/opensearch"
+          - name: SERVER_REWRITEBASEPATH
+            value: "true"
+          - name: DISABLE_SECURITY_DASHBOARDS_PLUGIN
+            value: "true"
+        ports:
+        - containerPort: 5601
+        readinessProbe:
+          httpGet:
+            path: /opensearch/api/status
+            port: 5601
+          periodSeconds: 15
+          timeoutSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /opensearch/api/status
+            port: 5601
+          initialDelaySeconds: 60
+          periodSeconds: 30
+          timeoutSeconds: 10

--- a/internal/orchestrators/kubernetes/files/kubernetes/opensearch.yaml
+++ b/internal/orchestrators/kubernetes/files/kubernetes/opensearch.yaml
@@ -1,0 +1,89 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: opensearch
+spec:
+  selector:
+    app: opensearch
+  ports:
+    - protocol: TCP
+      port: 9200
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: opensearch-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "1Gi"
+  volumeMode: Filesystem
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opensearch
+spec:
+  selector:
+    matchLabels:
+      app: opensearch
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: opensearch
+    spec:
+      containers:
+      - name: opensearch
+        image: opensearchproject/opensearch:2.11.1
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "200m"
+          limits:
+            memory: "1536Mi"
+            cpu: "500m"
+        env:
+          - name: discovery.type
+            value: "single-node"
+          - name: bootstrap.memory_lock
+            value: "true"
+          - name: plugins.security.disabled
+            value: "true"
+          - name: OPENSEARCH_JAVA_OPTS
+            value: "-Xms512m -Xmx512m"
+        ports:
+        - containerPort: 9200
+        startupProbe:
+          httpGet:
+            path: /_cluster/health
+            port: 9200
+          failureThreshold: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /_cluster/health
+            port: 9200
+          periodSeconds: 15
+          timeoutSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /_cluster/health
+            port: 9200
+          initialDelaySeconds: 60
+          periodSeconds: 30
+          timeoutSeconds: 10
+        volumeMounts:
+        - name: opensearch-data
+          mountPath: /usr/share/opensearch/data
+      volumes:
+      - name: opensearch-data
+        persistentVolumeClaim:
+          claimName: opensearch-data


### PR DESCRIPTION
## Summary

Closes #333

- **Rename env var**: Replace Compose-specific `COMPOSE_PROFILES=observable` with orchestrator-agnostic `CANASTA_ENABLE_OBSERVABILITY=true`. Add `syncComposeProfiles()` to auto-set `COMPOSE_PROFILES` for Compose, and migration for existing installations.
- **K8s observability stack**: Add OpenSearch, OpenSearch Dashboards, and Fluent Bit to the Kubernetes orchestrator, gated behind the new env var. Architecture mirrors Compose — a single Fluent Bit Deployment reads from three shared PVC log volumes and ships to OpenSearch with date-based indices.
- **Logstash path fix**: Widen mediawiki log path from `*.log` to `*` so Logstash picks up all MW log files (e.g. `mwjobrunner_log_20260223`).

### K8s resources added when observability is enabled

| Resource | Purpose |
|---|---|
| `opensearch.yaml` | OpenSearch Deployment + PVC (single-node, security disabled) |
| `opensearch-dashboards.yaml` | Dashboards Deployment (basepath `/opensearch`) |
| `fluent-bit.yaml` | Standalone Fluent Bit Deployment reading all 3 log PVCs |
| `fluent-bit-config.yaml` | Combined config + parsers ConfigMap |
| `log-pvcs.yaml` | PVCs for mediawiki-logs, caddy-logs, mysql-logs |
| `observable-init.yaml` | One-shot Job: creates index patterns, fixes `.kibana` mapping, configures Dashboards defaults |

Source pods (web, caddy, db) get a simple kustomize patch adding the log PVC mount.

## Test plan

- [x] `go test ./...` passes
- [x] Compose: `canasta create` with `CANASTA_ENABLE_OBSERVABILITY=true` — Dashboards accessible at `/opensearch`, caddy and mediawiki logs visible in Discover
- [x] K8s: `canasta create -o kubernetes` with `CANASTA_ENABLE_OBSERVABILITY=true` — same result
- [x] Migration: existing `.env` with `COMPOSE_PROFILES=observable` gets `CANASTA_ENABLE_OBSERVABILITY=true` added on upgrade
- [ ] MySQL logging (no data yet — MySQL not writing to `/var/log/mysql/error.log`)