### PR TITLE
Pin default Canasta image to versioned tag instead of latest

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -250,11 +250,11 @@ func createCanasta(canastaInfo canasta.CanastaVariables, workingDir, path, wikiI
 	if err := canasta.UpdateEnvFile(envFile, path, workingDir, canastaInfo.RootDBPassword, canastaInfo.WikiDBPassword); err != nil {
 		return err
 	}
-	// Set CANASTA_IMAGE in .env when using a non-default image (local build or --canasta-image)
-	if buildFromPath != "" || canastaImage != "" {
-		if err := canasta.SaveEnvVariable(path+"/.env", "CANASTA_IMAGE", baseImage); err != nil {
-			return err
-		}
+	// Always set CANASTA_IMAGE in .env so the installation is pinned to a
+	// specific image. For default installs this is the CLI's pinned version;
+	// for --canasta-image or --build-from it's the user-specified image.
+	if err := canasta.SaveEnvVariable(path+"/.env", "CANASTA_IMAGE", baseImage); err != nil {
+		return err
 	}
 	if err := canasta.CopySettings(path); err != nil {
 		return err

--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -1,0 +1,121 @@
+# Contributing
+
+This guide covers the release workflow for the Canasta project and how the various repositories work together.
+
+## Contents
+
+- [Repository overview](#repository-overview)
+- [Release workflow](#release-workflow)
+- [Image tagging strategy](#image-tagging-strategy)
+- [Updating the CLI default image](#updating-the-cli-default-image)
+- [Testing changes locally](#testing-changes-locally)
+
+---
+
+## Repository overview
+
+The Canasta project spans several repositories:
+
+| Repository | Description |
+|-----------|-------------|
+| [CanastaBase](https://github.com/CanastaWiki/CanastaBase) | Base Docker image with MediaWiki, Apache, PHP, and bundled extensions/skins |
+| [Canasta](https://github.com/CanastaWiki/Canasta) | Thin layer on top of CanastaBase that adds the Canasta stack (Caddy, Varnish, maintenance scripts) |
+| [Canasta-CLI](https://github.com/CanastaWiki/Canasta-CLI) | Go CLI tool for managing Canasta installations |
+
+The Docker image hierarchy is:
+
+```
+CanastaBase (mediawiki + extensions + skins)
+  └── Canasta (caddy, varnish, scripts, config)
+```
+
+---
+
+## Release workflow
+
+A typical Canasta release involves changes across one or more repositories. The general flow is:
+
+### 1. Merge changes into CanastaBase and/or Canasta
+
+Submit and merge pull requests to the relevant repos. For changes that span both CanastaBase and Canasta (e.g., a new MediaWiki version), merge CanastaBase first so the new base image is available when Canasta builds.
+
+### 2. Bump the VERSION file in the Canasta repo
+
+Once all PRs for the release are merged into `master`, update the `VERSION` file in the Canasta repository to the new version number (e.g., `3.3.0`). This can be done directly on `master` or via a final PR.
+
+### 3. Auto-tagging and image publishing
+
+When the `VERSION` file changes on `master`, the CI workflow automatically:
+
+1. Builds and pushes the Docker image with the mutable rolling tags (`latest`, `<MW_MAJOR>-latest`, `<MW_VERSION>-latest`, `<MW_VERSION>-<DATE>-<SHA>`)
+2. Creates a Git tag `v<VERSION>` (e.g., `v3.3.0`) if it doesn't already exist
+3. The new tag triggers a second CI run that builds and pushes an **immutable** versioned image tag (e.g., `3.3.0`)
+
+The immutable tag is the one that CLI installations are pinned to. It is never overwritten by future builds.
+
+### 4. Update the CLI default image tag
+
+After the versioned image is published, update `DefaultImageTag` in `internal/canasta/canasta.go` to match the new version:
+
+```go
+DefaultImageTag = "3.3.0"
+```
+
+This ensures new installations created with `canasta create` use the new version. Existing installations keep whatever version is in their `.env` file until explicitly upgraded.
+
+### 5. Release the CLI
+
+Tag and release the CLI via GitHub Releases. The install script (`install.sh`) downloads the latest CLI release.
+
+---
+
+## Image tagging strategy
+
+The Canasta Docker image uses several tag types:
+
+| Tag | When published | Mutable? | Example |
+|-----|---------------|----------|---------|
+| `latest` | Every push to `master` | Yes | `canasta:latest` |
+| `<MW_MAJOR>-latest` | Every push to `master` | Yes | `canasta:1.43-latest` |
+| `<MW_VERSION>-latest` | Every push to `master` | Yes | `canasta:1.43.1-latest` |
+| `<MW_VERSION>-<DATE>-<SHA>` | Every push to `master` | No | `canasta:1.43.1-20260224-abc1234` |
+| `<CANASTA_VERSION>` | Git tag push (auto or manual) | No | `canasta:3.2.0` |
+| `<MW_VERSION>-<DATE>-<PR>` | Pull requests | No | `canasta:1.43.1-20260224-42` |
+
+The CLI pins installations to the immutable `<CANASTA_VERSION>` tag (e.g., `3.2.0`). This guarantees reproducible deployments — the image an installation uses does not change unless the user explicitly upgrades.
+
+---
+
+## Updating the CLI default image
+
+The default image tag is defined in a single place:
+
+```
+internal/canasta/canasta.go → DefaultImageTag
+```
+
+When `canasta create` runs, it writes `CANASTA_IMAGE=ghcr.io/canastawiki/canasta:<DefaultImageTag>` to the installation's `.env` file. The `docker-compose.yml` and Kubernetes `web.yaml` templates reference `${CANASTA_IMAGE:-ghcr.io/canastawiki/canasta:latest}` — the `latest` fallback is never used in practice since `CANASTA_IMAGE` is always set.
+
+To update:
+
+1. Change `DefaultImageTag` in `internal/canasta/canasta.go`
+2. Submit a PR to `Canasta-CLI`
+3. After merging, cut a new CLI release
+
+---
+
+## Testing changes locally
+
+To test changes to CanastaBase or Canasta before they are published, use `--build-from`:
+
+```bash
+# Directory structure expected by --build-from:
+# ~/canasta-repos/
+#   ├── Canasta/       (required)
+#   └── CanastaBase/   (optional — if present, built first)
+
+canasta create -i test-instance -w mywiki -n localhost -a admin \
+  --build-from ~/canasta-repos
+```
+
+This builds the image(s) locally and uses them for the installation. See [Custom Canasta images](general-concepts.md#custom-canasta-images) and [Development mode](devmode.md#building-from-local-source) for details.

--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -41,19 +41,19 @@ A typical Canasta release involves changes across one or more repositories. The 
 
 Submit and merge pull requests to the relevant repos. For changes that span both CanastaBase and Canasta (e.g., a new MediaWiki version), merge CanastaBase first so the new base image is available when Canasta builds.
 
-### 2. Bump the VERSION file in the Canasta repo
+### 2. CI builds on every master push
+
+Every push to `master` triggers the CI workflow, which:
+
+1. Builds the Docker image for `linux/amd64` and `linux/arm64`
+2. Pushes the mutable rolling tags: `latest`, `<MW_MAJOR>-latest`, `<MW_VERSION>-latest`, and `<MW_VERSION>-<DATE>-<SHA>`
+3. Runs the auto-tag job: if the version in the `VERSION` file does not already have a corresponding Git tag, it creates one (e.g., `v3.3.0`)
+
+### 3. Bump the VERSION file for a new release
 
 Once all PRs for the release are merged into `master`, update the `VERSION` file in the Canasta repository to the new version number (e.g., `3.3.0`). This can be done directly on `master` or via a final PR.
 
-### 3. Auto-tagging and image publishing
-
-When the `VERSION` file changes on `master`, the CI workflow automatically:
-
-1. Builds and pushes the Docker image with the mutable rolling tags (`latest`, `<MW_MAJOR>-latest`, `<MW_VERSION>-latest`, `<MW_VERSION>-<DATE>-<SHA>`)
-2. Creates a Git tag `v<VERSION>` (e.g., `v3.3.0`) if it doesn't already exist
-3. The new tag triggers a second CI run that builds and pushes an **immutable** versioned image tag (e.g., `3.3.0`)
-
-The immutable tag is the one that CLI installations are pinned to. It is never overwritten by future builds.
+The next CI run will see that the `v3.3.0` tag does not exist and create it. The new tag triggers a second CI run that builds and pushes an **immutable** versioned image tag (e.g., `3.3.0`). This is the tag that CLI installations are pinned to — it is never overwritten by future builds.
 
 ### 4. Update the CLI default image tag
 

--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -18,16 +18,18 @@ The Canasta project spans several repositories:
 
 | Repository | Description |
 |-----------|-------------|
-| [CanastaBase](https://github.com/CanastaWiki/CanastaBase) | Base Docker image with MediaWiki, Apache, PHP, and bundled extensions/skins |
-| [Canasta](https://github.com/CanastaWiki/Canasta) | Thin layer on top of CanastaBase that adds the Canasta stack (Caddy, Varnish, maintenance scripts) |
+| [CanastaBase](https://github.com/CanastaWiki/CanastaBase) | Base Docker image with MediaWiki, Apache, PHP, bundled extensions/skins, and maintenance scripts |
+| [Canasta](https://github.com/CanastaWiki/Canasta) | Thin layer on top of CanastaBase that adds additional extensions/skins, patches, and extension-specific maintenance scripts |
 | [Canasta-CLI](https://github.com/CanastaWiki/Canasta-CLI) | Go CLI tool for managing Canasta installations |
 
 The Docker image hierarchy is:
 
 ```
-CanastaBase (mediawiki + extensions + skins)
-  └── Canasta (caddy, varnish, scripts, config)
+CanastaBase (mediawiki + core extensions + skins + maintenance scripts)
+  └── Canasta (additional extensions/skins, patches, extension-specific maintenance)
 ```
+
+Caddy, Varnish, MySQL, and Elasticsearch/OpenSearch run as **separate containers** alongside the Canasta web container — they are not part of the Canasta image.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,4 +51,5 @@ canasta create -i myinstance -w wiki1 -a admin -n localhost
 - [Observability](guide/observability.md) - Log aggregation with OpenSearch and Dashboards
 - [Sitemaps](guide/sitemaps.md) - XML sitemap generation for search engine indexing
 - [Development mode](guide/devmode.md) - Live code editing and Xdebug debugging
+- [Contributing](guide/contributing.md) - Release workflow and repository overview
 - [Troubleshooting](guide/troubleshooting.md) - Common issues and debugging

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -36,8 +36,10 @@ const (
 	DefaultImageRegistry = "ghcr.io/canastawiki"
 	// DefaultImageName is the name of the Canasta image
 	DefaultImageName = "canasta"
-	// DefaultImageTag is the default tag to use for the Canasta image
-	DefaultImageTag = "latest"
+	// DefaultImageTag is the default tag to use for the Canasta image.
+	// This should match the current stable Canasta release. Update it
+	// when cutting a new CLI release to pair with a new Canasta version.
+	DefaultImageTag = "3.2.0"
 )
 
 // GetDefaultImage returns the full default Canasta image reference


### PR DESCRIPTION
## Summary

- Change `DefaultImageTag` from `"latest"` to `"3.2.0"` so new installations are pinned to a known, tested image
- This is the single source of truth — `docker-compose.yml` and `web.yaml` retain `latest` as a fallback, but it is never used because `CANASTA_IMAGE` is now always written to `.env` during create via `GetDefaultImage()`
- Always write `CANASTA_IMAGE` to `.env` during `canasta create` (not just for `--canasta-image`/`--build-from`) so the pinned version is explicit
- `canasta upgrade` continues to work — it pulls whatever image is in the installation's `.env`/compose config
- Users who want bleeding edge can still use `--canasta-image ghcr.io/canastawiki/canasta:latest`
- Add contributing guide (`docs/guide/contributing.md`) documenting the multi-repo release workflow, CI behavior on every master push, image tagging strategy, and how `DefaultImageTag` flows into installations

Depends on CanastaWiki/Canasta#587 (CI change to make versioned tags immutable + auto-tag job).

Closes #361

## Test plan

- [x] `canasta create` writes `CANASTA_IMAGE=ghcr.io/canastawiki/canasta:3.2.0` to `.env`
- [x] `canasta create --canasta-image ghcr.io/canastawiki/canasta:latest` writes the specified image
- [x] `canasta upgrade` pulls the image specified in `.env`
- [x] `go test ./...` passes
- [x] `docs/guide/contributing.md` renders correctly and links work