### PR TITLE
Make `canasta upgrade` upgrade CLI and all instances by default

### DIFF
--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -22,7 +22,6 @@ import (
 )
 
 var dryRun bool
-var skipCLIUpdate bool
 
 func NewCmdCreate() *cobra.Command {
 	var upgradeCmd = &cobra.Command{
@@ -35,7 +34,7 @@ latest container images, running any necessary migrations, and restarting
 the containers.
 
 The CLI itself is also updated to the latest version before upgrading instances.
-Use --skip-cli-update to skip the CLI update if needed.
+Dev builds (compiled without version ldflags) skip the CLI self-update automatically.
 
 Use --dry-run to preview migrations without applying them.
 
@@ -47,13 +46,10 @@ distributed using the stored configuration.`,
   canasta upgrade
 
   # Preview what would change without applying
-  canasta upgrade --dry-run
-
-  # Upgrade all installations without updating the CLI
-  canasta upgrade --skip-cli-update`,
+  canasta upgrade --dry-run`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Check for CLI updates first (unless skipped or dry-run)
-			if !skipCLIUpdate && !dryRun {
+			// Check for CLI updates first (skipped automatically for dev builds and dry-run)
+			if !dryRun {
 				if _, err := selfupdate.CheckAndUpdate(); err != nil {
 					return fmt.Errorf("CLI update failed: %w", err)
 				}
@@ -64,7 +60,6 @@ distributed using the stored configuration.`,
 		},
 	}
 	upgradeCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show what would change without applying")
-	upgradeCmd.Flags().BoolVar(&skipCLIUpdate, "skip-cli-update", false, "Skip updating the CLI itself")
 	return upgradeCmd
 }
 

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -36,6 +36,9 @@ the containers.
 The CLI itself is also updated to the latest version before upgrading instances.
 Dev builds (compiled without version ldflags) skip the CLI self-update automatically.
 
+If an installation fails to upgrade, the error is printed and the remaining
+installations are still upgraded. A summary at the end reports how many succeeded.
+
 Use --dry-run to preview migrations without applying them.
 
 Installations created with --build-from automatically rebuild the Canasta image

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -22,51 +21,37 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/selfupdate"
 )
 
-var instance config.Installation
 var dryRun bool
-var upgradeAll bool
 var skipCLIUpdate bool
 
 func NewCmdCreate() *cobra.Command {
-	workingDir, err := os.Getwd()
-	if err != nil {
-		log.Fatal(err)
-	}
-	instance.Path = workingDir
-
 	var upgradeCmd = &cobra.Command{
 		Use:   "upgrade",
-		Short: "Upgrade a Canasta installation to the latest version",
-		Long: `Upgrade a Canasta installation by updating configuration files,
-pulling the latest container images, running any necessary migrations, and
-restarting the containers.
+		Short: "Upgrade the Canasta CLI and all registered installations",
+		Long: `Upgrade the Canasta CLI binary and all registered installations.
+
+Each installation is updated by refreshing configuration files, pulling the
+latest container images, running any necessary migrations, and restarting
+the containers.
 
 The CLI itself is also updated to the latest version before upgrading instances.
 Use --skip-cli-update to skip the CLI update if needed.
 
-Use --dry-run to preview migrations without applying them, or --all to upgrade
-every registered installation.
+Use --dry-run to preview migrations without applying them.
 
 Installations created with --build-from automatically rebuild the Canasta image
 from the stored source path during upgrade. For Kubernetes installations created
 with a kind cluster or custom registry, the rebuilt image is automatically
 distributed using the stored configuration.`,
-		Example: `  # Upgrade a single installation
-  canasta upgrade -i myinstance
+		Example: `  # Upgrade the CLI and all installations
+  canasta upgrade
 
   # Preview what would change without applying
-  canasta upgrade -i myinstance --dry-run
+  canasta upgrade --dry-run
 
-  # Upgrade all registered installations
-  canasta upgrade --all
-
-  # Upgrade without updating the CLI
-  canasta upgrade -i myinstance --skip-cli-update`,
+  # Upgrade all installations without updating the CLI
+  canasta upgrade --skip-cli-update`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if upgradeAll && instance.Id != "" {
-				return fmt.Errorf("cannot use --all with --id")
-			}
-
 			// Check for CLI updates first (unless skipped or dry-run)
 			if !skipCLIUpdate && !dryRun {
 				if _, err := selfupdate.CheckAndUpdate(); err != nil {
@@ -75,21 +60,10 @@ distributed using the stored configuration.`,
 				fmt.Println()
 			}
 
-			if upgradeAll {
-				return upgradeAllInstances(dryRun)
-			}
-			if instance.Id == "" && len(args) > 0 {
-				instance.Id = args[0]
-			}
-			if err := Upgrade(instance, dryRun); err != nil {
-				return err
-			}
-			return nil
+			return upgradeAllInstances(dryRun)
 		},
 	}
