### PR TITLE
Validate config keys against known settings

### DIFF
--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -42,6 +42,47 @@ func TestResolveKey(t *testing.T) {
 	}
 }
 
+func TestIsKnownKey(t *testing.T) {
+	tests := []struct {
+		key  string
+		want bool
+	}{
+		// Exact known keys
+		{"HTTP_PORT", true},
+		{"HTTPS_PORT", true},
+		{"PHP_UPLOAD_MAX_FILESIZE", true},
+		{"CANASTA_ENABLE_ELASTICSEARCH", true},
+		{"CANASTA_IMAGE", true},
+		{"RESTIC_REPOSITORY", true},
+		{"MW_SITEMAP_PAUSE_DAYS", true},
+
+		// Restic backend prefixes
+		{"AWS_ACCESS_KEY_ID", true},
+		{"AWS_SECRET_ACCESS_KEY", true},
+		{"AZURE_ACCOUNT_NAME", true},
+		{"B2_ACCOUNT_ID", true},
+		{"GOOGLE_PROJECT_ID", true},
+		{"OS_AUTH_URL", true},
+		{"ST_AUTH", true},
+		{"RCLONE_BWLIMIT", true},
+
+		// Unknown keys
+		{"TYPO_VAR", false},
+		{"CANASTA_ENABLE_ELASTICSEARH", false},
+		{"RANDOM_SETTING", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			got := isKnownKey(tt.key)
+			if got != tt.want {
+				t.Errorf("isKnownKey(%q) = %v, want %v", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestUpdateURLPort(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/cmd/config/get.go
+++ b/cmd/config/get.go
@@ -12,7 +12,8 @@ import (
 )
 
 func getCmdCreate() *cobra.Command {
-	return &cobra.Command{
+	var force bool
+	cmd := &cobra.Command{
 		Use:   "get [KEY]",
 		Short: "Show configuration settings",
 		Long: `Show configuration settings from the .env file of a Canasta installation.
@@ -30,6 +31,9 @@ Key lookup is case-insensitive.`,
 
 			if len(args) == 1 {
 				key := resolveKey(envVars, args[0])
+				if !force && !isKnownKey(key) {
+					return fmt.Errorf("unrecognized setting %q\nUse 'canasta config get --force %s' to query it anyway\nRun 'canasta config --help' to see available settings", key, key)
+				}
 				val, ok := envVars[key]
 				if !ok {
 					return fmt.Errorf("key %q is not set", key)
@@ -50,6 +54,9 @@ Key lookup is case-insensitive.`,
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Allow querying unrecognized keys")
+	return cmd
 }
 
 // resolveKey finds the actual key in envVars using case-insensitive matching

--- a/cmd/config/unset.go
+++ b/cmd/config/unset.go
@@ -11,6 +11,7 @@ import (
 )
 
 func unsetCmdCreate() *cobra.Command {
+	var force bool
 	cmd := &cobra.Command{
 		Use:   "unset KEY [KEY ...]",
 		Short: "Remove a configuration setting",
@@ -37,6 +38,9 @@ is removed. The instance is then restarted unless --no-restart is specified.`,
 			keys := make([]string, 0, len(args))
 			for _, arg := range args {
 				key := resolveKey(envVars, arg)
+				if !force && !isKnownKey(key) {
+					return fmt.Errorf("unrecognized setting %q\nUse 'canasta config unset --force %s' to remove it anyway\nRun 'canasta config --help' to see available settings", key, key)
+				}
 				if _, ok := envVars[key]; !ok {
 					return fmt.Errorf("key %q is not set", key)
 				}
@@ -91,5 +95,6 @@ is removed. The instance is then restarted unless --no-restart is specified.`,
 	}
 
 	cmd.Flags().BoolVar(&noRestart, "no-restart", false, "Remove the setting without restarting the instance")
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Allow unsetting unrecognized keys")
 	return cmd
 }


### PR DESCRIPTION
Closes #389

## Summary
- Reject unrecognized keys in `config set`, `config get`, and `config unset` with a helpful error message pointing to `--force` and `--help`
- Add `--force` / `-f` flag to all three subcommands to bypass the check
- Known keys include the documented `.env` settings plus Restic backend credential prefixes (`AWS_`, `AZURE_`, `B2_`, `GOOGLE_`, `OS_`, `ST_`, `RCLONE_`)
- Add `TestIsKnownKey` with 19 test cases

## Test plan
- [x] `canasta config set TYPO_VAR=true -i wikifarm` → rejected
- [x] `canasta config set TYPO_VAR=true --force -i wikifarm` → accepted
- [x] `canasta config set HTTP_PORT=8080 -i wikifarm` → accepted (known key)
- [x] `canasta config set AWS_ACCESS_KEY_ID=xxx -i wikifarm` → accepted (Restic prefix)
- [x] `canasta config get TYPO_VAR -i wikifarm` → rejected
- [x] `canasta config get TYPO_VAR --force -i wikifarm` → accepted
- [x] `canasta config unset TYPO_VAR -i wikifarm` → rejected
- [x] `canasta config unset TYPO_VAR --force -i wikifarm` → accepted
- [x] `go test ./...` passes