### PR TITLE
Rename --dev-tag to --canasta-image and document custom ES images

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -36,7 +36,7 @@ func NewCmdCreate() *cobra.Command {
 		override      string
 		envFile       string
 		devModeFlag   bool   // enable dev mode
-		devTag        string // registry image tag for dev mode
+		canastaImage  string // custom Canasta image reference
 		buildFromPath string // path to build Canasta from source
 		databasePath       string // path to existing database dump
 		wikiSettingsPath   string // path to existing per-wiki Settings.php
@@ -86,9 +86,9 @@ or enable development mode with Xdebug (Compose only).`,
 				return fmt.Errorf("Canasta installation with ID '%s' already exists", canastaInfo.Id)
 			}
 
-			// Validate --dev-tag and --build-from are mutually exclusive
-			if devTag != "latest" && buildFromPath != "" {
-				return fmt.Errorf("--dev-tag and --build-from are mutually exclusive")
+			// Validate --canasta-image and --build-from are mutually exclusive
+			if canastaImage != "" && buildFromPath != "" {
+				return fmt.Errorf("--canasta-image and --build-from are mutually exclusive")
 			}
 
 			// Validate database path if provided
@@ -157,7 +157,7 @@ or enable development mode with Xdebug (Compose only).`,
 			if err = orch.CheckDependencies(); err != nil {
 				return err
 			}
-			if err = createCanasta(canastaInfo, workingDir, path, wikiID, siteName, domain, yamlPath, orch, orchestrator, override, envFile, composerFile, devModeFlag, devTag, buildFromPath, registry, createCluster, databasePath, wikiSettingsPath, globalSettingsPath); err != nil {
+			if err = createCanasta(canastaInfo, workingDir, path, wikiID, siteName, domain, yamlPath, orch, orchestrator, override, envFile, composerFile, devModeFlag, canastaImage, buildFromPath, registry, createCluster, databasePath, wikiSettingsPath, globalSettingsPath); err != nil {
 				stopSpinner()
 				fmt.Print(err.Error(), "\n")
 				if !keepConfig {
@@ -197,8 +197,8 @@ or enable development mode with Xdebug (Compose only).`,
 	createCmd.Flags().StringVar(&canastaInfo.WikiDBPassword, "wikidbpass", "", "Wiki database password (if not provided, auto-generates and saves to .env). Tip: Use --wikidbpass \"$WIKI_DB_PASS\" to avoid exposing password in shell history")
 	createCmd.Flags().StringVarP(&envFile, "envfile", "e", "", "Path to .env file with password overrides (merged with default .env)")
 	createCmd.Flags().BoolVarP(&devModeFlag, "dev", "D", false, "Enable development mode with Xdebug and code extraction (Compose only)")
-	createCmd.Flags().StringVar(&devTag, "dev-tag", "latest", "Canasta image tag to use (e.g., latest, dev-branch) (Compose only)")
-	createCmd.Flags().StringVar(&buildFromPath, "build-from", "", "Build a local Canasta and/or CanastaBase image from the specified local source directory")
+	createCmd.Flags().StringVar(&canastaImage, "canasta-image", "", "Canasta image to use (e.g., ghcr.io/canastawiki/canasta:dev-branch)")
+	createCmd.Flags().StringVar(&buildFromPath, "build-from", "", "Build from local source (directory must contain Canasta/, and optionally CanastaBase/)")
 	createCmd.Flags().StringVarP(&databasePath, "database", "d", "", "Path to existing database dump (.sql or .sql.gz) to import instead of running install.php")
 	createCmd.Flags().StringVarP(&wikiSettingsPath, "wiki-settings", "l", "", "Path to per-wiki settings file to copy to config/settings/wikis/<wiki_id>/ (filename preserved)")
 	createCmd.Flags().StringVarP(&globalSettingsPath, "global-settings", "g", "", "Path to global settings file to copy to config/settings/global/ (filename preserved)")
@@ -213,30 +213,25 @@ or enable development mode with Xdebug (Compose only).`,
 }
 
 // createCanasta accepts all the keyword arguments and creates an installation of the latest Canasta.
-func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiID, siteName, domain, yamlPath string, orch orchestrators.Orchestrator, orchestrator, override, envFile, composerFile string, devModeEnabled bool, devTag, buildFromPath, registry string, createCluster bool, databasePath, wikiSettingsPath, globalSettingsPath string) error {
+func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiID, siteName, domain, yamlPath string, orch orchestrators.Orchestrator, orchestrator, override, envFile, composerFile string, devModeEnabled bool, canastaImage, buildFromPath, registry string, createCluster bool, databasePath, wikiSettingsPath, globalSettingsPath string) error {
 	// Determine the base image to use
 	var baseImage string
 	var localImageBuilt bool
 	if buildFromPath != "" {
-		// Check if local Canasta repo exists for building
-		canastaPath := filepath.Join(buildFromPath, "Canasta")
-		if _, err := os.Stat(canastaPath); err == nil {
-			// Build Canasta (and optionally CanastaBase) from source
-			logging.Print("Building Canasta from local source...\n")
-			builtImage, err := imagebuild.BuildFromSource(buildFromPath)
-			if err != nil {
-				return fmt.Errorf("failed to build from source: %w", err)
-			}
-			baseImage = builtImage
-			localImageBuilt = true
-		} else {
-			// No local Canasta repo, use registry image
-			logging.Print("No local Canasta repo found, using registry image\n")
-			baseImage = canasta.GetImageWithTag(devTag)
+		// Build Canasta (and optionally CanastaBase) from source
+		logging.Print("Building from local source...\n")
+		builtImage, err := imagebuild.BuildFromSource(buildFromPath)
+		if err != nil {
+			return fmt.Errorf("failed to build from source: %w", err)
 		}
+		baseImage = builtImage
+		localImageBuilt = true
+	} else if canastaImage != "" {
+		// Use the user-specified image
+		baseImage = canastaImage
 	} else {
-		// Use registry image with specified tag
-		baseImage = canasta.GetImageWithTag(devTag)
+		// Use the default Canasta image
+		baseImage = canasta.GetDefaultImage()
 	}
 
 	// Create the installation directory and write orchestrator stack files
@@ -269,8 +264,8 @@ func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiI
 	if err := canasta.UpdateEnvFile(envFile, path, workingDir, canastaInfo.RootDBPassword, canastaInfo.WikiDBPassword); err != nil {
 		return err
 	}
-	// Set CANASTA_IMAGE in .env for local builds so docker-compose uses the locally built image
-	if buildFromPath != "" {
+	// Set CANASTA_IMAGE in .env when using a non-default image (local build or --canasta-image)
+	if buildFromPath != "" || canastaImage != "" {
 		if err := canasta.SaveEnvVariable(path+"/.env", "CANASTA_IMAGE", baseImage); err != nil {
 			return err
 		}

--- a/docs/guide/devmode.md
+++ b/docs/guide/devmode.md
@@ -39,25 +39,18 @@ Development mode enables live code editing and step debugging with Xdebug for Ca
 # Use the default (latest) Canasta image
 canasta create -i mydev -w mywiki -n localhost -a admin --dev
 
-# Or specify a specific Canasta image tag
-canasta create -i mydev -w mywiki -n localhost -a admin --dev --dev-tag dev-branch
+# Or specify a specific Canasta image
+canasta create -i mydev -w mywiki -n localhost -a admin --dev --canasta-image ghcr.io/canastawiki/canasta:dev-branch
 ```
 
-The `--dev` flag enables development mode with Xdebug. Use `--dev-tag` to specify which Canasta image tag to use:
-- Without `--dev-tag` — Uses the `latest` image (default)
-- `--dev-tag dev-branch` — Uses the specified image tag
+The `--dev` flag enables development mode with Xdebug. You can combine it with `--canasta-image` to use a specific image (see [Custom Canasta images](general-concepts.md#custom-canasta-images)).
 
 This will:
 1. Clone the Canasta stack
 2. Extract MediaWiki code to `mediawiki-code/` for live editing
-3. Build an Xdebug-enabled Docker image using the specified tag
+3. Build an Xdebug-enabled Docker image from the base Canasta image
 4. Create IDE configuration files
 5. Start the installation
-
-### Available image tags
-
-- `latest` - Latest stable release (default)
-- Any tag from [ghcr.io/canastawiki/canasta](https://github.com/CanastaWiki/Canasta/pkgs/container/canasta)
 
 ---
 
@@ -70,16 +63,14 @@ canasta create -i mydev -w mywiki -n localhost -a admin --build-from ~/canasta-r
 ```
 
 The `--build-from` flag expects a directory containing:
-- `Canasta/` — Required. The Canasta repository with a Dockerfile. Fails if not found.
-- `CanastaBase/` — Optional. If present, CanastaBase is built first and used as the base image for Canasta. If not found, uses the published CanastaBase image.
-- `Canasta-DockerCompose/` — Optional. If present, the docker-compose stack files are copied from here instead of cloning from GitHub.
+- `Canasta/` — Required. The Canasta repository with a Dockerfile.
+- `CanastaBase/` — Optional. If present, CanastaBase is built first and used as the base image for Canasta. If absent, the published CanastaBase image is used.
 
 This will:
 1. Build CanastaBase locally (if the directory exists) → `canasta-base:local`
 2. Build Canasta using the local or published base image → `canasta:local`
-3. Copy docker-compose files from local Canasta-DockerCompose (if exists) or clone from GitHub
-4. Extract MediaWiki code from the locally built image
-5. Continue with normal installation
+3. Extract MediaWiki code from the locally built image
+4. Continue with normal installation
 
 ### Combining with dev mode
 
@@ -89,7 +80,7 @@ You can combine `--build-from` with `--dev` to build from source and enable Xdeb
 canasta create -i mydev -w mywiki -n localhost -a admin --dev --build-from ~/canasta-repos
 ```
 
-**Note:** `--dev-tag` and `--build-from` are mutually exclusive since `--build-from` builds its own image.
+**Note:** `--canasta-image` and `--build-from` are mutually exclusive since `--build-from` builds its own image.
 
 ### Switching back to upstream images
 
@@ -126,7 +117,7 @@ This will:
 
 **Note:** If `mediawiki-code/` already exists, it will NOT be overwritten. You'll see a warning message. To regenerate the code, delete the directory first and then restart with `--dev`.
 
-**Note:** When enabling dev mode on an existing installation, the default `latest` image tag is used. To use a specific image tag, recreate the installation with `canasta create --dev --dev-tag <tag>`.
+**Note:** When enabling dev mode on an existing installation, the default `latest` image tag is used. To use a specific image, recreate the installation with `canasta create --dev --canasta-image <image>`.
 
 ---
 

--- a/docs/guide/extensions-and-skins.md
+++ b/docs/guide/extensions-and-skins.md
@@ -302,6 +302,39 @@ canasta maintenance extension -i myinstance --all CirrusSearch ForceSearchIndex.
 
 See [Running extension maintenance scripts](general-concepts.md#running-extension-maintenance-scripts) for general usage of the extension maintenance command.
 
+### Custom Elasticsearch plugins
+
+If you need additional Elasticsearch plugins (for example, `analysis-icu` for ICU-based text analysis), you can build a custom Elasticsearch image using `docker-compose.override.yml` (see [Orchestrators](orchestrators.md#docker-composeoverrideyml) for general override file usage).
+
+**1. Create a Dockerfile for your custom Elasticsearch image:**
+
+Create a file called `Dockerfile.elasticsearch` in a build directory (e.g., `build/`):
+
+```dockerfile
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+RUN elasticsearch-plugin install analysis-icu
+```
+
+**2. Create or edit `docker-compose.override.yml`** in your installation directory:
+
+```yaml
+services:
+  elasticsearch:
+    build:
+      context: ./build
+      dockerfile: Dockerfile.elasticsearch
+    image: canasta-elasticsearch-icu:7.10.2
+```
+
+**3. Rebuild and restart:**
+
+```bash
+docker compose build elasticsearch
+canasta restart -i myinstance
+```
+
+The override file is automatically picked up by Docker Compose alongside the main `docker-compose.yml`. It is also included in backups.
+
 ---
 
 ## How it works under the hood

--- a/docs/guide/general-concepts.md
+++ b/docs/guide/general-concepts.md
@@ -402,7 +402,6 @@ By default, `canasta create` uses the latest published Canasta image (`ghcr.io/c
 | Use a specific published version or branch | `--canasta-image` | `--canasta-image ghcr.io/canastawiki/canasta:version-3.0.7` |
 | Use an image from a private registry | `--canasta-image` | `--canasta-image myregistry.io/canasta:v1.2.3` |
 | Test local changes to Canasta or CanastaBase | `--build-from` | `--build-from ~/canasta-repos` |
-| Enable Xdebug and live code editing | `--dev` | `--dev` (can combine with either of the above) |
 
 ### --canasta-image
 
@@ -421,15 +420,11 @@ Builds Canasta (and optionally CanastaBase) from local source repositories. The 
 
 `--canasta-image` and `--build-from` are mutually exclusive since `--build-from` builds its own image.
 
-### --dev
-
-Enables development mode with Xdebug and live code editing. This is orthogonal to image selection — you can combine `--dev` with `--canasta-image` or `--build-from`. See [Development mode](devmode.md) for details.
-
 ### Orchestrator differences
 
 **Docker Compose:** Both `--canasta-image` and `--build-from` work directly. Docker pulls or builds the image locally, and the Compose stack uses it.
 
-**Kubernetes:** `--canasta-image` works as long as the image is pullable from the cluster (i.e., it's in a public registry or one the cluster has credentials for). `--build-from` requires extra image distribution: with `--create-cluster` (kind), the image is automatically loaded into the kind cluster; without it, the image is pushed to a registry specified by `--registry` so the cluster can pull it. `--dev` is not supported on Kubernetes.
+**Kubernetes:** `--canasta-image` works as long as the image is pullable from the cluster (i.e., it's in a public registry or one the cluster has credentials for). `--build-from` requires extra image distribution: with `--create-cluster` (kind), the image is automatically loaded into the kind cluster; without it, the image is pushed to a registry specified by `--registry` so the cluster can pull it.
 
 ### Caveats
 

--- a/docs/guide/orchestrators.md
+++ b/docs/guide/orchestrators.md
@@ -242,6 +242,8 @@ The following features are not yet available for Kubernetes installations:
 | Feature | Status | Notes |
 |---------|--------|-------|
 | Development mode (Xdebug) | Not supported | Use Docker Compose for Xdebug debugging |
+| Backup create | Not supported | Use `kubectl exec` to run mysqldump manually |
+| Backup restore | Not supported | |
 | Backup scheduling | Not supported | Use a Kubernetes CronJob instead |
 | Remote/multi-node clusters | Not supported | Manifests use `hostPath` volumes |
 | Horizontal scaling | Limited | HPA is defined but not tested with the current volume setup |

--- a/docs/guide/orchestrators.md
+++ b/docs/guide/orchestrators.md
@@ -1,26 +1,105 @@
-# Kubernetes
+# Orchestrators
+
+Canasta CLI supports two orchestrators for running your wiki stack:
+
+- **Docker Compose** (default) — the recommended option for most users
+- **Kubernetes** — for users who need Kubernetes, with CLI-managed kind clusters or existing clusters
+
+Both orchestrators share the same CLI commands (`canasta start`, `canasta stop`, `canasta upgrade`, etc.) and the same installation directory layout (`.env`, `config/`, `extensions/`, `skins/`, `images/`).
+
+## Contents
+
+- [Docker Compose](#docker-compose)
+  - [docker-compose.override.yml](#docker-composeoverrideyml)
+- [Kubernetes](#kubernetes)
+  - [Prerequisites](#prerequisites)
+  - [Creating an installation (managed cluster)](#creating-an-installation-managed-cluster)
+  - [Managing the installation](#managing-the-installation)
+  - [How it works](#how-it-works)
+  - [Non-standard ports](#non-standard-ports)
+  - [Building from source](#building-from-source)
+  - [Using an existing cluster](#using-an-existing-cluster)
+  - [Current limitations](#current-limitations)
+
+---
+
+## Docker Compose
+
+Docker Compose is the default orchestrator. No `-o` flag is needed:
+
+```bash
+canasta create -i myinstance -w main -a admin -n localhost
+```
+
+This creates a standard Docker Compose stack with containers for the web server, database, Caddy reverse proxy, and other services. All data is stored on the host in the installation directory.
+
+Docker Compose supports all Canasta features including [development mode](devmode.md), [backup and restore](backup.md), and [observability](observability.md).
+
+### docker-compose.override.yml
+
+Docker Compose automatically merges `docker-compose.override.yml` with the main `docker-compose.yml` when present. Use this file to customize services without modifying the managed stack files.
+
+You can provide an override file at creation time with the `-r` flag:
+
+```bash
+canasta create -i myinstance -w main -a admin -n localhost -r my-overrides.yml
+```
+
+Or create/edit the file directly in the installation directory at any time.
+
+Common use cases:
+
+**Custom service images** — build a service with additional plugins or configuration:
+
+```yaml
+services:
+  elasticsearch:
+    build:
+      context: ./build
+      dockerfile: Dockerfile.elasticsearch
+    image: canasta-elasticsearch-icu:7.10.2
+```
+
+See [Custom Elasticsearch plugins](extensions-and-skins.md#custom-elasticsearch-plugins) for a full example.
+
+**Extra volumes** — mount additional directories into a container:
+
+```yaml
+services:
+  web:
+    volumes:
+      - ./my-data:/var/www/mediawiki/w/my-data
+```
+
+**Environment variables** — add or override environment variables for a service:
+
+```yaml
+services:
+  web:
+    environment:
+      - MY_CUSTOM_VAR=value
+```
+
+After editing the override file, restart the installation for changes to take effect:
+
+```bash
+canasta restart -i myinstance
+```
+
+The override file is included in [backups](backup.md).
+
+---
+
+## Kubernetes
 
 Canasta CLI can deploy to Kubernetes in two ways:
 
 - **Managed cluster** (`--create-cluster`): The CLI creates and manages a local [kind](https://kind.sigs.k8s.io/) cluster for you. This is the recommended approach for local development and testing.
 - **Existing cluster**: You provide a pre-configured Kubernetes cluster and the CLI deploys to it. This is experimental and has [significant limitations](#using-an-existing-cluster).
 
-## Contents
+### Prerequisites
 
-- [Prerequisites](#prerequisites)
-- [Creating an installation (managed cluster)](#creating-an-installation-managed-cluster)
-- [Managing the installation](#managing-the-installation)
-- [How it works](#how-it-works)
-- [Non-standard ports](#non-standard-ports)
-- [Building from source](#building-from-source)
-- [Using an existing cluster](#using-an-existing-cluster)
-- [Current limitations](#current-limitations)
-
----
-
-## Prerequisites
-
-### Managed cluster (recommended)
+#### Managed cluster (recommended)
 
 In addition to Docker (required for kind), you need:
 
@@ -31,13 +110,13 @@ In addition to Docker (required for kind), you need:
 
 The CLI checks for these tools at creation time and will report a clear error if either is missing.
 
-### Existing cluster
+#### Existing cluster
 
 You need `kubectl` installed and configured to connect to your cluster (`kubectl cluster-info` must succeed).
 
 ---
 
-## Creating an installation (managed cluster)
+### Creating an installation (managed cluster)
 
 Use `-o k8s` with the `--create-cluster` flag:
 
@@ -55,7 +134,7 @@ Once complete, your wiki is accessible at `https://localhost/main/`.
 
 ---
 
-## Managing the installation
+### Managing the installation
 
 The same CLI commands work for both Compose and Kubernetes installations:
 
@@ -75,7 +154,7 @@ If the kind cluster is manually deleted (e.g., via `kind delete cluster`), `cana
 
 ---
 
-## How it works
+### How it works
 
 With `--create-cluster`, the CLI creates a kind cluster with `extraPortMappings` that map host ports directly to Kubernetes NodePort services:
 
@@ -85,7 +164,7 @@ Browser -> localhost:443 -> kind node:443 -> NodePort 30443 -> caddy pod -> Medi
 
 Each installation gets its own kind cluster (`canasta-<id>`) and Kubernetes namespace. The cluster configuration, including port mappings, is stored in the CLI's configuration file so it survives restarts.
 
-### Directory structure
+#### Directory structure
 
 The installation directory has the same structure as a Compose installation, with Kubernetes manifests added:
 
@@ -106,7 +185,7 @@ The `kustomization.yaml` is regenerated automatically by the CLI and should not 
 
 ---
 
-## Non-standard ports
+### Non-standard ports
 
 By default, Canasta uses ports 80 (HTTP) and 443 (HTTPS). To use different ports, pass an env file:
 
@@ -123,7 +202,7 @@ Each installation must use unique ports. If two installations attempt to bind th
 
 ---
 
-## Building from source
+### Building from source
 
 To test a locally built Canasta image with a managed K8s cluster, use `--build-from`:
 
@@ -137,7 +216,7 @@ Without `--create-cluster`, the CLI pushes the image to a registry (default `loc
 
 ---
 
-## Using an existing cluster
+### Using an existing cluster
 
 To deploy to a pre-existing Kubernetes cluster without `--create-cluster`:
 
@@ -156,15 +235,13 @@ For most users, `--create-cluster` is the recommended approach.
 
 ---
 
-## Current limitations
+### Current limitations
 
 The following features are not yet available for Kubernetes installations:
 
 | Feature | Status | Notes |
 |---------|--------|-------|
 | Development mode (Xdebug) | Not supported | Use Docker Compose for Xdebug debugging |
-| Backup create | Not supported | Use `kubectl exec` to run mysqldump manually |
-| Backup restore | Not supported | |
 | Backup scheduling | Not supported | Use a Kubernetes CronJob instead |
 | Remote/multi-node clusters | Not supported | Manifests use `hostPath` volumes |
 | Horizontal scaling | Limited | HPA is defined but not tested with the current volume setup |

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,13 +42,13 @@ canasta create -i myinstance -w wiki1 -a admin -n localhost
 ### Guides
 
 - [General concepts](guide/general-concepts.md) - Installation IDs, wiki IDs, directory structure, settings, and configuration
-- [Wiki farms](guide/wiki-farms.md) - Running multiple wikis in one installation
+- [Best practices](guide/best-practices.md) - Security considerations and best practices
 - [Extensions and skins](guide/extensions-and-skins.md) - Enabling, disabling, and adding extensions and skins
-- [Observability](guide/observability.md) - Log aggregation with OpenSearch and Dashboards
-- [Development mode](guide/devmode.md) - Live code editing and Xdebug debugging
-- [Kubernetes](guide/kubernetes.md) - Deploying to Kubernetes with a CLI-managed kind cluster
+- [Wiki farms](guide/wiki-farms.md) - Running multiple wikis in one installation
 - [Backup and restore](guide/backup.md) - Setting up backups with restic
 - [Upgrading](guide/upgrading.md) - Upgrade process, version notes, and legacy migration
+- [Orchestrators](guide/orchestrators.md) - Docker Compose and Kubernetes orchestrator details
+- [Observability](guide/observability.md) - Log aggregation with OpenSearch and Dashboards
 - [Sitemaps](guide/sitemaps.md) - XML sitemap generation for search engine indexing
-- [Best practices](guide/best-practices.md) - Security considerations and best practices
+- [Development mode](guide/devmode.md) - Live code editing and Xdebug debugging
 - [Troubleshooting](guide/troubleshooting.md) - Common issues and debugging

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -55,7 +55,7 @@ On macOS: `brew install kubectl kind`
 
 On Linux: download the binaries from the links above or use your package manager.
 
-Docker is still required since kind uses it to run cluster nodes. See the [Kubernetes guide](guide/kubernetes.md) for full details.
+Docker is still required since kind uses it to run cluster nodes. See the [Orchestrators guide](guide/orchestrators.md#kubernetes) for full details.
 
 ## Install
 

--- a/internal/imagebuild/imagebuild.go
+++ b/internal/imagebuild/imagebuild.go
@@ -17,7 +17,9 @@ const (
 )
 
 // BuildFromSource builds Canasta (and optionally CanastaBase) from local repositories.
-// workspacePath should contain a "Canasta" directory (required) and optionally a "CanastaBase" directory.
+// workspacePath must contain a "Canasta" directory (required) and optionally a "CanastaBase" directory.
+// If CanastaBase is present, it is built first and used as the base image for Canasta.
+// If CanastaBase is absent, the published CanastaBase image is used.
 // Returns the final Canasta image tag to use.
 func BuildFromSource(workspacePath string) (string, error) {
 	canastaBasePath := filepath.Join(workspacePath, "CanastaBase")
@@ -25,7 +27,7 @@ func BuildFromSource(workspacePath string) (string, error) {
 
 	// Verify Canasta repo exists (required)
 	if _, err := os.Stat(canastaPath); os.IsNotExist(err) {
-		return "", fmt.Errorf("Canasta repo not found at %s", canastaPath)
+		return "", fmt.Errorf("Canasta/ directory not found in %s", workspacePath)
 	}
 
 	// Check if Canasta has a Dockerfile


### PR DESCRIPTION
## Summary

### --canasta-image flag
- Rename `--dev-tag` to `--canasta-image`, accepting a full image reference (e.g., `ghcr.io/canastawiki/canasta:dev-branch` or `myregistry.io/canasta:v1`) instead of just a tag
- Fix `CANASTA_IMAGE` not being persisted to `.env` when using the flag without `--build-from`, which caused the flag to silently have no effect
- The flag now works independently of `--dev`, so users can specify a custom image for any installation

### --build-from cleanup
- Clarify that `--build-from` requires `Canasta/` (with `CanastaBase/` optional)
- Remove references to the obsolete `Canasta-DockerCompose/` directory (stack files are now embedded in the CLI)
- Error clearly when `Canasta/` is missing instead of silently falling back to the default image

### Documentation
- Add "Custom Canasta images" section to `general-concepts.md` explaining `--canasta-image`, `--build-from`, and `--dev` use cases, orchestrator differences, and caveats
- Rename `kubernetes.md` to `orchestrators.md` and add a Docker Compose section covering `docker-compose.override.yml` usage (custom service images, extra volumes, environment variables)
- Update K8s limitations table (remove backup create/restore, now implemented)
- Add custom Elasticsearch plugins example to `extensions-and-skins.md`
- Reorder guides in `index.md` from general to specialized
- Simplify `devmode.md` image selection docs to reference the new `general-concepts.md` section
- Update cross-references in `installation.md` and `extensions-and-skins.md`

## Test plan

- [x] `canasta create --canasta-image ghcr.io/canastawiki/canasta:latest` — verify `CANASTA_IMAGE` is written to `.env`
- [x] `canasta create` (no flag) — verify default image is used, no `CANASTA_IMAGE` in `.env`
- [x] `canasta create --canasta-image X --build-from Y` — verify mutual exclusion error
- [x] Verify `--dev-tag` is no longer accepted
- [x] `go test ./...` passes

Closes #359, closes #360