-	upgradeCmd.Flags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
 	upgradeCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show what would change without applying")
-	upgradeCmd.Flags().BoolVar(&upgradeAll, "all", false, "Upgrade all registered Canasta instances")
 	upgradeCmd.Flags().BoolVar(&skipCLIUpdate, "skip-cli-update", false, "Skip updating the CLI itself")
 	return upgradeCmd
 }

--- a/docs/guide/devmode.md
+++ b/docs/guide/devmode.md
@@ -103,7 +103,7 @@ To switch back to the upstream Canasta image:
 1. Remove the `CANASTA_IMAGE` line from `.env` (or set it to the desired upstream image, e.g. `CANASTA_IMAGE=ghcr.io/canastawiki/canasta:latest`)
 2. Pull the upstream image and restart:
    ```bash
-   canasta upgrade -i myinstance
+   canasta upgrade
    ```
 
 ---

--- a/docs/guide/general-concepts.md
+++ b/docs/guide/general-concepts.md
@@ -33,7 +33,7 @@ The installation ID is used to refer to the installation in all subsequent comma
 ```bash
 canasta start -i myinstance
 canasta extension list -i myinstance
-canasta upgrade -i myinstance
+canasta upgrade
 ```
 
 If you run a command from within the installation directory, the `-i` flag is not required.

--- a/docs/guide/kubernetes.md
+++ b/docs/guide/kubernetes.md
@@ -64,7 +64,7 @@ canasta stop -i my-wiki      # Scale deployments to 0 (cluster stays running)
 canasta start -i my-wiki     # Scale deployments back up
 canasta restart -i my-wiki   # Stop then start
 canasta delete -i my-wiki    # Delete the kind cluster and all data
-canasta upgrade -i my-wiki   # Update stack files and restart
+canasta upgrade              # Update CLI and all installations
 ```
 
 **Stop** scales all Kubernetes deployments to zero replicas. The kind cluster and persistent volumes remain intact, so your data is preserved.

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -35,7 +35,7 @@ canasta create -i myinstance -w mywiki -a admin -e my.env
 Add `CANASTA_ENABLE_OBSERVABILITY=true` to the `.env` file in your installation directory, then upgrade:
 
 ```bash
-canasta upgrade -i myinstance
+canasta upgrade
 ```
 
 In both cases, the CLI automatically:

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -30,6 +30,8 @@ Use `--dry-run` to preview what would change without applying:
 canasta upgrade --dry-run
 ```
 
+If an installation fails to upgrade, the error is printed and the remaining installations are still upgraded. A summary at the end reports how many succeeded.
+
 ## Pre-upgrade checklist
 
 1. **Back up your data** before every upgrade:

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -13,25 +13,22 @@ This guide covers upgrading Canasta installations and migrating from legacy (non
 
 ## How upgrading works
 
-The `canasta upgrade` command performs the following steps:
+The `canasta upgrade` command updates the CLI binary and all registered installations:
 
-1. Pulls the latest Canasta Docker image (or rebuilds it if the installation was created with `--build-from`)
-2. Restarts the containers with the new image
-3. Runs `maintenance/update.php` automatically to apply any database schema changes
-
-To upgrade a single installation:
-
-```bash
-canasta upgrade -i myinstance
-```
-
-To upgrade all installations at once:
+1. Updates the CLI itself to the latest version
+2. For each installation: pulls the latest Canasta Docker image (or rebuilds it if the installation was created with `--build-from`)
+3. Restarts the containers with the new image
+4. Runs `maintenance/update.php` automatically to apply any database schema changes
 
 ```bash
-canasta upgrade --all
+canasta upgrade
 ```
 
-The CLI also updates itself during the upgrade process, so you always have the latest CLI version.
+Use `--dry-run` to preview what would change without applying:
+
+```bash
+canasta upgrade --dry-run
+```
 
 ## Pre-upgrade checklist
 


### PR DESCRIPTION
## Summary

- `canasta upgrade` now updates the CLI binary **and** all registered installations by default, preventing CLI/instance version skew
- Removes the `-i`/`--id`, `--all`, and `--skip-cli-update` flags — the command always operates on everything
- Dev builds (compiled without version ldflags) skip the CLI self-update automatically
- If an installation fails to upgrade, the error is printed and the remaining installations are still upgraded
- Updates docs across 5 guide pages to reflect the new behavior

Closes #357

## Test plan

- [x] `canasta upgrade --help` shows updated description (no `-i`, `--all`, or `--skip-cli-update`)
- [x] `canasta upgrade` upgrades CLI + all registered instances
- [x] `canasta upgrade --dry-run` previews without applying
- [x] `go build ./...` and `go test ./...` pass