### PR TITLE
Add canasta devmode enable/disable command

### DIFF
--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -241,7 +241,7 @@ func AddWiki(instance config.Installation, wikiID, siteName, domain, wikipath, d
 		return err
 	}
 
-	err = restart.Restart(instance, false, false)
+	err = restart.Restart(instance)
 	if err != nil {
 		return err
 	}

--- a/cmd/devmode/devmode.go
+++ b/cmd/devmode/devmode.go
@@ -1,0 +1,60 @@
+package devmode
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
+	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
+	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
+)
+
+var (
+	instance config.Installation
+	orch     orchestrators.Orchestrator
+	err      error
+	verbose  bool
+)
+
+func NewCmdCreate() *cobra.Command {
+	workingDir, wdErr := os.Getwd()
+	if wdErr != nil {
+		log.Fatal(wdErr)
+	}
+	instance.Path = workingDir
+
+	devmodeCmd := &cobra.Command{
+		Use:   "devmode",
+		Short: "Manage development mode",
+		Long: `Enable or disable development mode on a Canasta installation. Development
+mode extracts MediaWiki code for live editing and enables Xdebug for step
+debugging. This is only supported with Docker Compose.`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			logging.SetVerbose(verbose)
+			instance, err = canasta.CheckCanastaId(instance)
+			if err != nil {
+				return err
+			}
+			orch, err = orchestrators.NewFromInstance(instance)
+			if err != nil {
+				return err
+			}
+			if !orch.SupportsDevMode() {
+				return fmt.Errorf("development mode is not supported with %s", orch.Name())
+			}
+			return nil
+		},
+	}
+
+	devmodeCmd.PersistentFlags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
+	devmodeCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Verbose Output")
+
+	devmodeCmd.AddCommand(enableCmdCreate())
+	devmodeCmd.AddCommand(disableCmdCreate())
+
+	return devmodeCmd
+}

--- a/cmd/devmode/disable.go
+++ b/cmd/devmode/disable.go
@@ -1,0 +1,54 @@
+package devmode
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	devmodePkg "github.com/CanastaWiki/Canasta-CLI/internal/devmode"
+	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
+)
+
+func disableCmdCreate() *cobra.Command {
+	return &cobra.Command{
+		Use:   "disable",
+		Short: "Disable development mode",
+		Long: `Disable development mode on a Canasta installation. This restores extensions
+and skins as real directories and restarts without Xdebug. The mediawiki-code/
+directory is preserved so you can re-enable dev mode later without
+re-extracting code.`,
+		Example: `  # Disable dev mode on an installation
+  canasta devmode disable -i myinstance`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Printf("Disabling development mode on '%s'...\n", instance.Id)
+
+			// Disable dev mode (restore symlinks to real directories)
+			if err := devmodePkg.DisableDevMode(instance.Path); err != nil {
+				return err
+			}
+
+			// Update config registry
+			instance.DevMode = false
+			if instance.Id != "" {
+				if err := config.Update(instance); err != nil {
+					logging.Print(fmt.Sprintf("Warning: could not update config: %v\n", err))
+				}
+			}
+
+			// Regenerate orchestrator config and restart
+			if err := orch.UpdateConfig(instance.Path); err != nil {
+				return err
+			}
+			if err := orch.Stop(instance); err != nil {
+				return err
+			}
+			if err := orch.Start(instance); err != nil {
+				return err
+			}
+
+			fmt.Println("Development mode disabled.")
+			return nil
+		},
+	}
+}

