### PR TITLE
Add test for list command

### DIFF
--- a/cmd/list/list_test.go
+++ b/cmd/list/list_test.go
@@ -1,0 +1,86 @@
+package list
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
+)
+
+func TestList(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "canasta-list-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp config dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	config.ResetForTesting(tmpDir)
+
+	installPath := filepath.Join(tmpDir, "canasta-test")
+	err = os.MkdirAll(filepath.Join(installPath, "config"), 0755)
+	if err != nil {
+		t.Fatalf("Failed to create mock config dir: %v", err)
+	}
+
+	err = farmsettings.AddWiki("testwiki", installPath, "testwiki.local", "/", "Test Wiki")
+	if err != nil {
+		t.Fatalf("Failed to add mock wiki: %v", err)
+	}
+	err = farmsettings.AddWiki("devwiki", installPath, "devwiki.local", "/", "Dev Wiki")
+	if err != nil {
+		t.Fatalf("Failed to add second mock wiki: %v", err)
+	}
+
+	installation := config.Installation{
+		Id:           "test-instance",
+		Path:         installPath,
+		Orchestrator: "compose",
+	}
+	err = config.Add(installation)
+	if err != nil {
+		t.Fatalf("Failed to add installation to config: %v", err)
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err = List(config.Installation{}, false)
+	
+	w.Close()
+
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("List() returned an error: %v", err)
+	}
+
+	var out bytes.Buffer
+	_, err = io.Copy(&out, r)
+	if err != nil {
+		t.Fatalf("Failed to read from stdout pipe: %v", err)
+	}
+
+	outputStr := out.String()
+
+	expectedValues := []string{
+		"Canasta ID", "Wiki ID", "Server Name", "Server Path", "Installation Path", "Orchestrator",
+		"test-instance",
+		"testwiki", "testwiki.local",
+		"devwiki", "devwiki.local",
+		"/",
+		installPath,
+		"compose",
+	}
+
+	for _, expected := range expectedValues {
+		if !strings.Contains(outputStr, expected) {
+			t.Errorf("Expected output to contain '%s', but it did not.\nFull output:\n%s", expected, outputStr)
+		}
+	}
+}

--- a/cmd/list/list_test.go
+++ b/cmd/list/list_test.go
@@ -13,16 +13,13 @@ import (
 )
 
 func TestList(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "canasta-list-test")
