### PR TITLE
Add Docker logging limits, backup log rotation, and update docs

### DIFF
--- a/cmd/backup/schedule.go
+++ b/cmd/backup/schedule.go
@@ -122,7 +122,8 @@ func scheduleBackup(cronExpression string) error {
 	}
 
 	logPath := filepath.Join(instance.Path, "backup.log")
-	cmdStr := fmt.Sprintf("%s %s backup create -i %s --tag scheduled-$(date +\\%%Y\\%%m\\%%d\\%%H\\%%M\\%%S) >> %s 2>&1", cronExpression, executable, instance.Id, logPath)
+	rotateCmd := fmt.Sprintf("find %s -size +10M -exec mv {} %s.1 \\;", logPath, logPath)
+	cmdStr := fmt.Sprintf("%s %s && %s backup create -i %s --tag scheduled-$(date +\\%%Y\\%%m\\%%d\\%%H\\%%M\\%%S) >> %s 2>&1", cronExpression, rotateCmd, executable, instance.Id, logPath)
 
 	logging.Print(fmt.Sprintf("Scheduling backup with cron: %s", cronExpression))
 

--- a/docs/guide/backup.md
+++ b/docs/guide/backup.md
@@ -137,6 +137,8 @@ canasta backup schedule set -i myinstance "0 */6 * * *"
 
 If you reschedule with a new expression, the existing schedule is replaced. To schedule multiple times, combine them in one expression (e.g., `"0 0 * * 2,5"` for Tuesdays and Fridays).
 
+Backup output is logged to `backup.log` in the installation directory. The log is automatically rotated when it exceeds 10 MB — the previous log is kept as `backup.log.1`.
+
 To view the current schedule:
 
 ```bash

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -48,13 +48,16 @@ For more detailed debugging, you can access log files inside the container:
 
 | Log | Description | Command |
 |-----|-------------|---------|
-| MediaWiki debug | Application debug log (see below) | `docker compose exec web tail -f /var/log/mediawiki/debug.log` |
+| Exceptions | Uncaught exceptions (exists by default) | `docker compose exec web tail -f /var/log/mediawiki/exception.log` |
+| Errors | PHP errors (exists by default) | `docker compose exec web tail -f /var/log/mediawiki/error.log` |
+| Fatal errors | Fatal errors (exists by default) | `docker compose exec web tail -f /var/log/mediawiki/fatal.log` |
+| MediaWiki debug | Verbose debug log (opt-in, see below) | `docker compose exec web tail -f /var/log/mediawiki/debug.log` |
 | Apache error | PHP errors and Apache warnings | `docker compose exec web tail -f /var/log/apache2/error_log.current` |
 | Apache access | HTTP request log | `docker compose exec web tail -f /var/log/apache2/access_log.current` |
 
 ### Enabling the MediaWiki debug log
 
-The MediaWiki debug log is the most useful log for debugging application issues, but it requires explicit configuration. Add this to a settings file (e.g., `config/settings/global/Debug.php`):
+The exception, error, and fatal log files are created automatically. For more verbose debugging, enable the full debug log by adding this to a settings file (e.g., `config/settings/global/Debug.php`):
 
 ```php
 <?php

--- a/internal/orchestrators/compose/files/docker-compose.yml
+++ b/internal/orchestrators/compose/files/docker-compose.yml
@@ -5,18 +5,27 @@
 # THIS FILE SHOULD ONLY BE EDITED BY THE DEVELOPERS OF CANASTA
 #
 # Only edits to docker-compose.override.yml are officially supported by Canasta.
+
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "50m"
+    max-file: "3"
+
 services:
   db:
     image: docker.io/library/mysql:8.0
     command: >
       bash -c "
         chown -R mysql:mysql /var/log/mysql &&