--- a/cmd/devmode/enable.go
+++ b/cmd/devmode/enable.go
@@ -1,0 +1,64 @@
+package devmode
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
+	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	devmodePkg "github.com/CanastaWiki/Canasta-CLI/internal/devmode"
+	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
+)
+
+func enableCmdCreate() *cobra.Command {
+	return &cobra.Command{
+		Use:   "enable",
+		Short: "Enable development mode",
+		Long: `Enable development mode on an existing Canasta installation. This extracts
+MediaWiki code for live editing, builds an Xdebug-enabled image, and restarts
+the instance with dev mode compose files. Only supported with Docker Compose.`,
+		Example: `  # Enable dev mode on an installation
+  canasta devmode enable -i myinstance`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Printf("Enabling development mode on '%s'...\n", instance.Id)
+
+			// Determine the base image: check .env for CANASTA_IMAGE, fall back to default
+			baseImage := canasta.GetDefaultImage()
+			envVars, envErr := canasta.GetEnvVariable(instance.Path + "/.env")
+			if envErr == nil {
+				if img, ok := envVars["CANASTA_IMAGE"]; ok && img != "" {
+					baseImage = img
+				}
+			}
+
+			// Enable dev mode (extract code, create files, build xdebug image)
+			if err := devmodePkg.EnableDevMode(instance.Path, orch, baseImage); err != nil {
+				return err
+			}
+
+			// Update config registry
+			instance.DevMode = true
+			if instance.Id != "" {
+				if err := config.Update(instance); err != nil {
+					logging.Print(fmt.Sprintf("Warning: could not update config: %v\n", err))
+				}
+			}
+
+			// Regenerate orchestrator config and restart
+			if err := orch.UpdateConfig(instance.Path); err != nil {
+				return err
+			}
+			if err := orch.Stop(instance); err != nil {
+				return err
+			}
+			if err := orch.Start(instance); err != nil {
+				return err
+			}
+
+			fmt.Println("\033[32mDevelopment mode enabled. Edit files in mediawiki-code/ - changes appear immediately.\033[0m")
+			fmt.Println("\033[32mVSCode: Open the installation directory, install PHP Debug extension, and start 'Listen for Xdebug'.\033[0m")
+			return nil
+		},
+	}
+}

--- a/cmd/import/import.go
+++ b/cmd/import/import.go
@@ -119,7 +119,7 @@ func importDatabase(orch orchestrators.Orchestrator, instance config.Installatio
 	}
 
 	// Restart containers to apply changes
-	err = restart.Restart(instance, false, false)
+	err = restart.Restart(instance)
 	if err != nil {
 		return err
 	}

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -148,7 +148,7 @@ func RemoveWiki(instance config.Installation, wikiID string, yes bool) error {
 	}
 
 	//Restart the Canasta Instance
