### PR TITLE
Make -a/--admin flag optional with default WikiSysop

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ canasta create [flags]
 - `-w, --wiki`: ID of the wiki.
 - `-t, --site-name`: Display name of the wiki (optional, defaults to wiki ID).
 - `-n, --domain-name`: Domain name (default: "localhost").
-- `-a, --admin`: Initial wiki admin username (required).
+- `-a, --admin`: Initial wiki admin username (default: "WikiSysop").
 - `-s, --password`: Initial wiki admin password (if not provided, auto-generates and saves to config/admin-password_{wikiid}).
 - `-f, --yamlfile`: Initial wiki yaml file for wiki farm setup.
 - `-k, --keep-config`: Keep the config files on installation failure.
@@ -80,7 +80,7 @@ canasta add [flags]
 - `-i, --id`: Canasta instance ID (required).
 - `-o, --orchestrator`: Orchestrator to use for installation (default: "compose").
 - `-d, --database`: Path to the existing database dump.
-- `-a, --admin`: Admin name of the new wiki (required).
+- `-a, --admin`: Admin name of the new wiki (default: "WikiSysop").
 - `-s, --password`: Admin password for the new wiki (if not provided, auto-generates and saves to config/admin-password_{wikiid}).
 - `--wikidbuser`: The username of the wiki database user (default: "root").
 

--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -79,10 +79,10 @@ The new wiki is registered in wikis.yaml, the Caddyfile is regenerated,
 and the MediaWiki installer runs for the new wiki. You can also import
 an existing database dump instead of running the installer.`,
 		Example: `  # Add a wiki accessible at localhost/docs
-  canasta add -i myinstance -w docs -u localhost/docs -a admin
+  canasta add -i myinstance -w docs -u localhost/docs
 
   # Add a wiki on a different domain
-  canasta add -i myinstance -w blog -u blog.example.com -a admin
+  canasta add -i myinstance -w blog -u blog.example.com
 
   # Add a wiki with an existing database dump
   canasta add -i myinstance -w docs -u localhost/docs -d /path/to/dump.sql`,
@@ -111,11 +111,6 @@ an existing database dump instead of running the installer.`,
 				if err := canasta.ValidateDatabasePath(databasePath); err != nil {
 					return err
 				}
-			}
-
-			// Validate --admin is required when --database is not provided
-			if databasePath == "" && admin == "" {
-				return fmt.Errorf("--admin flag is required when --database is not provided")
 			}
 
 			// Generate admin password only if not importing and admin is provided
@@ -148,11 +143,11 @@ an existing database dump instead of running the installer.`,
 	addCmd.Flags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
 	addCmd.Flags().StringVarP(&databasePath, "database", "d", "", "Path to existing database dump (.sql or .sql.gz) to import instead of running install.php")
 	addCmd.Flags().StringVarP(&wikiSettingsPath, "wiki-settings", "l", "", "Path to per-wiki settings file to copy to config/settings/wikis/<wiki_id>/ (filename preserved)")
-	addCmd.Flags().StringVarP(&admin, "admin", "a", "", "Admin name of the new wiki")
+	addCmd.Flags().StringVarP(&admin, "admin", "a", "WikiSysop", "Admin name of the new wiki (default: \"WikiSysop\")")
 	addCmd.Flags().StringVarP(&adminPassword, "password", "s", "", "Admin password for the new wiki (if not provided, auto-generates and saves to config/admin-password_{wikiid})")
 	addCmd.Flags().StringVar(&wikidbuser, "wikidbuser", "root", "The username of the wiki database user (default: \"root\")")
 
-	// Mark required flags (admin is validated at runtime based on whether --database is provided)
+	// Mark required flags
 	_ = addCmd.MarkFlagRequired("wiki")
 	_ = addCmd.MarkFlagRequired("url")
 

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -51,7 +51,7 @@ files, starts the containers, and runs the MediaWiki installer. You can
 optionally import an existing database dump instead of running the installer.
 After creating, use 'canasta devmode enable' to enable development mode.`,
 		Example: `  # Create a basic single-wiki installation
-  canasta create -i myinstance -w main -a admin -n example.com
+  canasta create -i myinstance -w main -n example.com
 
   # Create with an existing database dump
   canasta create -i myinstance -w main -d /path/to/dump.sql -n example.com`,
