### PR TITLE
docs: add missing guides and devmode CLI to navigation

### DIFF
--- a/docs/guide/general-concepts.md
+++ b/docs/guide/general-concepts.md
@@ -46,8 +46,8 @@ Installation IDs must start and end with an alphanumeric character and may conta
 Every wiki in a Canasta installation has a **wiki ID** — a short identifier set with the `-w` flag when creating or adding a wiki:
 
 ```bash
-canasta create -i myinstance -w main -n localhost```
-
+canasta create -i myinstance -w main -n localhost
+```
 Even a single-wiki installation requires a wiki ID. The wiki ID is used as:
 
 - The MySQL database name for that wiki

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,9 +59,11 @@ nav:
     - Upgrading: guide/upgrading.md
     - Sitemaps: guide/sitemaps.md
     - Kubernetes: guide/kubernetes.md
+    - Orchestrators: guide/orchestrators.md
     - Best practices: guide/best-practices.md
     - Observability: guide/observability.md
     - Troubleshooting: guide/troubleshooting.md
+    - Contributing: guide/contributing.md
   - CLI Reference:
     - Overview: cli/canasta.md
     - Commands:
@@ -92,6 +94,10 @@ nav:
       - get: cli/canasta_config_get.md
       - set: cli/canasta_config_set.md
       - unset: cli/canasta_config_unset.md
+    - devmode:
+      - Overview: cli/canasta_devmode.md
+      - enable: cli/canasta_devmode_enable.md
+      - disable: cli/canasta_devmode_disable.md
     - maintenance:
       - Overview: cli/canasta_maintenance.md
       - update: cli/canasta_maintenance_update.md


### PR DESCRIPTION
**Changes**

- Added Orchestrators and Contributing guides to the Guides section
- Added devmode CLI command (overview, enable, disable) to the CLI Reference section