-	err = restart.Restart(instance, false, false)
+	err = restart.Restart(instance)
 	if err != nil {
 		return err
 	}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -4,6 +4,7 @@ import (
 	addCmd "github.com/CanastaWiki/Canasta-CLI/cmd/add"
 	createCmd "github.com/CanastaWiki/Canasta-CLI/cmd/create"
 	deleteCmd "github.com/CanastaWiki/Canasta-CLI/cmd/delete"
+	devmodeCmd "github.com/CanastaWiki/Canasta-CLI/cmd/devmode"
 	exportCmd "github.com/CanastaWiki/Canasta-CLI/cmd/export"
 	extensionCmd "github.com/CanastaWiki/Canasta-CLI/cmd/extension"
 	importCmd "github.com/CanastaWiki/Canasta-CLI/cmd/import"
@@ -62,6 +63,7 @@ func init() {
 
 	rootCmd.AddCommand(createCmd.NewCmdCreate())
 	rootCmd.AddCommand(deleteCmd.NewCmdCreate())
+	rootCmd.AddCommand(devmodeCmd.NewCmdCreate())
 	rootCmd.AddCommand(exportCmd.NewCmdCreate())
 	rootCmd.AddCommand(extensionCmd.NewCmdCreate())
 	rootCmd.AddCommand(importCmd.NewCmdCreate())

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -9,16 +9,10 @@ import (
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
-	"github.com/CanastaWiki/Canasta-CLI/internal/devmode"
-	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-var (
-	instance    config.Installation
-	devModeFlag bool
-	noDevFlag   bool
-)
+var instance config.Installation
 
 func NewCmdCreate() *cobra.Command {
 	workingDir, err := os.Getwd()
@@ -31,16 +25,11 @@ func NewCmdCreate() *cobra.Command {
 		Use:   "start",
 		Short: "Start the Canasta installation",
 		Long: `Start the Docker containers for a Canasta installation. If the installation
-was created with development mode, it starts with Xdebug enabled by default.
-Use --dev to enable or --no-dev to disable development mode at start time.`,
+has development mode enabled, it starts with Xdebug automatically. Use
+'canasta devmode enable' or 'canasta devmode disable' to change the
+development mode setting.`,
 		Example: `  # Start an installation by ID
-  canasta start -i myinstance
-
-  # Start with development mode enabled
-  canasta start -i myinstance -D
-
-  # Start with development mode disabled
-  canasta start -i myinstance --no-dev`,
+  canasta start -i myinstance`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if instance.Id == "" && len(args) > 0 {
 				instance.Id = args[0]
@@ -50,7 +39,7 @@ Use --dev to enable or --no-dev to disable development mode at start time.`,
 				return err
 			}
 			fmt.Println("Starting Canasta installation '" + resolvedInstance.Id + "'...")
-			if err := Start(resolvedInstance, devModeFlag, noDevFlag); err != nil {
+			if err := Start(resolvedInstance); err != nil {
 				return err
 			}
 			fmt.Println("Started.")
@@ -58,47 +47,13 @@ Use --dev to enable or --no-dev to disable development mode at start time.`,
 		},
 	}
 	startCmd.Flags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
-	startCmd.Flags().BoolVarP(&devModeFlag, "dev", "D", false, "Start in development mode with Xdebug (Compose only)")
-	startCmd.Flags().BoolVar(&noDevFlag, "no-dev", false, "Start without development mode (disable dev mode) (Compose only)")
 	return startCmd
 }
 
-func Start(instance config.Installation, enableDev, disableDev bool) error {
-	// Handle --dev and --no-dev flags
-	if enableDev && disableDev {
-		return fmt.Errorf("cannot specify both --dev and --no-dev")
-	}
-
+func Start(instance config.Installation) error {
 	orch, err := orchestrators.NewFromInstance(instance)
 	if err != nil {
 		return err
-	}
-	if (enableDev || disableDev) && !orch.SupportsDevMode() {
-		return fmt.Errorf("development mode is not supported with %s", orch.Name())
-	}
-	if enableDev {
-		// Enable dev mode using default registry image
-		baseImage := canasta.GetDefaultImage()
-		if err = devmode.EnableDevMode(instance.Path, orch, baseImage); err != nil {
-			return err
-		}
-		instance.DevMode = true
-		if instance.Id != "" {
-			if err = config.Update(instance); err != nil {
-				logging.Print(fmt.Sprintf("Warning: could not update config: %v\n", err))
-			}
-		}
-	} else if disableDev {
-		// Disable dev mode - restore extensions/skins as real directories
-		if err = devmode.DisableDevMode(instance.Path); err != nil {
-			return err
-		}
-		instance.DevMode = false
-		if instance.Id != "" {
-			if err = config.Update(instance); err != nil {
-				logging.Print(fmt.Sprintf("Warning: could not update config: %v\n", err))
-			}
-		}
 	}
 
 	// Regenerate orchestrator config (Compose: Caddyfile; K8s: kustomization.yaml)

--- a/docs/guide/devmode.md
+++ b/docs/guide/devmode.md
@@ -158,7 +158,7 @@ After enabling dev mode, verify the setup by running these commands from the ins
 
 A `.vscode/launch.json` file is automatically created. To start debugging:
 
-1. Open the installation directory in VSCode
+1. Open the installation's root directory in VSCode (not the `mediawiki-code/` subdirectory) — the path mappings require this
 2. Install the **PHP Debug** extension (by Xdebug)
 3. Go to **Run and Debug** (Ctrl+Shift+D / Cmd+Shift+D)
 4. Select **"Listen for Xdebug"** and click the play button
@@ -169,7 +169,7 @@ A `.vscode/launch.json` file is automatically created. To start debugging:
 
 Configuration files are automatically created in the `.idea/` directory. To start debugging:
 
-1. Open the installation directory in PHPStorm
+1. Open the installation's root directory in PHPStorm (not the `mediawiki-code/` subdirectory) — the path mappings require this
 2. Go to **Run** → **Edit Configurations**
 3. The **"Listen for Xdebug"** configuration should already be available
 4. Click the **phone/listen icon** in the toolbar (or **Run** → **Start Listening for PHP Debug Connections**)

--- a/docs/guide/devmode.md
+++ b/docs/guide/devmode.md
@@ -5,9 +5,8 @@ Development mode enables live code editing and step debugging with Xdebug for Ca
 ## Contents
 
 - [Features](#features)
-- [Creating a dev mode installation](#creating-a-dev-mode-installation)
+- [Enabling dev mode](#enabling-dev-mode)
 - [Building from local source](#building-from-local-source)
-- [Enabling dev mode on existing installations](#enabling-dev-mode-on-existing-installations)
 - [Disabling dev mode](#disabling-dev-mode)
 - [Verifying dev mode is working](#verifying-dev-mode-is-working)
 - [IDE setup](#ide-setup)
@@ -33,26 +32,33 @@ Development mode enables live code editing and step debugging with Xdebug for Ca
 
 ---
 
-## Creating a dev mode installation
+## Enabling dev mode
+
+First create a Canasta installation, then enable dev mode:
 
 ```bash
-# Use the default (latest) Canasta image
-canasta create -i mydev -w mywiki -n localhost -a admin --dev
+# Create an installation
+canasta create -i mydev -w mywiki -n localhost -a admin
 
-# Or specify a specific Canasta image tag
-canasta create -i mydev -w mywiki -n localhost -a admin --dev --dev-tag dev-branch
+# Enable development mode
+canasta devmode enable -i mydev
 ```
 
-The `--dev` flag enables development mode with Xdebug. Use `--dev-tag` to specify which Canasta image tag to use:
+You can also specify a specific Canasta image tag when creating. Use `--dev-tag` to control which Canasta image tag to use:
 - Without `--dev-tag` — Uses the `latest` image (default)
 - `--dev-tag dev-branch` — Uses the specified image tag
 
-This will:
-1. Clone the Canasta stack
-2. Extract MediaWiki code to `mediawiki-code/` for live editing
-3. Build an Xdebug-enabled Docker image using the specified tag
+```bash
+canasta create -i mydev -w mywiki -n localhost -a admin --dev-tag dev-branch
+canasta devmode enable -i mydev
+```
+
+Enabling dev mode will:
+1. Extract MediaWiki code to `mediawiki-code/` for live editing
+2. Create dev mode files (Dockerfile.xdebug, docker-compose.dev.yml, xdebug.ini)
+3. Build an Xdebug-enabled Docker image
 4. Create IDE configuration files
-5. Start the installation
+5. Restart the installation with dev mode enabled
 
 ### Available image tags
 
@@ -78,16 +84,18 @@ This will:
 1. Build CanastaBase locally (if the directory exists) → `canasta-base:local`
 2. Build Canasta using the local or published base image → `canasta:local`
 3. Copy docker-compose files from local Canasta-DockerCompose (if exists) or clone from GitHub
-4. Extract MediaWiki code from the locally built image
-5. Continue with normal installation
+4. Continue with normal installation
 
 ### Combining with dev mode
 
-You can combine `--build-from` with `--dev` to build from source and enable Xdebug:
+You can enable dev mode after building from source:
 
 ```bash
-canasta create -i mydev -w mywiki -n localhost -a admin --dev --build-from ~/canasta-repos
+canasta create -i mydev -w mywiki -n localhost -a admin --build-from ~/canasta-repos
+canasta devmode enable -i mydev
 ```
+
+The dev mode enable command will detect the locally built image from the `.env` file and use it for code extraction and xdebug image building.
 
 **Note:** `--dev-tag` and `--build-from` are mutually exclusive since `--build-from` builds its own image.
 
@@ -108,43 +116,21 @@ To switch back to the upstream Canasta image:
 
 ---
 
-## Enabling dev mode on existing installations
-
-You can enable dev mode on an installation that wasn't created with `--dev`:
-
-```bash
-canasta start -i myinstance --dev
-# or
-canasta restart -i myinstance --dev
-```
-
-This will:
-1. Extract MediaWiki code to `mediawiki-code/` (if not already present)
-2. Create dev mode files (Dockerfile.xdebug, docker-compose.dev.yml, xdebug.ini)
-3. Build the xdebug-enabled image
-4. Start with dev mode compose files
-
-**Note:** If `mediawiki-code/` already exists, it will NOT be overwritten. You'll see a warning message. To regenerate the code, delete the directory first and then restart with `--dev`.
-
-**Note:** When enabling dev mode on an existing installation, the default `latest` image tag is used. To use a specific image tag, recreate the installation with `canasta create --dev --dev-tag <tag>`.
-
----
-
 ## Disabling dev mode
 
 To disable dev mode and restore normal operation:
 
 ```bash
-canasta restart -i myinstance --no-dev
+canasta devmode disable -i myinstance
 ```
 
-This starts without dev compose files (no xdebug). The dev mode files (Dockerfile.xdebug, docker-compose.dev.yml, mediawiki-code/) are left in place so you can re-enable dev mode later without re-extracting code.
+This restores extensions and skins as real directories and restarts without Xdebug. The dev mode files (Dockerfile.xdebug, docker-compose.dev.yml, mediawiki-code/) are left in place so you can re-enable dev mode later without re-extracting code.
 
 ---
 
 ## Verifying dev mode is working
 
-After creating a dev mode installation, verify the setup by running these commands from the installation directory:
+After enabling dev mode, verify the setup by running these commands from the installation directory:
 
 1. **Check containers are running with the dev image**:
    ```bash
@@ -257,7 +243,7 @@ docker compose exec -e XDEBUG_TRIGGER=1 web php maintenance/run.php someScript
 
 ## Directory structure
 
-After creating a dev mode installation:
+After enabling dev mode on an installation:
 
 ```
 installation/
@@ -349,7 +335,7 @@ For IDE path mapping to work correctly, set breakpoints in files under `mediawik
 
 ### When dev mode is disabled
 
-When you disable dev mode (`canasta restart --no-dev`), the CLI:
+When you disable dev mode (`canasta devmode disable -i myinstance`), the CLI:
 1. Removes the `extensions/` symlink
 2. Copies content from `mediawiki-code/user-extensions/` back to a real `extensions/` directory
 3. Leaves `mediawiki-code/` in place (not volumed in, but available for reference)
@@ -358,7 +344,7 @@ Your user extensions are preserved in both modes.
 
 ### When dev mode is re-enabled
 
-When you re-enable dev mode (`canasta restart --dev`) after having disabled it:
+When you re-enable dev mode (`canasta devmode enable -i myinstance`) after having disabled it:
 1. Extensions in `extensions/` **take precedence** over `mediawiki-code/user-extensions/`
 2. Any changes made to `extensions/` while in non-dev mode are synced to `mediawiki-code/user-extensions/`
 3. The `extensions/` directory becomes a symlink again
@@ -438,8 +424,8 @@ canasta stop -i myinstance
 # Remove the extracted code
 rm -rf mediawiki-code/
 
-# Restart in dev mode (this will re-extract the code)
-canasta restart -i myinstance --dev
+# Re-enable dev mode (this will re-extract the code)
+canasta devmode enable -i myinstance
 ```
 
 This preserves your wikis, configuration, and database while updating the MediaWiki code.
@@ -456,5 +442,5 @@ Dev mode with Xdebug is slower than production mode due to:
 
 For performance testing, disable dev mode:
 ```bash
-canasta restart -i myinstance --no-dev
+canasta devmode disable -i myinstance
 ```


### PR DESCRIPTION
## Summary

- Adds a dedicated `canasta devmode enable/disable` subcommand for toggling development mode (#328)
- Removes `--dev`/`--no-dev` flags from `start`, `restart`, and `create` commands
- Keeps `--dev-tag` on `create` (controls image tag independently; will be replaced by `--canasta-image` in #362)
- Fixes PHPStorm debug config to use actual host/port from `.env` instead of hardcoding `localhost:80`
- IDE configs are refreshed on every `devmode enable` so they stay in sync after port changes

New workflow:
```bash
canasta create -i x -w mywiki -n localhost -a admin
canasta devmode enable -i x
canasta devmode disable -i x
```

## Test plan

- [x] `go build ./...` and `go test ./...` pass
- [x] `canasta devmode enable --help` and `canasta devmode disable --help` show correct descriptions
- [x] `canasta start --help`, `canasta restart --help`, `canasta create --help` no longer show `--dev`/`--no-dev` flags
- [x] `canasta devmode enable -i x` sets up dev mode and restarts with xdebug
- [x] `canasta devmode disable -i x` restores normal mode and restarts
- [x] `canasta devmode enable -i x` on a K8s instance fails with clear error
- [x] PHPStorm `php.xml` reflects actual `HTTPS_PORT` and `MW_SITE_FQDN` from `.env`
- [x] Re-running `devmode enable` after a port change updates IDE configs
- [x] Xdebug breakpoints work in PHPStorm on non-standard port (8443)

Closes #328