-	if err != nil {
-		t.Fatalf("Failed to create temp config dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	config.ResetForTesting(tmpDir)
+	t.Cleanup(func() { config.ResetForTesting("") })
 
 	installPath := filepath.Join(tmpDir, "canasta-test")
-	err = os.MkdirAll(filepath.Join(installPath, "config"), 0755)
+	err := os.MkdirAll(filepath.Join(installPath, "config"), 0755)
 	if err != nil {
 		t.Fatalf("Failed to create mock config dir: %v", err)
 	}
@@ -86,13 +83,10 @@ func TestList(t *testing.T) {
 }
 
 func TestListCleanup(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "canasta-list-cleanup-test")
-	if err != nil {
-		t.Fatalf("Failed to create temp config dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	config.ResetForTesting(tmpDir)
+	t.Cleanup(func() { config.ResetForTesting("") })
 
 	installPath := filepath.Join(tmpDir, "stale-installation")
 
@@ -109,7 +103,7 @@ func TestListCleanup(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	err = List(config.Installation{}, true)
+	err := List(config.Installation{}, true)
 
 	w.Close()
 	os.Stdout = oldStdout
@@ -125,8 +119,14 @@ func TestListCleanup(t *testing.T) {
 
 	outputStr := out.String()
 	expectedOutput := "Removed stale entry 'stale-instance' (directory not found)"
+	tableStr := strings.Replace(outputStr, expectedOutput, "", 1)
+
 	if !strings.Contains(outputStr, expectedOutput) {
 		t.Errorf("Expected output to contain '%s', but it did not.\nFull output:\n%s", expectedOutput, outputStr)
+	}
+
+	if strings.Contains(tableStr, "stale-instance") {
+		t.Errorf("Expected stale entry 'stale-instance' to not appear in the listed output table, but it did.\nFull output:\n%s", outputStr)
 	}
 
 	installations, err := config.GetAll()
@@ -139,13 +139,10 @@ func TestListCleanup(t *testing.T) {
 }
 
 func TestListNotFound(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "canasta-list-notfound-test")
-	if err != nil {
-		t.Fatalf("Failed to create temp config dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	config.ResetForTesting(tmpDir)
+	t.Cleanup(func() { config.ResetForTesting("") })
 
 	installPath := filepath.Join(tmpDir, "missing-installation")
 
@@ -162,7 +159,7 @@ func TestListNotFound(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	err = List(config.Installation{}, false)
+	err := List(config.Installation{}, false)
 
 	w.Close()
 	os.Stdout = oldStdout

--- a/cmd/list/list_test.go
+++ b/cmd/list/list_test.go
@@ -51,7 +51,7 @@ func TestList(t *testing.T) {
 	os.Stdout = w
 
 	err = List(config.Installation{}, false)
-	
+
 	w.Close()
 
 	os.Stdout = oldStdout
@@ -82,5 +82,103 @@ func TestList(t *testing.T) {
 		if !strings.Contains(outputStr, expected) {
 			t.Errorf("Expected output to contain '%s', but it did not.\nFull output:\n%s", expected, outputStr)
 		}
+	}
+}
+
+func TestListCleanup(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "canasta-list-cleanup-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp config dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	config.ResetForTesting(tmpDir)
+
+	installPath := filepath.Join(tmpDir, "stale-installation")
+
+	installation := config.Installation{
+		Id:           "stale-instance",
+		Path:         installPath,
+		Orchestrator: "compose",
+	}
+	if err := config.Add(installation); err != nil {
+		t.Fatalf("Failed to add installation to config: %v", err)
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err = List(config.Installation{}, true)
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("List() returned an error: %v", err)
+	}
+
+	var out bytes.Buffer
+	if _, err := io.Copy(&out, r); err != nil {
+		t.Fatalf("Failed to read from stdout pipe: %v", err)
+	}
+
+	outputStr := out.String()
+	expectedOutput := "Removed stale entry 'stale-instance' (directory not found)"
+	if !strings.Contains(outputStr, expectedOutput) {
+		t.Errorf("Expected output to contain '%s', but it did not.\nFull output:\n%s", expectedOutput, outputStr)
+	}
+
+	installations, err := config.GetAll()
+	if err != nil {
+		t.Fatalf("Failed to get config: %v", err)
+	}
+	if _, exists := installations["stale-instance"]; exists {
+		t.Errorf("Expected stale entry 'stale-instance' to be removed from config, but it still exists")
+	}
+}
+
+func TestListNotFound(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "canasta-list-notfound-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp config dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	config.ResetForTesting(tmpDir)
+
+	installPath := filepath.Join(tmpDir, "missing-installation")
+
+	installation := config.Installation{
+		Id:           "missing-instance",
+		Path:         installPath,
+		Orchestrator: "compose",
+	}
+	if err := config.Add(installation); err != nil {
+		t.Fatalf("Failed to add installation to config: %v", err)
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err = List(config.Installation{}, false)
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("List() returned an error: %v", err)
+	}
+
+	var out bytes.Buffer
+	if _, err := io.Copy(&out, r); err != nil {
+		t.Fatalf("Failed to read from stdout pipe: %v", err)
+	}
+
+	outputStr := out.String()
+	expectedOutput := installPath + " [not found]"
+	if !strings.Contains(outputStr, expectedOutput) {
+		t.Errorf("Expected output to contain '%s', but it did not.\nFull output:\n%s", expectedOutput, outputStr)
 	}
 }


### PR DESCRIPTION
Add tests for the `List()` function in `cmd/list/list.go`:

- `TestList` — registers an installation with two wikis and verifies the table output contains all expected fields
- `TestListCleanup` — registers an installation with a missing directory, calls `List` with `cleanup=true`, and verifies the stale entry is removed
- `TestListNotFound` — registers an installation with a missing directory and verifies the `[not found]` annotation appears in the output

Fixes #505