### PR TITLE
Add config unset and maintenance exec commands

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -89,6 +89,7 @@ To change the domain, edit config/wikis.yaml instead.`,
 
 	configCmd.AddCommand(getCmdCreate())
 	configCmd.AddCommand(setCmdCreate())
+	configCmd.AddCommand(unsetCmdCreate())
 
 	return configCmd
 }

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -21,12 +21,16 @@ import (
 type sideEffect struct {
 	validate func(instance config.Installation, value string) error
 	apply    func(instance config.Installation, value string) error
+	unapply  func(instance config.Installation) error
 }
 
 var sideEffects = map[string]sideEffect{
 	"HTTPS_PORT": {
 		validate: validatePort,
 		apply:    applyHTTPSPortChange,
+		unapply: func(inst config.Installation) error {
+			return applyHTTPSPortChange(inst, "443")
+		},
 	},
 	"HTTP_PORT": {
 		validate: validatePort,

--- a/cmd/config/unset.go
+++ b/cmd/config/unset.go
@@ -1,0 +1,95 @@
+package config
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
+	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
+)
+
+func unsetCmdCreate() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unset KEY [KEY ...]",
+		Short: "Remove a configuration setting",
+		Long: `Remove one or more configuration keys from the .env file of a Canasta installation.
+
+Each argument is a key name to remove. Multiple keys can be removed in a single
+invocation and only one restart is performed.
+
+If a key has side effects (e.g., HTTPS_PORT), they are reverted before the key
+is removed. The instance is then restarted unless --no-restart is specified.`,
+		Example: `  canasta config unset CADDY_AUTO_HTTPS -i myinstance
+  canasta config unset HTTPS_PORT -i myinstance
+  canasta config unset HTTP_PORT HTTPS_PORT -i myinstance
+  canasta config unset CANASTA_ENABLE_OBSERVABILITY -i myinstance --no-restart`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			envPath := filepath.Join(instance.Path, ".env")
+			envVars, err := canasta.GetEnvVariable(envPath)
+			if err != nil {
+				return fmt.Errorf("failed to read .env: %w", err)
+			}
+
+			// Resolve and validate all keys exist
+			keys := make([]string, 0, len(args))
+			for _, arg := range args {
+				key := resolveKey(envVars, arg)
+				if _, ok := envVars[key]; !ok {
+					return fmt.Errorf("key %q is not set", key)
+				}
+				keys = append(keys, key)
+			}
+
+			// Run unapply side effects before removing keys
+			for _, key := range keys {
+				if se, ok := sideEffects[key]; ok && se.unapply != nil {
+					if err := se.unapply(instance); err != nil {
+						return fmt.Errorf("unapply side effect for %s failed: %w", key, err)
+					}
+				}
+			}
+
+			// Remove keys from .env
+			portKeyChanged := false
+			for _, key := range keys {
+				if err := canasta.DeleteEnvVariable(envPath, key); err != nil {
+					return fmt.Errorf("failed to remove %s: %w", key, err)
+				}
+				logging.Print(fmt.Sprintf("Removed %s\n", key))
+				if portKeys[key] {
+					portKeyChanged = true
+				}
+			}
+
+			if noRestart {
+				fmt.Println("Settings removed. Restart skipped (--no-restart).")
+				return nil
+			}
+
+			// Restart: UpdateConfig → Stop → (recreate kind cluster if port key) → Start
+			fmt.Println("Applying configuration and restarting...")
+			if err := orch.UpdateConfig(instance.Path); err != nil {
+				return fmt.Errorf("failed to update config: %w", err)
+			}
+			if err := orch.Stop(instance); err != nil {
+				return fmt.Errorf("failed to stop instance: %w", err)
+			}
+			if instance.KindCluster != "" && portKeyChanged {
+				if err := recreateKindCluster(instance); err != nil {
+					return err
+				}
+			}
+			if err := orch.Start(instance); err != nil {
+				return fmt.Errorf("failed to start instance: %w", err)
+			}
+			fmt.Println("Done.")
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&noRestart, "no-restart", false, "Remove the setting without restarting the instance")
+	return cmd
+}

--- a/cmd/maintenanceUpdate/exec.go
+++ b/cmd/maintenanceUpdate/exec.go
@@ -1,0 +1,94 @@
+package maintenance
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
+	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
+)
+
+func execCmdCreate() *cobra.Command {
+	var service string
+
+	cmd := &cobra.Command{
+		Use:   "exec [-- command ...]",
+		Short: "Execute a command in a running container",
+		Long: `Execute a command or open an interactive shell in a running container
+of a Canasta installation.
+
+With no arguments and no --service flag, lists the running services.
+With --service (or -s) and no command, opens an interactive bash shell.
+With --service and a command after --, runs that command.
+
+The default service is "web" (the MediaWiki container).`,
+		Example: `  # List running services
+  canasta maintenance exec -i myinstance
+
+  # Open a shell in the web container
+  canasta maintenance exec -i myinstance -s web
+
+  # Run a command in the web container
+  canasta maintenance exec -i myinstance -s web -- ls /var/www
+
+  # Default service is "web", so this also works
+  canasta maintenance exec -i myinstance -- php -v`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			instance, err = canasta.CheckCanastaId(instance)
+			return err
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			orch, err := orchestrators.New(instance.Orchestrator)
+			if err != nil {
+				return err
+			}
+
+			// No service flag and no args: list services
+			if service == "" && len(args) == 0 {
+				services, err := orch.ListServices(instance)
+				if err != nil {
+					return err
+				}
+				if len(services) == 0 {
+					fmt.Println("No running services found.")
+					return nil
+				}
+				sort.Strings(services)
+				fmt.Println("Running services:")
+				for _, s := range services {
+					fmt.Printf("  %s\n", s)
+				}
+				return nil
+			}
+
+			// Default service to "web" if not specified
+			if service == "" {
+				service = "web"
+			}
+
+			// Ensure containers are running
+			if err := orch.CheckRunningStatus(instance); err != nil {
+				return fmt.Errorf("containers are not running: %w", err)
+			}
+
+			// Warning message
+			fmt.Println("WARNING: You are about to execute a command directly inside a container.")
+			fmt.Println("Changes made here are not managed by the Canasta CLI and may not persist")
+			fmt.Println("across restarts.")
+			fmt.Println()
+
+			// Default command to bash shell
+			command := args
+			if len(command) == 0 {
+				command = []string{"/bin/bash"}
+			}
+
+			return orch.ExecInteractive(instance, service, command)
+		},
+	}
+
+	cmd.Flags().StringVarP(&service, "service", "s", "", "Service name (default: web)")
+	return cmd
+}

--- a/cmd/maintenanceUpdate/extension_test.go
+++ b/cmd/maintenanceUpdate/extension_test.go
@@ -77,6 +77,12 @@ func (m *extMockOrchestrator) MigrateConfig(installPath string, dryRun bool) (bo
 	return false, nil
 }
 
+func (m *extMockOrchestrator) ListServices(inst config.Installation) ([]string, error) {
+	return nil, nil
+}
+func (m *extMockOrchestrator) ExecInteractive(inst config.Installation, service string, command []string) error {
+	return nil
+}
 func (m *extMockOrchestrator) Name() string              { return "Mock" }
 func (m *extMockOrchestrator) SupportsDevMode() bool     { return true }
 func (m *extMockOrchestrator) SupportsImagePull() bool   { return true }

--- a/cmd/maintenanceUpdate/maintenance.go
+++ b/cmd/maintenanceUpdate/maintenance.go
@@ -33,6 +33,7 @@ arbitrary core maintenance scripts, or run extension-specific maintenance script
 	maintenanceCmd.AddCommand(updateCmdCreate())
 	maintenanceCmd.AddCommand(scriptCmdCreate())
 	maintenanceCmd.AddCommand(extensionCmdCreate())
+	maintenanceCmd.AddCommand(execCmdCreate())
 
 	maintenanceCmd.PersistentFlags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
 	maintenanceCmd.PersistentFlags().StringVarP(&wiki, "wiki", "w", "", "Wiki ID to run maintenance on")

--- a/cmd/maintenanceUpdate/maintenance_test.go
+++ b/cmd/maintenanceUpdate/maintenance_test.go
@@ -19,7 +19,7 @@ func findSubcommand(parent interface{ Commands() []*cobra.Command }, name string
 func TestMaintenanceSubcommands(t *testing.T) {
 	cmd := NewCmdCreate()
 
-	expected := []string{"update", "script", "extension"}
+	expected := []string{"update", "script", "extension", "exec"}
 	for _, name := range expected {
 		if findSubcommand(cmd, name) == nil {
 			t.Errorf("expected subcommand %q not found", name)

--- a/docs/guide/general-concepts.md
+++ b/docs/guide/general-concepts.md
@@ -455,6 +455,12 @@ For an existing installation:
 canasta config set -i myinstance CADDY_AUTO_HTTPS=off
 ```
 
