### PR TITLE
Update email messaging and add email guide

### DIFF
--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -63,6 +63,8 @@ var knownKeys = map[string]bool{
 	"CANASTA_ENABLE_ELASTICSEARCH":  true,
 	"CANASTA_ENABLE_OBSERVABILITY":  true,
 	"CANASTA_ENABLE_WIKI_DIRECTORY": true,
+	// Email
+	"MW_ENABLE_POSTFIX": true,
 	// Caddy / TLS
 	"CADDY_AUTO_HTTPS": true,
 	// Docker Image

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -153,7 +153,7 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
 				return fmt.Errorf("Installation failed. Keeping all the containers and config files")
 			}
 			stopSpinner()
-			fmt.Println("\033[32mEmail is sent via a built-in mail server. For reliable delivery, configure $wgSMTP with an authenticated SMTP provider. See https://mediawiki.org/wiki/Manual:$wgSMTP\033[0m")
+			fmt.Println("\033[32mEmail is sent via the built-in mail server, which works but messages may be flagged as spam. To improve deliverability, you can configure $wgSMTP to use an authenticated SMTP provider instead. See https://mediawiki.org/wiki/Manual:$wgSMTP\033[0m")
 			fmt.Println("Done.")
 			return nil
 		},

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -153,7 +153,7 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
 				return fmt.Errorf("Installation failed. Keeping all the containers and config files")
 			}
 			stopSpinner()
-			fmt.Println("\033[32mIf you need email enabled for this wiki, please set $wgSMTP; email will not work otherwise. See https://mediawiki.org/wiki/Manual:$wgSMTP for options.\033[0m")
+			fmt.Println("\033[32mEmail is sent via a built-in mail server. For reliable delivery, configure $wgSMTP with an authenticated SMTP provider. See https://mediawiki.org/wiki/Manual:$wgSMTP\033[0m")
 			fmt.Println("Done.")
 			return nil
 		},

--- a/docs/guide/email.md
+++ b/docs/guide/email.md
@@ -1,0 +1,95 @@
+# Email
+
+Canasta includes a built-in mail server ([Postfix](https://www.postfix.org/)) that lets your wiki send email out of the box. This covers account confirmations, password resets, watchlist notifications, and user-to-user email.
+
+## Contents
+
+- [How it works](#how-it-works)
+- [Improving deliverability](#improving-deliverability)
+- [Disabling the built-in mail server](#disabling-the-built-in-mail-server)
+- [Disabling email entirely](#disabling-email-entirely)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## How it works
+
+Postfix runs inside the Canasta container as a local-only mail transfer agent. When MediaWiki sends an email (via PHP's `mail()` function), Postfix accepts the message and delivers it directly to the recipient's mail server by looking up MX records in DNS.
+
+No configuration is needed — email works immediately after `canasta create`.
+
+The sender domain is derived from your wiki's URL (`MW_SITE_SERVER`). For example, if your wiki is at `https://wiki.example.com`, outgoing mail will come from `wiki.example.com`.
+
+!!! warning
+    Messages sent from the built-in mail server may be flagged as spam by recipients, because the server has no SPF, DKIM, or DMARC records. This is fine for development and testing, but for production wikis you should [configure an external SMTP provider](#improving-deliverability).
+
+---
+
+## Improving deliverability
+
+For production use, configure [`$wgSMTP`](https://www.mediawiki.org/wiki/Manual:$wgSMTP) in your wiki's settings file to route email through an authenticated SMTP provider. This gives you proper SPF/DKIM alignment and much better inbox placement.
+
+Example using a generic SMTP provider:
+
+```php
+$wgSMTP = [
+    'host'     => 'ssl://smtp.example.com',
+    'IDHost'   => 'example.com',
+    'port'     => 465,
+    'auth'     => true,
+    'username' => 'your-username',
+    'password' => 'your-password',
+];
+```
+
+Popular providers include [Amazon SES](https://aws.amazon.com/ses/), [SendGrid](https://sendgrid.com/), [Mailgun](https://www.mailgun.com/), and [Brevo](https://www.brevo.com/). Most offer a free tier sufficient for small wikis.
+
+Once `$wgSMTP` is configured, MediaWiki connects directly to the external provider — Postfix is bypassed entirely. You can then [disable the built-in mail server](#disabling-the-built-in-mail-server) to avoid running an unused service.
+
+---
+
+## Disabling the built-in mail server
+
+If you configure an external SMTP provider via `$wgSMTP`, you can disable Postfix:
+
+```bash
+canasta config set MW_ENABLE_POSTFIX=false -i myinstance
+canasta restart -i myinstance
+```
+
+To re-enable it:
+
+```bash
+canasta config set MW_ENABLE_POSTFIX=true -i myinstance
+canasta restart -i myinstance
+```
+
+---
+
+## Disabling email entirely
+
+To prevent the wiki from sending any email at all, set [`$wgEnableEmail`](https://www.mediawiki.org/wiki/Manual:$wgEnableEmail) to `false` in your wiki's settings file:
+
+```php
+$wgEnableEmail = false;
+```
+
+---
+
+## Troubleshooting
+
+### Emails not being sent
+
+- Verify Postfix is running: `docker exec <container> service postfix status`
+- Check Postfix is enabled: `canasta config get MW_ENABLE_POSTFIX -i myinstance`
+- Check the mail log inside the container: `docker exec <container> cat /var/log/postfix.log`
+
+### Emails landing in spam
+
+This is expected with the built-in mail server. To fix it, [configure an external SMTP provider](#improving-deliverability) and set up SPF, DKIM, and DMARC records for your domain.
+
+### Emails not sent after configuring $wgSMTP
+
+- Verify the SMTP credentials are correct by testing with a simple PHP script
+- Check that your hosting provider does not block outbound connections on the SMTP port (465 or 587)
+- Look for errors in the MediaWiki debug log (set `$wgDebugLogFile` temporarily)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -97,4 +97,4 @@ The configuration directory location depends on your platform:
 
 ### Email configuration
 
-Email functionality is **not enabled by default**. To enable email for your wiki, you must configure the `$wgSMTP` setting in your wiki's settings file. See the [MediaWiki SMTP documentation](https://www.mediawiki.org/wiki/Manual:$wgSMTP) for configuration options.
+Email works out of the box using a built-in mail server (Postfix). Messages may be flagged as spam by recipients since the server has no SPF or DKIM records. For production use, configure an authenticated SMTP provider via `$wgSMTP`. See the [Email guide](guide/email.md) for details.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
     - Development mode: guide/devmode.md
     - Backup and restore: guide/backup.md
     - Upgrading: guide/upgrading.md
+    - Email: guide/email.md
     - Sitemaps: guide/sitemaps.md
     - Kubernetes: guide/kubernetes.md
     - Orchestrators: guide/orchestrators.md


### PR DESCRIPTION
## Summary

- Update the post-create email message to reflect that the built-in mailer works out of the box
- Add `docs/guide/email.md` documenting the built-in Postfix mailer, `$wgSMTP` configuration for external providers, the `MW_ENABLE_POSTFIX` toggle, and troubleshooting
- Update the stale "email not enabled" blurb in `docs/installation.md`
- Add email guide to mkdocs.yml navigation
- Add `MW_ENABLE_POSTFIX` to `knownKeys` so `canasta config set` accepts it without `--force`

Companion PR: https://github.com/CanastaWiki/CanastaBase/pull/114

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Docs render correctly (new guide linked from nav and installation page)

Resolves #395