@@ -96,11 +96,6 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
 			// Resolve relative database path to absolute (relative to working directory)
 			if databasePath != "" && !filepath.IsAbs(databasePath) {
 				databasePath = filepath.Join(workingDir, databasePath)
-			}
-
-			// Validate --admin is required when --database is not provided
-			if databasePath == "" && canastaInfo.AdminName == "" {
-				return fmt.Errorf("--admin flag is required when --database is not provided")
 			}
 
 			// Always generate database passwords
@@ -174,7 +169,7 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
 	createCmd.Flags().StringVarP(&wikiID, "wiki", "w", "", "ID of the wiki")
 	createCmd.Flags().StringVarP(&siteName, "site-name", "t", "", "Display name of the wiki (optional, defaults to wiki ID)")
 	createCmd.Flags().StringVarP(&domain, "domain-name", "n", "localhost", "Domain name")
-	createCmd.Flags().StringVarP(&canastaInfo.AdminName, "admin", "a", "", "Initial wiki admin username")
+	createCmd.Flags().StringVarP(&canastaInfo.AdminName, "admin", "a", "WikiSysop", "Initial wiki admin username (default: \"WikiSysop\")")
 	createCmd.Flags().StringVarP(&canastaInfo.AdminPassword, "password", "s", "", "Initial wiki admin password (if not provided, auto-generates and saves to config/admin-password_{wikiid})")
 	createCmd.Flags().StringVarP(&yamlPath, "yamlfile", "f", "", "Initial wiki yaml file")
 	createCmd.Flags().BoolVarP(&keepConfig, "keep-config", "k", false, "Keep the config files on installation failure")

--- a/docs/guide/best-practices.md
+++ b/docs/guide/best-practices.md
@@ -25,7 +25,7 @@ This page covers security considerations and best practices for managing Canasta
 - Ensure proper file permissions on the installation directory to restrict access to these files
 - Consider using environment variables when passing passwords on the command line to avoid exposing them in shell history:
   ```bash
-  canasta create -i myinstance -w main -a admin --rootdbpass "$ROOT_DB_PASS"
+  canasta create -i myinstance -w main --rootdbpass "$ROOT_DB_PASS"
   ```
 
 ### Docker access

--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -116,7 +116,7 @@ To test changes to CanastaBase or Canasta before they are published, use `--buil
 #   ├── Canasta/       (required)
 #   └── CanastaBase/   (optional — if present, built first)
 
-canasta create -i test-instance -w mywiki -n localhost -a admin \
+canasta create -i test-instance -w mywiki -n localhost \
   --build-from ~/canasta-repos
 ```
 

--- a/docs/guide/devmode.md
+++ b/docs/guide/devmode.md
@@ -38,8 +38,7 @@ First create a Canasta installation, then enable dev mode:
 
 ```bash
 # Create an installation
-canasta create -i mydev -w mywiki -n localhost -a admin
-
+canasta create -i mydev -w mywiki -n localhost
 # Enable development mode
 canasta devmode enable -i mydev
 ```