+To re-enable automatic HTTPS (e.g., if you move the wiki off the reverse proxy):
+
+```bash
+canasta config unset -i myinstance CADDY_AUTO_HTTPS
+```
+
 ---
 
 ## Running on non-standard ports
@@ -479,6 +485,12 @@ Use `canasta config set`. Multiple settings can be changed in a single command. 
 
 ```bash
 canasta config set -i myinstance HTTP_PORT=8080 HTTPS_PORT=8443
+```
+
+To revert to the default ports (80/443), remove the overrides:
+
+```bash
+canasta config unset -i myinstance HTTP_PORT HTTPS_PORT
 ```
 
 ### Example: multiple installations on the same machine

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -76,30 +76,43 @@ canasta restart -i myinstance
 
 To connect to the MySQL database directly:
 ```bash
-cd /path/to/installation
-docker compose exec db mysql -u root -p
+canasta maintenance exec -i myinstance -s db -- mysql -u root -p
 ```
-Enter the root database password from your `.env` file when prompted.
+Enter the root database password from your `.env` file (`MYSQL_PASSWORD`) when prompted.
 
 ---
 
 ## Running commands inside containers
 
-To run arbitrary commands inside the web container:
+Use `canasta maintenance exec` to run commands inside a running container. This works with both Docker Compose and Kubernetes installations.
+
+To list running services:
 ```bash
-cd /path/to/installation
-docker compose exec web <command>
+canasta maintenance exec -i myinstance
 ```
 
