### PR TITLE
Add healthcheck for Varnish container

### DIFF
--- a/internal/orchestrators/compose/files/docker-compose.yml
+++ b/internal/orchestrators/compose/files/docker-compose.yml
@@ -99,6 +99,12 @@ services:
     depends_on:
       web:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "varnishadm", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     volumes:
        - ./config/default.vcl:/etc/varnish/default.vcl:ro
     tmpfs:


### PR DESCRIPTION
## Summary

- Adds a healthcheck to the Varnish service in `docker-compose.yml` using `varnishadm ping`
- Detects hung Varnish processes that `restart: unless-stopped` alone would miss (e.g. after OOM)
- Matches the pattern used by the db and elasticsearch services which already have healthchecks

## Test plan

- [x] `go build ./...` and `go test ./...` pass
- [x] `canasta create` — Varnish container starts and reports healthy
- [x] Existing installations pick up the healthcheck after `canasta upgrade`

Closes #367