### PR TITLE
Remove unnecessary --no-defaults from mysqldump command

### DIFF
--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -111,7 +111,7 @@ func exportDatabase(instance config.Installation, wikiID, outputPath string) err
 	tempFile := fmt.Sprintf("/tmp/%s.sql", wikiID)
 
 	// Run mysqldump inside the db container (no --databases flag to avoid USE statements)
-	dumpCmd := fmt.Sprintf("mysqldump --no-defaults -u root -p'%s' %s > %s", escapedPassword, wikiID, tempFile)
+	dumpCmd := fmt.Sprintf("mysqldump -u root -p'%s' %s > %s", escapedPassword, wikiID, tempFile)
 	output, err := orch.ExecWithError(instance.Path, "db", dumpCmd)
 	if err != nil {
 		return fmt.Errorf("failed to export database: %s", output)


### PR DESCRIPTION
## Summary

- Remove the `--no-defaults` flag from the `mysqldump` command in `export.go`
- The embedded `my.cnf` (since e380b79) only contains a `[mysql]` section, which `mysqldump` does not read, making the flag unnecessary
- The `mysql` client commands in `orchestrator.go` intentionally keep `--no-defaults` since the `[mysql]` section applies to them and `my.cnf` is user-editable

Fixes #373