-For example, to check PHP version:
+To get a shell inside the web container:
 ```bash
-docker compose exec web php -v
+canasta maintenance exec -i myinstance -s web
 ```
 
-To get a shell inside the container:
+To run a specific command (the default service is `web`):
 ```bash
-docker compose exec web bash
+canasta maintenance exec -i myinstance -- php -v
 ```
+
+To run a command in a different container:
+```bash
+canasta maintenance exec -i myinstance -s db -- mysql -u root -p
+```
+
+!!! warning "Container changes are ephemeral"
+    Files created or modified directly inside a container are **not** persisted
+    across restarts. Only mounted volumes (`.env`, `config/`, `extensions/`,
+    `skins/`, `images/`) survive a `canasta stop`/`canasta start` cycle.
+    Use `canasta maintenance exec` for debugging and inspection, not for
+    permanent configuration changes — use `canasta config set`, settings
+    files, or `wikis.yaml` instead.
 
 ---
 

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -741,6 +741,31 @@ func SavePasswordToFile(directory, filename, password string) error {
 }
 
 
+// DeleteEnvVariable removes a key from the .env file.
+// Returns an error if the key is not found.
+func DeleteEnvVariable(envPath, key string) error {
+	file, err := os.ReadFile(envPath)
+	if err != nil {
+		return err
+	}
+	data := string(file)
+	list := strings.Split(data, "\n")
+	found := false
+	result := make([]string, 0, len(list))
+	for _, line := range list {
+		if strings.HasPrefix(line, key+"=") {
+			found = true
+			continue
+		}
+		result = append(result, line)
+	}
+	if !found {
+		return fmt.Errorf("key %q not found in %s", key, envPath)
+	}
+	lines := strings.Join(result, "\n")
+	return ioutil.WriteFile(envPath, []byte(lines), 0644)
+}
+
 // Make changes to the .env file at the installation directory
 // If the key exists, it updates the value; if not, it appends the key=value pair
 func SaveEnvVariable(envPath, key, value string) error {

--- a/internal/orchestrators/orchestrator.go
+++ b/internal/orchestrators/orchestrator.go
@@ -41,6 +41,13 @@ type Orchestrator interface {
 	// "canasta upgrade". Returns true if any changes were made.
 	MigrateConfig(installPath string, dryRun bool) (bool, error)
 
+	// ListServices returns the names of running services for the installation.
+	ListServices(instance config.Installation) ([]string, error)
+
+	// ExecInteractive runs an interactive command in a service container with
+	// stdin/stdout/stderr attached. If command is nil, defaults to a shell.
+	ExecInteractive(instance config.Installation, service string, command []string) error
+
 	// Name returns a human-readable name for the orchestrator (e.g. "Docker Compose").
 	Name() string
 

--- a/internal/orchestrators/orchestrator_test.go
+++ b/internal/orchestrators/orchestrator_test.go
@@ -90,6 +90,12 @@ func (m *mockOrchestrator) MigrateConfig(installPath string, dryRun bool) (bool,
 	return false, nil
 }
 
+func (m *mockOrchestrator) ListServices(instance config.Installation) ([]string, error) {
+	return nil, nil
+}
+func (m *mockOrchestrator) ExecInteractive(instance config.Installation, service string, command []string) error {
+	return nil
+}
 func (m *mockOrchestrator) Name() string              { return "Mock" }
 func (m *mockOrchestrator) SupportsDevMode() bool     { return true }
 func (m *mockOrchestrator) SupportsImagePull() bool   { return true }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,11 +87,17 @@ nav:
       - list: cli/canasta_skin_list.md
       - enable: cli/canasta_skin_enable.md
       - disable: cli/canasta_skin_disable.md
+    - config:
+      - Overview: cli/canasta_config.md
+      - get: cli/canasta_config_get.md
+      - set: cli/canasta_config_set.md
+      - unset: cli/canasta_config_unset.md
     - maintenance:
       - Overview: cli/canasta_maintenance.md
       - update: cli/canasta_maintenance_update.md
       - script: cli/canasta_maintenance_script.md
       - extension: cli/canasta_maintenance_extension.md
+      - exec: cli/canasta_maintenance_exec.md
     - backup:
       - Overview: cli/canasta_backup.md
       - init: cli/canasta_backup_init.md


### PR DESCRIPTION
## Summary

- Add `canasta config unset KEY [KEY ...]` to remove configuration keys from `.env`, with proper side-effect reversal (e.g., unsetting `HTTPS_PORT` reverts wiki URLs to port 443) and restart handling
- Add `canasta maintenance exec` to list running services, open interactive shells, or run arbitrary commands in containers
- Add `config` section and `maintenance exec` entry to mkdocs nav

## Details

### `config unset` (#378)
- New `cmd/config/unset.go` subcommand with `--no-restart` flag
- Added `unapply` field to `sideEffect` struct in `set.go` for reverting side effects on key removal
- Added `DeleteEnvVariable()` to `internal/canasta/canasta.go`

### `maintenance exec` (#379)
- New `cmd/maintenanceUpdate/exec.go` with three modes: list services (no args), interactive shell (`-s web`), run command (`-s web -- ls /var/www`)
- Added `ListServices()` and `ExecInteractive()` to the `Orchestrator` interface with implementations for both Docker Compose and Kubernetes
- Prints a warning before executing to remind users that container changes are not managed by the CLI

### Documentation (#380)
- Updated `mkdocs.yml` nav with `config` command group (get, set, unset) and `maintenance exec`
- Updated guide pages (troubleshooting.md, general-concepts.md) to reference new commands
- CLI reference pages are auto-generated by `tools/docgen`

## Test plan

- [x] `go build ./...` compiles without errors
- [x] `go test ./...` passes (including updated mock orchestrators)
- [x] Manual (Compose): `canasta config set CADDY_AUTO_HTTPS=off` then `canasta config unset CADDY_AUTO_HTTPS` — key removed
- [x] Manual (Compose): `canasta config set HTTPS_PORT=8443` then `canasta config unset HTTPS_PORT` — port reverts to 443 in wikis.yaml, MW_SITE_SERVER, MW_SITE_FQDN
- [x] Manual (Compose): `canasta maintenance exec` — lists services (caddy, db, varnish, web)
- [x] Manual (Compose): `canasta maintenance exec -s web -- php -v` — runs command with warning
- [x] Manual (K8s): `canasta config set CADDY_AUTO_HTTPS=off` then `canasta config unset CADDY_AUTO_HTTPS` — key removed
- [x] Manual (K8s): `canasta config set HTTPS_PORT=9443` then `canasta config unset HTTPS_PORT` — port reverts to 443 in wikis.yaml, MW_SITE_SERVER, MW_SITE_FQDN
- [x] Manual (K8s): `canasta maintenance exec` — lists services (caddy, db, varnish, web)
- [x] Manual (K8s): `canasta maintenance exec -s web -- php -v` — runs command with warning
- [x] Manual: `canasta config unset NONEXISTENT_KEY` — errors with "key not set"

Closes #378
Closes #379
Closes #380