### PR TITLE
Implement backup and restore for Kubernetes installations

### DIFF
--- a/internal/orchestrators/backup.go
+++ b/internal/orchestrators/backup.go
@@ -1,0 +1,110 @@
+package orchestrators
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/execute"
+)
+
+// backupVolumeName returns the persistent Docker volume name for an installation.
+func backupVolumeName(installPath string) string {
+	return "canasta-backup-" + filepath.Base(installPath)
+}
+
+// isLocalRepo returns true if the repository URL is a local filesystem path
+// rather than a remote backend (s3:, sftp:, rest:, gs:, azure:, b2:, rclone:).
+func isLocalRepo(repoURL string) bool {
+	return strings.HasPrefix(repoURL, "/")
+}
+
+// repoFromArgs extracts the repository URL following the -r flag in args.
+func repoFromArgs(args []string) string {
+	for i, arg := range args {
+		if arg == "-r" && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+// stageToVolume copies host directories into the backup volume via an alpine container.
+func stageToVolume(volName string, volumes map[string]string) error {
+	cmdArgs := []string{"docker", "run", "--rm",
+		"-v", volName + ":/currentsnapshot",
+	}
+
+	var copyParts []string
+	i := 0
+	for hostPath, containerPath := range volumes {
+		mountPoint := fmt.Sprintf("/src%d", i)
+		cmdArgs = append(cmdArgs, "-v", hostPath+":"+mountPoint+":ro")
+		copyParts = append(copyParts, fmt.Sprintf("cp -a %s %s", mountPoint, containerPath))
+		i++
+	}
+
+	shellCmd := "rm -rf /currentsnapshot/* && " + strings.Join(copyParts, " && ")
+	cmdArgs = append(cmdArgs, "alpine", "sh", "-c", "'"+shellCmd+"'")
+
+	err, output := execute.Run("", cmdArgs[0], cmdArgs[1:]...)
+	if err != nil {
+		return fmt.Errorf("failed to stage files to backup volume: %s", output)
+	}
+	return nil
+}
+
+// runResticDocker runs a restic command inside a Docker container with the
+// backup volume mounted at /currentsnapshot. The envPath file provides
+// environment variables (RESTIC_REPOSITORY, RESTIC_PASSWORD, etc.).
+func runResticDocker(installPath, envPath, volName string, args ...string) (string, error) {
+	cmdArgs := []string{"docker", "run", "--rm", "-i", "--env-file", envPath,
+		"-v", volName + ":/currentsnapshot",
+	}
+
+	cmdArgs = append(cmdArgs, "restic/restic")
+	cmdArgs = append(cmdArgs, args...)
+
+	err, output := execute.Run(installPath, cmdArgs[0], cmdArgs[1:]...)
+	if err != nil {
+		if strings.Contains(output, "repository does not exist") {
+			return output, fmt.Errorf("backup repository not found. Run 'canasta backup init' to create it")
+		}
+		return output, fmt.Errorf("restic command failed: %s", output)
+	}
+	return output, nil
+}
+
+// restoreFromVolume copies data from the backup Docker volume to host
+// directories. Each entry in dirs maps a volume path (e.g.
+// "/currentsnapshot/config") to a host path.
+func restoreFromVolume(volName, installPath string, dirs map[string]string) error {
+	cmdArgs := []string{"docker", "run", "--rm",
+		"-v", volName + ":/currentsnapshot:ro",
+		"-v", installPath + ":/install",
+	}
+
+	var copyParts []string
+	for volumePath, hostPath := range dirs {
+		relPath, err := filepath.Rel(installPath, hostPath)
+		if err != nil {
+			return fmt.Errorf("failed to compute relative path for %s: %w", hostPath, err)
+		}
+		dst := "/install/" + relPath
+		// Handle both directories and individual files.
+		// For directories, clear contents without removing the directory itself
+		// to preserve active Docker bind mounts.
+		copyParts = append(copyParts,
+			fmt.Sprintf("if [ -d %s ]; then mkdir -p %s && rm -rf %s/* %s/.[!.]* 2>/dev/null; cp -a %s/. %s/; elif [ -f %s ]; then cp -a %s %s; fi",
+				volumePath, dst, dst, dst, volumePath, dst, volumePath, volumePath, dst))
+	}
+
+	shellCmd := strings.Join(copyParts, " && ")
+	cmdArgs = append(cmdArgs, "alpine", "sh", "-c", "'"+shellCmd+"'")
+
+	err, output := execute.Run("", cmdArgs[0], cmdArgs[1:]...)
+	if err != nil {
+		return fmt.Errorf("failed to restore files from backup volume: %s", output)
+	}
+	return nil
+}

--- a/internal/orchestrators/backup_test.go
+++ b/internal/orchestrators/backup_test.go
@@ -1,0 +1,20 @@
+package orchestrators
+
+import "testing"
+
+func TestBackupVolumeName(t *testing.T) {
+	tests := []struct {
+		installPath string
+		want        string
+	}{
+		{"/opt/canasta/my-wiki", "canasta-backup-my-wiki"},
+		{"/home/user/test", "canasta-backup-test"},
+		{"/single", "canasta-backup-single"},
+	}
+	for _, tt := range tests {
+		got := backupVolumeName(tt.installPath)
+		if got != tt.want {
+			t.Errorf("backupVolumeName(%q) = %q, want %q", tt.installPath, got, tt.want)
+		}
+	}
+}

--- a/internal/orchestrators/compose.go
+++ b/internal/orchestrators/compose.go
@@ -440,27 +440,6 @@ func (c *ComposeOrchestrator) CopyTo(installPath, service, hostPath, containerPa
 	return nil
 }
 
-// backupVolumeName returns the persistent Docker volume name for an installation.
-func backupVolumeName(installPath string) string {
-	return "canasta-backup-" + filepath.Base(installPath)
-}
-
-// isLocalRepo returns true if the repository URL is a local filesystem path
-// rather than a remote backend (s3:, sftp:, rest:, gs:, azure:, b2:, rclone:).
-func isLocalRepo(repoURL string) bool {
-	return strings.HasPrefix(repoURL, "/")
-}
-
-// repoFromArgs extracts the repository URL following the -r flag in args.
-func repoFromArgs(args []string) string {
-	for i, arg := range args {
-		if arg == "-r" && i+1 < len(args) {
-			return args[i+1]
-		}
-	}
-	return ""
-}
-
 func (c *ComposeOrchestrator) RunBackup(installPath, envPath string, volumes map[string]string, args ...string) (string, error) {
 	volName := backupVolumeName(installPath)
 
@@ -477,20 +456,26 @@ func (c *ComposeOrchestrator) RunBackup(installPath, envPath string, volumes map
 		}
 	}
 
-	// Run restic with the persistent volume mounted
-	cmdArgs := []string{"docker", "run", "--rm", "-i", "--env-file", envPath,
-		"-v", volName + ":/currentsnapshot",
+	// For local repos, add a bind-mount so restic can access the host path
+	if repo := repoFromArgs(args); repo != "" && isLocalRepo(repo) {
+		return runResticDockerWithBindMount(installPath, envPath, volName, repo, args...)
 	}
 
-	// If the repository is a local path, bind-mount it into the container
-	if repo := repoFromArgs(args); repo != "" && isLocalRepo(repo) {
-		cmdArgs = append(cmdArgs, "-v", repo+":"+repo)
+	return runResticDocker(installPath, envPath, volName, args...)
+}
+
+// runResticDockerWithBindMount runs restic with an extra bind-mount for a
+// local repository path. This is Compose-specific since K8s rejects local repos.
+func runResticDockerWithBindMount(installPath, envPath, volName, repoPath string, args ...string) (string, error) {
+	cmdArgs := []string{"docker", "run", "--rm", "-i", "--env-file", envPath,
+		"-v", volName + ":/currentsnapshot",
+		"-v", repoPath + ":" + repoPath,
 	}
 
 	cmdArgs = append(cmdArgs, "restic/restic")
 	cmdArgs = append(cmdArgs, args...)
 
-	err, output = execute.Run(installPath, cmdArgs[0], cmdArgs[1:]...)
+	err, output := execute.Run(installPath, cmdArgs[0], cmdArgs[1:]...)
 	if err != nil {
 		if strings.Contains(output, "repository does not exist") {
 			return output, fmt.Errorf("backup repository not found. Run 'canasta backup init' to create it")
@@ -500,62 +485,8 @@ func (c *ComposeOrchestrator) RunBackup(installPath, envPath string, volumes map
 	return output, nil
 }
 
-// stageToVolume copies host directories into the backup volume via an alpine container.
-func stageToVolume(volName string, volumes map[string]string) error {
-	cmdArgs := []string{"docker", "run", "--rm",
-		"-v", volName + ":/currentsnapshot",
-	}
-
-	var copyParts []string
-	i := 0
-	for hostPath, containerPath := range volumes {
-		mountPoint := fmt.Sprintf("/src%d", i)
-		cmdArgs = append(cmdArgs, "-v", hostPath+":"+mountPoint+":ro")
-		copyParts = append(copyParts, fmt.Sprintf("cp -a %s %s", mountPoint, containerPath))
-		i++
-	}
-
-	shellCmd := "rm -rf /currentsnapshot/* && " + strings.Join(copyParts, " && ")
-	cmdArgs = append(cmdArgs, "alpine", "sh", "-c", "'"+shellCmd+"'")
-
-	err, output := execute.Run("", cmdArgs[0], cmdArgs[1:]...)
-	if err != nil {
-		return fmt.Errorf("failed to stage files to backup volume: %s", output)
-	}
-	return nil
-}
-
 func (c *ComposeOrchestrator) RestoreFromBackupVolume(installPath string, dirs map[string]string) error {
-	volName := backupVolumeName(installPath)
-
-	cmdArgs := []string{"docker", "run", "--rm",
-		"-v", volName + ":/currentsnapshot:ro",
-		"-v", installPath + ":/install",
-	}
-
-	var copyParts []string
-	for volumePath, hostPath := range dirs {
-		relPath, err := filepath.Rel(installPath, hostPath)
-		if err != nil {
-			return fmt.Errorf("failed to compute relative path for %s: %w", hostPath, err)
-		}
-		dst := "/install/" + relPath
-		// Handle both directories and individual files.
-		// For directories, clear contents without removing the directory itself
-		// to preserve active Docker bind mounts.
-		copyParts = append(copyParts,
-			fmt.Sprintf("if [ -d %s ]; then mkdir -p %s && rm -rf %s/* %s/.[!.]* 2>/dev/null; cp -a %s/. %s/; elif [ -f %s ]; then cp -a %s %s; fi",
-				volumePath, dst, dst, dst, volumePath, dst, volumePath, volumePath, dst))
-	}
-
-	shellCmd := strings.Join(copyParts, " && ")
-	cmdArgs = append(cmdArgs, "alpine", "sh", "-c", "'"+shellCmd+"'")
-
-	err, output := execute.Run("", cmdArgs[0], cmdArgs[1:]...)
-	if err != nil {
-		return fmt.Errorf("failed to restore files from backup volume: %s", output)
-	}
-	return nil
+	return restoreFromVolume(backupVolumeName(installPath), installPath, dirs)
 }
 
 func (c *ComposeOrchestrator) CopyOverrideFile(installPath, sourceFilename, workingDir string) error {

--- a/internal/orchestrators/kubernetes.go
+++ b/internal/orchestrators/kubernetes.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/execute"
 	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
 	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators/kubernetes"
@@ -351,11 +352,105 @@ func (k *KubernetesOrchestrator) CopyTo(installPath, service, hostPath, containe
 }
 
 func (k *KubernetesOrchestrator) RunBackup(installPath, envPath string, volumes map[string]string, args ...string) (string, error) {
-	return "", fmt.Errorf("backup is not yet supported for Kubernetes installations")
+	if err := ensureKindContext(installPath); err != nil {
+		return "", err
+	}
+
+	// Reject local repositories — K8s backups require a remote backend
+	if repo := repoFromArgs(args); repo != "" && isLocalRepo(repo) {
+		return "", fmt.Errorf("local backup repositories are not supported for Kubernetes; use a remote repository (s3:, sftp:, rest:, etc.)")
+	}
+
+	volName := backupVolumeName(installPath)
+
+	// Docker is available (required by kind), so create the staging volume
+	err, output := execute.Run("", "docker", "volume", "create", volName)
+	if err != nil {
+		return "", fmt.Errorf("failed to create backup volume: %s", output)
+	}
+
+	if len(volumes) > 0 {
+		// Sync cluster-side data (extensions, skins, images, database dumps)
+		// to the CLI host before staging into the Docker volume
+		if err := k.syncClusterDataToHost(installPath); err != nil {
+			return "", fmt.Errorf("failed to sync cluster data to host: %w", err)
+		}
+		if err := stageToVolume(volName, volumes); err != nil {
+			return "", err
+		}
+	}
+
+	return runResticDocker(installPath, envPath, volName, args...)
 }
 
 func (k *KubernetesOrchestrator) RestoreFromBackupVolume(installPath string, dirs map[string]string) error {
-	return fmt.Errorf("backup is not yet supported for Kubernetes installations")
+	if err := ensureKindContext(installPath); err != nil {
+		return err
+	}
+
+	volName := backupVolumeName(installPath)
+
+	// Copy from Docker volume to CLI host (same logic as Compose)
+	if err := restoreFromVolume(volName, installPath, dirs); err != nil {
+		return err
+	}
+
+	// Sync cluster-side data (extensions, skins, images) from CLI host to cluster
+	return k.syncHostDataToCluster(installPath)
+}
+
+// syncClusterDataToHost copies cluster-side data from the web pod to the CLI
+// host so it can be staged into the Docker backup volume. This includes:
+// - Database dumps from /mediawiki/config/backup/
+// - User extensions from /var/www/mediawiki/w/user-extensions/
+// - User skins from /var/www/mediawiki/w/user-skins/
+// - Images from /mediawiki/images/
+func (k *KubernetesOrchestrator) syncClusterDataToHost(installPath string) error {
+	syncs := []struct {
+		containerPath string
+		hostPath      string
+	}{
+		{"/mediawiki/config/backup/", filepath.Join(installPath, "config", "backup")},
+		{"/var/www/mediawiki/w/user-extensions/", filepath.Join(installPath, "extensions")},
+		{"/var/www/mediawiki/w/user-skins/", filepath.Join(installPath, "skins")},
+		{"/mediawiki/images/", filepath.Join(installPath, "images")},
+	}
+
+	for _, s := range syncs {
+		// Ensure the host directory exists
+		if err := os.MkdirAll(s.hostPath, 0755); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", s.hostPath, err)
+		}
+		if err := k.CopyFrom(installPath, "web", s.containerPath, s.hostPath); err != nil {
+			return fmt.Errorf("failed to copy %s from cluster: %w", s.containerPath, err)
+		}
+	}
+	return nil
+}
+
+// syncHostDataToCluster copies restored data from the CLI host back to the
+// web pod in the cluster. Config files (.env, wikis.yaml, Caddyfile, settings/)
+// stay on the CLI host and are applied via ConfigMaps on the next kustomize apply.
+func (k *KubernetesOrchestrator) syncHostDataToCluster(installPath string) error {
+	syncs := []struct {
+		hostPath      string
+		containerPath string
+	}{
+		{filepath.Join(installPath, "extensions") + "/", "/var/www/mediawiki/w/user-extensions/"},
+		{filepath.Join(installPath, "skins") + "/", "/var/www/mediawiki/w/user-skins/"},
+		{filepath.Join(installPath, "images") + "/", "/mediawiki/images/"},
+	}
+
+	for _, s := range syncs {
+		// Skip if the host directory doesn't exist (e.g. no extensions restored)
+		if _, err := os.Stat(s.hostPath); os.IsNotExist(err) {
+			continue
+		}
+		if err := k.CopyTo(installPath, "web", s.hostPath, s.containerPath); err != nil {
+			return fmt.Errorf("failed to copy %s to cluster: %w", s.hostPath, err)
+		}
+	}
+	return nil
 }
 
 func (k *KubernetesOrchestrator) InitConfig(installPath string) error {

--- a/internal/orchestrators/kubernetes_test.go
+++ b/internal/orchestrators/kubernetes_test.go
@@ -565,25 +565,14 @@ func TestGenerateKustomizationNoNodePort(t *testing.T) {
 	}
 }
 
-func TestRunBackupNotSupported(t *testing.T) {
+func TestRunBackupRejectsLocalRepo(t *testing.T) {
 	k := &KubernetesOrchestrator{}
-	_, err := k.RunBackup("/tmp", "/tmp/.env", nil)
+	_, err := k.RunBackup("/tmp/test-install", "/tmp/.env", nil, "-r", "/local/repo", "backup", "/currentsnapshot")
 	if err == nil {
-		t.Fatal("expected error from RunBackup without kustomization.yaml")
+		t.Fatal("expected error from RunBackup with local repo")
 	}
-	if !strings.Contains(err.Error(), "not yet supported") {
-		t.Errorf("RunBackup() error = %q, want 'not yet supported'", err.Error())
-	}
-}
-
-func TestRestoreFromBackupVolumeNotSupported(t *testing.T) {
-	k := &KubernetesOrchestrator{}
-	err := k.RestoreFromBackupVolume("/tmp", nil)
-	if err == nil {
-		t.Fatal("expected error from RestoreFromBackupVolume")
-	}
-	if !strings.Contains(err.Error(), "not yet supported") {
-		t.Errorf("RestoreFromBackupVolume() error = %q, want 'not yet supported'", err.Error())
+	if !strings.Contains(err.Error(), "local backup repositories are not supported") {
+		t.Errorf("RunBackup() error = %q, want 'local backup repositories are not supported'", err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extract shared backup helpers (volume staging, restic execution, restore) from `compose.go` into `backup.go` so both orchestrators can reuse them
- Implement `RunBackup` for Kubernetes: syncs cluster data (extensions, skins, images, DB dumps) to the CLI host via `kubectl cp`, stages into a Docker volume, and runs restic
- Implement `RestoreFromBackupVolume` for Kubernetes: restores from Docker volume to CLI host, then syncs extensions/skins/images back to the cluster
- Reject local backup repositories for K8s with a clear error (remote backends only)

Closes #324

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` passes (including new `TestBackupVolumeName` and `TestRunBackupRejectsLocalRepo`)
- [x] Compose backup/restore regression: `canasta backup create` / `canasta backup restore` still work on Compose installations
- [x] K8s backup create: create a kind installation, run `canasta backup init` and `canasta backup create` with a remote repo
- [x] K8s backup restore: run `canasta backup restore` and verify config restored on host, extensions/skins/images restored in cluster, databases restored
- [x] K8s local repo rejection: verify `canasta backup init` with `RESTIC_REPOSITORY=/local/path` returns clear error
- [x] K8s backup list/check/delete/files/diff work against the remote repo