### PR TITLE
Reject unexpected positional args in six commands

### DIFF
--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -87,6 +87,9 @@ an existing database dump instead of running the installer.`,
   # Add a wiki with an existing database dump
   canasta add -i myinstance -w docs -u localhost/docs -d /path/to/dump.sql`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("unknown argument %q; use flags to specify options (e.g. canasta add --wiki <wiki> --url <url>)", args[0])
+			}
 			var err error
 
 			// Validate wiki ID

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -41,8 +41,8 @@ prompted for confirmation before any data is deleted.`,
   # Delete without confirmation prompt
   canasta delete -i myinstance -y`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if instance.Id == "" && len(args) > 0 {
-				instance.Id = args[0]
+			if len(args) > 0 {
+				return fmt.Errorf("unknown argument %q; use --id to specify the instance ID (e.g. canasta delete --id %s)", args[0], args[0])
 			}
 			var err error
 			instance, err = canasta.CheckCanastaId(instance)

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -42,6 +42,13 @@ for confirmation before any data is deleted.`,
   # Remove without confirmation prompt
   canasta remove -i myinstance -w docs -y`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if wikiID == "" {
+				if len(args) > 0 {
+					return fmt.Errorf("unknown argument %q; use --wiki to specify the wiki ID (e.g. canasta remove --wiki %s)", args[0], args[0])
+				}
+				return fmt.Errorf("--wiki flag is required")
+			}
+
 			instance, err = canasta.CheckCanastaId(instance)
 			if err != nil {
 				return err

--- a/cmd/restart/restart.go
+++ b/cmd/restart/restart.go
@@ -34,8 +34,8 @@ change the development mode setting.`,
   canasta restart -i myinstance`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logging.SetVerbose(verbose)
-			if instance.Id == "" && len(args) > 0 {
-				instance.Id = args[0]
+			if len(args) > 0 {
+				return fmt.Errorf("unknown argument %q; use --id to specify the instance ID (e.g. canasta restart --id %s)", args[0], args[0])
 			}
 			resolvedInstance, err := canasta.CheckCanastaId(instance)
 			if err != nil {

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -31,8 +31,8 @@ development mode setting.`,
 		Example: `  # Start an installation by ID
   canasta start -i myinstance`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if instance.Id == "" && len(args) > 0 {
-				instance.Id = args[0]
+			if len(args) > 0 {
+				return fmt.Errorf("unknown argument %q; use --id to specify the instance ID (e.g. canasta start --id %s)", args[0], args[0])
 			}
 			resolvedInstance, err := canasta.CheckCanastaId(instance)
 			if err != nil {

--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -28,8 +28,8 @@ are stopped gracefully, preserving all data in Docker volumes.`,
 		Example: `  # Stop an installation by ID
   canasta stop -i myinstance`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if instance.Id == "" && len(args) > 0 {
-				instance.Id = args[0]
+			if len(args) > 0 {
+				return fmt.Errorf("unknown argument %q; use --id to specify the instance ID (e.g. canasta stop --id %s)", args[0], args[0])
 			}
 			resolvedInstance, err := canasta.CheckCanastaId(instance)
 			if err != nil {


### PR DESCRIPTION
Fixes #385

## Summary

- `add`, `remove`, `start`, `stop`, `restart`, and `delete` now reject unexpected positional arguments with a helpful error pointing users to the correct flag (`--id`, `--wiki`, `--url`).
- `start`, `stop`, `restart`, and `delete` previously accepted a positional arg as an undocumented fallback for `--id`; this is removed for consistency.
- `remove` now returns a clear `--wiki flag is required` error when called with no wiki ID at all.

## Test plan

- [x] `go build` compiles successfully
- [x] `go test ./...` passes
- [x] `canasta remove wiki2` → error mentioning `--wiki`
- [x] `canasta remove` (no args) → error saying `--wiki flag is required`
- [x] `canasta start myinstance` → error mentioning `--id`
- [x] `canasta stop myinstance` → error mentioning `--id`
- [x] `canasta restart myinstance` → error mentioning `--id`
- [x] `canasta delete myinstance` → error mentioning `--id`
- [x] `canasta add extra -w docs -u localhost/docs` → error mentioning `--wiki`/`--url`