@@ -47,7 +46,7 @@ canasta devmode enable -i mydev
 You can also specify a custom Canasta image when creating. Use `--canasta-image` to control which image to use (see [Custom Canasta images](general-concepts.md#custom-canasta-images)):
 
 ```bash
-canasta create -i mydev -w mywiki -n localhost -a admin --canasta-image ghcr.io/canastawiki/canasta:dev-branch
+canasta create -i mydev -w mywiki -n localhost--canasta-image ghcr.io/canastawiki/canasta:dev-branch
 canasta devmode enable -i mydev
 ```
 
@@ -65,7 +64,7 @@ Enabling dev mode will:
 For testing changes to Canasta or CanastaBase before they're published, you can build from local source repositories:
 
 ```bash
-canasta create -i mydev -w mywiki -n localhost -a admin --build-from ~/canasta-repos
+canasta create -i mydev -w mywiki -n localhost--build-from ~/canasta-repos
 ```
 
 The `--build-from` flag expects a directory containing:
@@ -82,7 +81,7 @@ This will:
 You can enable dev mode after building from source:
 
 ```bash
-canasta create -i mydev -w mywiki -n localhost -a admin --build-from ~/canasta-repos
+canasta create -i mydev -w mywiki -n localhost--build-from ~/canasta-repos
 canasta devmode enable -i mydev
 ```
 

--- a/docs/guide/extensions-and-skins.md
+++ b/docs/guide/extensions-and-skins.md
@@ -249,7 +249,7 @@ CANASTA_ENABLE_ELASTICSEARCH=true
 ```
 
 ```bash
-canasta create -i myinstance -w mywiki -a admin -e custom.env
+canasta create -i myinstance -w mywiki -e custom.env
 ```
 
 For an existing installation:

--- a/docs/guide/general-concepts.md
+++ b/docs/guide/general-concepts.md
@@ -26,8 +26,7 @@ This page covers foundational concepts that apply to all Canasta installations, 
 Every Canasta installation has an **installation ID** — a name you choose when creating it with the `-i` flag:
 
 ```bash
-canasta create -i myinstance -w main -n localhost -a admin
-```
+canasta create -i myinstance -w main -n localhost```
 
 The installation ID is used to refer to the installation in all subsequent commands:
 
@@ -47,8 +46,7 @@ Installation IDs must start and end with an alphanumeric character and may conta
 Every wiki in a Canasta installation has a **wiki ID** — a short identifier set with the `-w` flag when creating or adding a wiki:
 
 ```bash
-canasta create -i myinstance -w main -n localhost -a admin
-```
+canasta create -i myinstance -w main -n localhost```
 
 Even a single-wiki installation requires a wiki ID. The wiki ID is used as:
 
@@ -141,7 +139,7 @@ The `url` field uses `domain/path` format without the protocol. The Caddyfile is
 The `name` field in `wikis.yaml` controls the wiki's display name (`$wgSitename` in MediaWiki). It defaults to the wiki ID if not set. The name is initially set with the `-t` (`--site-name`) flag of `canasta create` or `canasta add`:
 
 ```bash
-canasta create -i myinstance -w docs -n example.com -a admin -t "Project Documentation"
+canasta create -i myinstance -w docs -n example.com-t "Project Documentation"
 ```
 
 To change it later, edit the `name` field directly in `config/wikis.yaml`:
@@ -266,22 +264,19 @@ Use this option for fully private wikis where the logo should not be visible to 
 To migrate an existing MediaWiki installation into Canasta, prepare a database dump (`.sql` or `.sql.gz` file) and pass it with the `-d` flag:
 
 ```bash
-canasta create -i myinstance -w main -n localhost -d ./backup.sql.gz -a admin
-```
+canasta create -i myinstance -w main -n localhost -d ./backup.sql.gz```
 
 You can also provide a per-wiki settings file and an environment file with password overrides:
 
 ```bash
-canasta create -i myinstance -w main -n localhost -d ./backup.sql.gz -l ./my-settings.php -e ./custom.env -a admin
-```
+canasta create -i myinstance -w main -n localhost -d ./backup.sql.gz -l ./my-settings.php -e ./custom.env```
 
 The `-l` flag (`--wiki-settings`) copies the specified file to `config/settings/wikis/{wiki-id}/`, preserving the filename. Use it to bring over custom settings from an existing wiki.
 
 To import a database into an additional wiki in an existing installation, use `canasta add` with the `--database` flag:
 
 ```bash
-canasta add -i myinstance -w docs -u example.com/docs -d ./docs-backup.sql.gz -a admin
-```
+canasta add -i myinstance -w docs -u example.com/docs -d ./docs-backup.sql.gz```
 
 See the [CLI Reference](../cli/canasta_create.md) for the full list of flags.
 
@@ -407,7 +402,7 @@ By default, `canasta create` uses the latest published Canasta image (`ghcr.io/c
 Specifies a full image reference to use instead of the default:
 
 ```bash
-canasta create -i myinstance -w mywiki -n localhost -a admin \
+canasta create -i myinstance -w mywiki -n localhost\
   --canasta-image ghcr.io/canastawiki/canasta:version-3.0.7
 ```
 
@@ -444,7 +439,7 @@ CADDY_AUTO_HTTPS=off
 ```
 
 ```bash
-canasta create -i myinstance -w main -n example.com -a admin -e custom.env
+canasta create -i myinstance -w main -n example.com-e custom.env
 ```
 
 This generates a Caddyfile with `http://` site addresses so Caddy listens on port 80 only.
@@ -470,7 +465,7 @@ HTTPS_PORT=8443
 ```
 
 ```bash
-canasta create -i staging -w testwiki -n localhost:8443 -a admin -e custom.env
+canasta create -i staging -w testwiki -n localhost:8443-e custom.env
 ```
 
 ### Existing installation
@@ -487,13 +482,12 @@ Each installation must use unique ports. This applies to both Docker Compose and
 
 ```bash
 # Docker Compose installation on default ports (80/443)
-canasta create -i production -w mainwiki -n localhost -a admin
-
+canasta create -i production -w mainwiki -n localhost
 # Docker Compose installation on custom ports
-canasta create -i staging -w testwiki -n localhost:8443 -a admin -e custom.env
+canasta create -i staging -w testwiki -n localhost:8443-e custom.env
 
 # Local Kubernetes installation on different custom ports
-canasta create -o k8s --create-cluster -i dev-k8s -w devwiki -n localhost:9443 -a admin -e another.env
+canasta create -o k8s --create-cluster -i dev-k8s -w devwiki -n localhost:9443-e another.env
 ```
 
 Access them at `https://localhost`, `https://localhost:8443`, and `https://localhost:9443`.

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -30,7 +30,7 @@ Create an `.env` file with observability enabled, then pass it to `canasta creat
 
 ```bash
 echo "CANASTA_ENABLE_OBSERVABILITY=true" > my.env
-canasta create -i myinstance -w mywiki -a admin -e my.env
+canasta create -i myinstance -w mywiki -e my.env
 ```
 
 ### Existing installations

--- a/docs/guide/orchestrators.md
+++ b/docs/guide/orchestrators.md
@@ -28,7 +28,7 @@ Both orchestrators share the same CLI commands (`canasta start`, `canasta stop`,
 Docker Compose is the default orchestrator. No `-o` flag is needed:
 
 ```bash
-canasta create -i myinstance -w main -a admin -n localhost
+canasta create -i myinstance -w main -n localhost
 ```
 
 This creates a standard Docker Compose stack with containers for the web server, database, Caddy reverse proxy, and other services. All data is stored on the host in the installation directory.
@@ -42,7 +42,7 @@ Docker Compose automatically merges `docker-compose.override.yml` with the main 
 You can provide an override file at creation time with the `-r` flag:
 
 ```bash
-canasta create -i myinstance -w main -a admin -n localhost -r my-overrides.yml
+canasta create -i myinstance -w main -n localhost -r my-overrides.yml
 ```
 
 Or create/edit the file directly in the installation directory at any time.
@@ -121,7 +121,7 @@ You need `kubectl` installed and configured to connect to your cluster (`kubectl
 Use `-o k8s` with the `--create-cluster` flag:
 
 ```bash
-canasta create -o k8s --create-cluster -i my-wiki -w main -a admin -n localhost
+canasta create -o k8s --create-cluster -i my-wiki -w main -n localhost
 ```
 
 This automatically:
@@ -195,7 +195,7 @@ HTTPS_PORT=8443
 ```
 
 ```bash
-canasta create -o k8s --create-cluster -i my-wiki -w main -a admin -n localhost:8443 -e custom.env
+canasta create -o k8s --create-cluster -i my-wiki -w main -n localhost:8443 -e custom.env
 ```
 
 Each installation must use unique ports. If two installations attempt to bind the same host port, kind will fail with a Docker port-binding error. See [Running on non-standard ports](general-concepts.md#running-on-non-standard-ports) for more details.
@@ -207,7 +207,7 @@ Each installation must use unique ports. If two installations attempt to bind th
 To test a locally built Canasta image with a managed K8s cluster, use `--build-from`:
 
 ```bash
-canasta create -o k8s --create-cluster --build-from /path/to/workspace -i my-wiki -w main -a admin -n localhost
+canasta create -o k8s --create-cluster --build-from /path/to/workspace -i my-wiki -w main -n localhost
 ```
 
 When `--create-cluster` is combined with `--build-from`, the CLI loads the built image directly into the kind cluster using `kind load docker-image`. No container registry is needed.
@@ -221,7 +221,7 @@ Without `--create-cluster`, the CLI pushes the image to a registry (default `loc
 To deploy to a pre-existing Kubernetes cluster without `--create-cluster`:
 
 ```bash
-canasta create -o k8s -i my-wiki -w main -a admin -n my-wiki.example.com
+canasta create -o k8s -i my-wiki -w main -n my-wiki.example.com
 ```
 
 This mode is **experimental** and has significant limitations:

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -79,7 +79,7 @@ mysqldump -u root -p wikidb > wikidb.sql
 ### 2. Create a new Canasta installation with the database dump
 
 ```bash
-canasta create -i myinstance -w mywiki -a admin -n example.com -d wikidb.sql
+canasta create -i myinstance -w mywiki -n example.com -d wikidb.sql
 ```
 
 The `-d` flag imports the SQL dump during installation. The `admin` account will be created only if it does not already exist in the imported database.

--- a/docs/guide/wiki-farms.md
+++ b/docs/guide/wiki-farms.md
@@ -40,14 +40,11 @@ Multiple wikis share the same domain, distinguished by URL path. The first wiki 
 
 ```bash
 # Create the farm with the first wiki at the root
-canasta create -i myfarm -w mainwiki -n example.com -a admin
-
+canasta create -i myfarm -w mainwiki -n example.com
 # Add a second wiki at example.com/docs
-canasta add -i myfarm -w docs -u example.com/docs -a admin
-
+canasta add -i myfarm -w docs -u example.com/docs
 # Add a third wiki at example.com/internal
-canasta add -i myfarm -w internal -u example.com/internal -a admin
-```
+canasta add -i myfarm -w internal -u example.com/internal```
 
 Users access these at `https://example.com`, `https://example.com/docs`, and `https://example.com/internal`.
 
@@ -56,20 +53,14 @@ Users access these at `https://example.com`, `https://example.com/docs`, and `ht
 Each wiki uses a different subdomain. This requires DNS records pointing each subdomain to your Canasta server. Caddy handles SSL/HTTPS automatically for all configured domains.
 
 ```bash
-canasta create -i myfarm -w mainwiki -n wiki.example.com -a admin
-canasta add -i myfarm -w docs -u docs.example.com -a admin
-canasta add -i myfarm -w community -u community.example.com -a admin
-```
+canasta create -i myfarm -w mainwiki -n wiki.example.comcanasta add -i myfarm -w docs -u docs.example.comcanasta add -i myfarm -w community -u community.example.com```
 
 ### Mixed
 
 You can combine both approaches:
 
 ```bash
-canasta create -i myfarm -w mainwiki -n example.com -a admin
-canasta add -i myfarm -w docs -u example.com/docs -a admin
-canasta add -i myfarm -w community -u community.example.com -a admin
-```
+canasta create -i myfarm -w mainwiki -n example.comcanasta add -i myfarm -w docs -u example.com/docscanasta add -i myfarm -w community -u community.example.com```
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ The **Canasta CLI** is the command-line tool for managing Canasta installations.
 curl -fsSL https://raw.githubusercontent.com/CanastaWiki/Canasta-CLI/main/install.sh | sudo bash
 
 # Create a new Canasta installation
-canasta create -i myinstance -w wiki1 -a admin -n localhost
+canasta create -i myinstance -w wiki1 -n localhost
 ```
 
 > **Note: Linux users**


### PR DESCRIPTION
## Summary

- Makes the `-a/--admin` flag optional on both `canasta create` and `canasta add`, with a default value of "WikiSysop"
- Removes the validation that required `--admin` when `--database` was not provided
- Updates all documentation examples to remove the now-unnecessary `-a admin` flag

Closes #382

## Test plan

### Compose

- [x] `canasta create` without `-a` flag creates wiki with admin "WikiSysop"
- [x] `canasta create` with `-a myadmin` creates wiki with custom admin name
- [x] `canasta add` without `-a` flag adds wiki with admin "WikiSysop"
- [x] `canasta add` with `-a myadmin` adds wiki with custom admin name
- [x] Clean up test instances

### Kubernetes

- [x] `canasta create -o k8s --create-cluster` without `-a` flag creates wiki with admin "WikiSysop"
- [x] `canasta create -o k8s --create-cluster` with `-a myadmin` creates wiki with custom admin name
- [x] Clean up test instances

### Documentation

- [x] No remaining `-a admin` in any documentation or example
- [x] `go test ./...` passes
- [x] `go build` succeeds