### PR TITLE
Deduplicate extension/skin commands

### DIFF
--- a/cmd/extension/extension.go
+++ b/cmd/extension/extension.go
@@ -1,54 +1,18 @@
 package extension
 
 import (
-	"log"
-	"os"
-
 	"github.com/spf13/cobra"
 
-	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
-	"github.com/CanastaWiki/Canasta-CLI/internal/config"
 	"github.com/CanastaWiki/Canasta-CLI/internal/extensionsskins"
-	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
 func NewCmd() *cobra.Command {
-	var (
-		instance config.Installation
-		orch     orchestrators.Orchestrator
-		wiki     string
-	)
-	constants := extensionsskins.Item{Name: "Canasta extension", RelativeInstallationPath: "extensions", PhpCommand: "wfLoadExtension"}
-
-	workingDir, wdErr := os.Getwd()
-	if wdErr != nil {
-		log.Fatal(wdErr)
-	}
-	instance.Path = workingDir
-
-	extensionCmd := &cobra.Command{
-		Use:   "extension",
-		Short: "Manage Canasta extensions",
-		Long: `Manage MediaWiki extensions in a Canasta installation. Subcommands allow you
-to list all available extensions, and enable or disable them globally or for
-a specific wiki in a farm.`,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			var err error
-			instance, err = canasta.CheckCanastaId(instance)
-			if err != nil {
-				return err
-			}
-			orch, err = orchestrators.New(instance.Orchestrator)
-			return err
-		},
-	}
-
-	extensionCmd.PersistentFlags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
-	extensionCmd.PersistentFlags().StringVarP(&wiki, "wiki", "w", "", "ID of the specific wiki within the Canasta farm")
-
-	extensionCmd.AddCommand(newListCmd(&instance, &orch, &wiki, &constants))
-	extensionCmd.AddCommand(newEnableCmd(&instance, &orch, &wiki, &constants))
-	extensionCmd.AddCommand(newDisableCmd(&instance, &orch, &wiki, &constants))
-
-	return extensionCmd
+	return extensionsskins.NewCmd(extensionsskins.Item{
+		Name:                     "Canasta extension",
+		CmdName:                  "extension",
+		Plural:                   "extensions",
+		RelativeInstallationPath: "extensions",
+		PhpCommand:               "wfLoadExtension",
+		ExampleNames:             "VisualEditor,Cite,ParserFunctions",
+	})
 }

--- a/cmd/skin/skin.go
+++ b/cmd/skin/skin.go
@@ -1,54 +1,18 @@
 package skin
 
 import (
-	"log"
-	"os"
-
 	"github.com/spf13/cobra"
 
-	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
-	"github.com/CanastaWiki/Canasta-CLI/internal/config"
 	"github.com/CanastaWiki/Canasta-CLI/internal/extensionsskins"
-	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
 func NewCmd() *cobra.Command {
-	var (
-		instance config.Installation
-		orch     orchestrators.Orchestrator
-		wiki     string
-	)
-	constants := extensionsskins.Item{Name: "Canasta skin", RelativeInstallationPath: "skins", PhpCommand: "wfLoadSkin"}
-
-	workingDir, wdErr := os.Getwd()
-	if wdErr != nil {
-		log.Fatal(wdErr)
-	}
-	instance.Path = workingDir
-
-	skinCmd := &cobra.Command{
-		Use:   "skin",
-		Short: "Manage Canasta skins",
-		Long: `Manage MediaWiki skins in a Canasta installation. Subcommands allow you
-to list all available skins, and enable or disable them globally or for
-a specific wiki in a farm.`,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			var err error
-			instance, err = canasta.CheckCanastaId(instance)
-			if err != nil {
-				return err
-			}
-			orch, err = orchestrators.New(instance.Orchestrator)
-			return err
-		},
-	}
-
-	skinCmd.PersistentFlags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
-	skinCmd.PersistentFlags().StringVarP(&wiki, "wiki", "w", "", "ID of the specific wiki within the Canasta farm")
-
-	skinCmd.AddCommand(newListCmd(&instance, &orch, &wiki, &constants))
-	skinCmd.AddCommand(newEnableCmd(&instance, &orch, &wiki, &constants))
-	skinCmd.AddCommand(newDisableCmd(&instance, &orch, &wiki, &constants))
-
-	return skinCmd
+	return extensionsskins.NewCmd(extensionsskins.Item{
+		Name:                     "Canasta skin",
+		CmdName:                  "skin",
+		Plural:                   "skins",
+		RelativeInstallationPath: "skins",
+		PhpCommand:               "wfLoadSkin",
+		ExampleNames:             "Timeless",
+	})
 }

