### PR TITLE
Update Kubernetes docs to reflect backup support

### DIFF
--- a/docs/guide/backup.md
+++ b/docs/guide/backup.md
@@ -41,6 +41,8 @@ RESTIC_PASSWORD=your-restic-password
 
 See the [restic documentation](https://restic.readthedocs.io/en/latest/030_preparing_a_new_repo.html) for the full list of supported backends and their URL formats.
 
+> **Kubernetes installations:** Only remote backup repositories (S3, SFTP, etc.) are supported. Local filesystem paths cannot be used as backup targets with the Kubernetes orchestrator.
+
 ### 2. Initialize the repository
 
 This must be done once before creating any backups:

--- a/docs/guide/orchestrators.md
+++ b/docs/guide/orchestrators.md
@@ -242,9 +242,6 @@ The following features are not yet available for Kubernetes installations:
 | Feature | Status | Notes |
 |---------|--------|-------|
 | Development mode (Xdebug) | Not supported | Use Docker Compose for Xdebug debugging |
-| Backup create | Not supported | Use `kubectl exec` to run mysqldump manually |
-| Backup restore | Not supported | |
-| Backup scheduling | Not supported | Use a Kubernetes CronJob instead |
 | Remote/multi-node clusters | Not supported | Manifests use `hostPath` volumes |
 | Horizontal scaling | Limited | HPA is defined but not tested with the current volume setup |
 


### PR DESCRIPTION
## Summary

- Remove backup create and backup restore from the Kubernetes limitations table since both are fully implemented
- Remove stale `mysqldump` reference from the table
- Add a note to the backup guide that Kubernetes installations require a remote backup repository (S3, SFTP, etc.)

Closes #376