+        (while sleep 86400; do LOG=/var/log/mysql/error.log; test -f $$LOG && test $$(wc -c <$$LOG) -gt 10485760 && mv $$LOG $$LOG.1 && mysqladmin -u root -p$$MYSQL_ROOT_PASSWORD flush-logs 2>/dev/null; done) &
         exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password --expire_logs_days=3 --secure-file-priv='' --log-error=/var/log/mysql/error.log
       "
     user: root  # Required so the entrypoint can chown /var/log/mysql before dropping to mysql
     cap_add:
       - SYS_NICE  # CAP_SYS_NICE, fix error mbind: Operation not permitted
     restart: unless-stopped
+    logging: *default-logging
     environment:
       - MYSQL_ROOT_HOST=%
       - MYSQL_ROOT_PASSWORD=${MYSQL_PASSWORD}
@@ -35,6 +44,7 @@ services:
   web:
     image: ${CANASTA_IMAGE:-ghcr.io/canastawiki/canasta:latest}
     restart: unless-stopped
+    logging: *default-logging
     extra_hosts:
       - "gateway.docker.internal:host-gateway"
     depends_on:
@@ -61,6 +71,7 @@ services:
     profiles:
       - elasticsearch
     restart: unless-stopped
+    logging: *default-logging
     environment:
       - discovery.type=single-node
       - bootstrap.memory_lock=true
@@ -81,6 +92,7 @@ services:
   caddy:
     image: docker.io/library/caddy:2.10.2-alpine
     restart: unless-stopped
+    logging: *default-logging
     ports:
       - "${HTTP_PORT:-80}:80"
       - "${HTTPS_PORT:-443}:443"
@@ -96,6 +108,7 @@ services:
   varnish:
     image: docker.io/library/varnish:7.0.2-alpine
     restart: unless-stopped
+    logging: *default-logging
     depends_on:
       web:
         condition: service_healthy
@@ -115,6 +128,7 @@ services:
     profiles:
       - observable
     restart: unless-stopped
+    logging: *default-logging
     environment:
       - discovery.type=single-node
       - bootstrap.memory_lock=true
@@ -134,6 +148,7 @@ services:
     profiles:
       - observable
     restart: unless-stopped
+    logging: *default-logging
     entrypoint: >
       bash -c "mkdir -p /usr/share/logstash/data/sincedb && exec /usr/local/bin/docker-entrypoint"
     depends_on:
@@ -152,6 +167,7 @@ services:
     profiles:
       - observable
     restart: unless-stopped
+    logging: *default-logging
     depends_on:
       - opensearch
     environment:
@@ -165,6 +181,7 @@ services:
     profiles:
       - observable
     restart: "no"
+    logging: *default-logging
     depends_on:
       - opensearch
       - opensearch-dashboards


### PR DESCRIPTION
## Summary

- Add `json-file` logging driver limits (`max-size: 50m`, `max-file: 3`) to all services in `docker-compose.yml` to prevent container stdout/stderr from filling disk. Backward-compatible since `json-file` is already Docker's default driver.
- Add MySQL error log rotation to the db service — a background loop checks daily and rotates at 10 MB using `mv` + `mysqladmin flush-logs` (the standard MySQL rotation approach). Caps at ~20 MB (current + one `.1` file).
- Add `backup.log` rotation (>10 MB) to scheduled backup crontab entries.
- Update observability, troubleshooting, and backup docs to reflect the new default MediaWiki error logging in CanastaBase and log rotation.

Companion PR: CanastaWiki/CanastaBase#108 (default MediaWiki error logging, log rotation script)

## Test plan

- [x] `canasta create`, inspect installed `docker-compose.yml` for `logging:` stanzas on all services
- [x] Run `canasta upgrade` on existing instance, verify `docker-compose.yml` is updated with logging config
- [x] `canasta backup schedule set`, inspect generated crontab entry for rotation logic before the backup command
- [x] Create >10 MB fake `backup.log`, run rotation command, verify `backup.log.1` created
- [x] Verify MySQL error log rotation loop is running: `docker compose exec db ps aux | grep sleep`
- [x] Manually trigger rotation on >10 MB error.log, verify `error.log.1` created and fresh `error.log` reopened

Closes CanastaWiki/Canasta#279
Refs CanastaWiki/CanastaBase#100