--- a/internal/extensionsskins/commands.go
+++ b/internal/extensionsskins/commands.go
@@ -1,0 +1,164 @@
+package extensionsskins
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
+	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
+)
+
+// NewCmd builds the full command tree (parent + enable/disable/list subcommands)
+// for an extension-or-skin item type.
+func NewCmd(constants Item) *cobra.Command {
+	var (
+		instance config.Installation
+		orch     orchestrators.Orchestrator
+		wiki     string
+	)
+
+	workingDir, wdErr := os.Getwd()
+	if wdErr != nil {
+		log.Fatal(wdErr)
+	}
+	instance.Path = workingDir
+
+	cmd := &cobra.Command{
+		Use:   constants.CmdName,
+		Short: fmt.Sprintf("Manage Canasta %s", constants.Plural),
+		Long: fmt.Sprintf(`Manage MediaWiki %s in a Canasta installation. Subcommands allow you
+to list all available %s, and enable or disable them globally or for
+a specific wiki in a farm.`, constants.Plural, constants.Plural),
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			instance, err = canasta.CheckCanastaId(instance)
+			if err != nil {
+				return err
+			}
+			orch, err = orchestrators.New(instance.Orchestrator)
+			return err
+		},
+	}
+
+	cmd.PersistentFlags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
+	cmd.PersistentFlags().StringVarP(&wiki, "wiki", "w", "", "ID of the specific wiki within the Canasta farm")
+
+	cmd.AddCommand(newListCmd(&instance, &orch, &wiki, &constants))
+	cmd.AddCommand(newEnableCmd(&instance, &orch, &wiki, &constants))
+	cmd.AddCommand(newDisableCmd(&instance, &orch, &wiki, &constants))
+
+	return cmd
+}
+
+func newListCmd(instance *config.Installation, orch *orchestrators.Orchestrator, wiki *string, constants *Item) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: fmt.Sprintf("Lists all the installed Canasta %s", constants.Plural),
+		Long: fmt.Sprintf(`List all Canasta %s available in the installation. Each %s
+is shown with its enabled/disabled status.`, constants.Plural, constants.CmdName),
+		Example: fmt.Sprintf("  canasta %s list -i myinstance", constants.CmdName),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return List(*instance, *orch, *constants)
+		},
+	}
+}
+
+func newEnableCmd(instance *config.Installation, orch *orchestrators.Orchestrator, wiki *string, constants *Item) *cobra.Command {
+	// Build the Use string with an appropriate argument placeholder
+	argName := strings.ToUpper(constants.CmdName)
+	useStr := fmt.Sprintf("enable %s1,%s2,...", argName, argName)
+
+	// Build example text
+	firstName := strings.SplitN(constants.ExampleNames, ",", 2)[0]
+	example := fmt.Sprintf(`  # Enable a single %s
+  canasta %s enable %s -i myinstance`, constants.CmdName, constants.CmdName, firstName)
+
+	if strings.Contains(constants.ExampleNames, ",") {
+		example += fmt.Sprintf(`
+
+  # Enable multiple %s at once
+  canasta %s enable %s -i myinstance`, constants.Plural, constants.CmdName, constants.ExampleNames)
+	}
+
+	example += fmt.Sprintf(`
+
+  # Enable %s %s for a specific wiki
+  canasta %s enable %s -i myinstance -w docs`, article(constants.CmdName), constants.CmdName, constants.CmdName, firstName)
+
+	return &cobra.Command{
+		Use:   useStr,
+		Short: fmt.Sprintf("Enable a %s", constants.Name),
+		Long: fmt.Sprintf(`Enable one or more Canasta %s by name. Multiple %s can be
+specified as a comma-separated list. Use the --wiki flag to enable %s %s
+for a specific wiki only.`, constants.Plural, constants.Plural, article(constants.CmdName), constants.CmdName),
+		Example: example,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			names := strings.Split(args[0], ",")
+			for _, name := range names {
+				checkedName, err := CheckInstalled(name, *instance, *orch, *constants)
+				if err != nil {
+					fmt.Print(err.Error() + "\n")
+					continue
+				}
+				if err := Enable(checkedName, *wiki, *instance, *orch, *constants); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+}
+
+func newDisableCmd(instance *config.Installation, orch *orchestrators.Orchestrator, wiki *string, constants *Item) *cobra.Command {
+	// Build the Use string with an appropriate argument placeholder
+	argName := strings.ToUpper(constants.CmdName)
+	useStr := fmt.Sprintf("disable %s1,%s2,...", argName, argName)
+
+	// Build example text
+	firstName := strings.SplitN(constants.ExampleNames, ",", 2)[0]
+	example := fmt.Sprintf(`  # Disable a single %s
+  canasta %s disable %s -i myinstance`, constants.CmdName, constants.CmdName, firstName)
+
+	example += fmt.Sprintf(`
+
+  # Disable %s %s for a specific wiki
+  canasta %s disable %s -i myinstance -w docs`, article(constants.CmdName), constants.CmdName, constants.CmdName, firstName)
+
+	return &cobra.Command{
+		Use:   useStr,
+		Short: fmt.Sprintf("Disable a %s", constants.Name),
+		Long: fmt.Sprintf(`Disable one or more Canasta %s by name. Multiple %s can be
+specified as a comma-separated list. Use the --wiki flag to disable %s %s
+for a specific wiki only.`, constants.Plural, constants.Plural, article(constants.CmdName), constants.CmdName),
+		Example: example,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			names := strings.Split(args[0], ",")
+			for _, name := range names {
+				checkedName, err := CheckEnabled(name, *wiki, *instance, *orch, *constants)
+				if err != nil {
+					fmt.Print(err.Error() + "\n")
+					continue
+				}
+				if err := Disable(checkedName, *wiki, *instance, *orch, *constants); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+}
+
+// article returns "an" for words starting with a vowel sound, "a" otherwise.
+func article(word string) string {
+	if len(word) > 0 && strings.ContainsRune("aeiouAEIOU", rune(word[0])) {
+		return "an"
+	}
+	return "a"
+}

--- a/internal/extensionsskins/extensionsskins.go
+++ b/internal/extensionsskins/extensionsskins.go
@@ -10,9 +10,12 @@ import (
 )
 
 type Item struct {
-	Name                     string
-	RelativeInstallationPath string
-	PhpCommand               string
+	Name                     string // e.g. "Canasta extension" or "Canasta skin"
+	CmdName                  string // e.g. "extension" or "skin"
+	Plural                   string // e.g. "extensions" or "skins"
+	RelativeInstallationPath string // e.g. "extensions" or "skins"
+	PhpCommand               string // e.g. "wfLoadExtension" or "wfLoadSkin"
+	ExampleNames             string // e.g. "VisualEditor,Cite,ParserFunctions" or "Timeless"
 }
 
 func Contains(list []string, element string) bool {


### PR DESCRIPTION
## Summary

- Move shared command-building logic (list, enable, disable) into `internal/extensionsskins/commands.go`
- `cmd/extension` and `cmd/skin` become thin wrappers passing an `Item` config
- Add `CmdName`, `Plural`, and `ExampleNames` fields to the `Item` struct so help text is generated dynamically

Split from #417.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] Verify `canasta extension list/enable/disable` and `canasta skin list/enable/disable` behave the same as before

Closes #402