### PR TITLE
Standardize logging across command packages

### DIFF
--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -2,7 +2,6 @@ package add
 
 import (
 	"fmt"
-	"log"
 	urlpkg "net/url"
 	"os"
 	"strings"
@@ -13,6 +12,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
 	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
+	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI/internal/mediawiki"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
@@ -67,7 +67,7 @@ func NewCmd() *cobra.Command {
 
 	workingDir, err := os.Getwd()
 	if err != nil {
-		log.Fatal(err)
+		logging.Fatal(err)
 	}
 	instance.Path = workingDir
 

--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -2,7 +2,6 @@ package backup
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
 	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
+	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
@@ -24,7 +24,7 @@ func NewCmd() *cobra.Command {
 
 	workingDir, wdErr := os.Getwd()
 	if wdErr != nil {
-		log.Fatal(wdErr)
+		logging.Fatal(wdErr)
 	}
 	instance.Path = workingDir
 

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -1,13 +1,13 @@
 package config
 
 import (
-	"log"
 	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
@@ -19,7 +19,7 @@ func NewCmd() *cobra.Command {
 
 	workingDir, wdErr := os.Getwd()
 	if wdErr != nil {
-		log.Fatal(wdErr)
+		logging.Fatal(wdErr)
 	}
 	instance.Path = workingDir
 

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -2,7 +2,6 @@ package create
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -181,7 +180,7 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
 	}
 
 	if workingDir, err = os.Getwd(); err != nil {
-		log.Fatal(err)
+		logging.Fatal(err)
 	}
 
 	createCmd.Flags().StringVarP(&path, "path", "p", workingDir, "Canasta directory")

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -3,7 +3,6 @@ package start
 import (
 	"bufio"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 
@@ -21,7 +20,7 @@ func NewCmd() *cobra.Command {
 	var instance config.Installation
 	workingDir, err := os.Getwd()
 	if err != nil {
-		log.Fatal(err)
+		logging.Fatal(err)
 	}
 	instance.Path = workingDir
 

--- a/cmd/devmode/devmode.go
+++ b/cmd/devmode/devmode.go
@@ -2,13 +2,13 @@ package devmode
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
@@ -20,7 +20,7 @@ func NewCmd() *cobra.Command {
 
 	workingDir, wdErr := os.Getwd()
 	if wdErr != nil {
-		log.Fatal(wdErr)
+		logging.Fatal(wdErr)
 	}
 	instance.Path = workingDir
 

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -2,7 +2,6 @@ package export
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"strings"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
 	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
+	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
@@ -76,7 +76,7 @@ Use a .gz extension on the output path to get a gzip-compressed dump.`,
 
 	workingDir, err := os.Getwd()
 	if err != nil {
-		log.Fatal(err)
+		logging.Fatal(err)
 	}
 	instance.Path = workingDir
 

--- a/cmd/import/import.go
+++ b/cmd/import/import.go
@@ -2,7 +2,6 @@ package importcmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -11,6 +10,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
 	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
+	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
@@ -81,7 +81,7 @@ To create a new wiki from a database dump, use the --database flag with
 
 	workingDir, err := os.Getwd()
 	if err != nil {
-		log.Fatal(err)
+		logging.Fatal(err)
 	}
 	instance.Path = workingDir
 

--- a/cmd/maintenanceUpdate/maintenance.go
+++ b/cmd/maintenanceUpdate/maintenance.go
@@ -1,11 +1,12 @@
 package maintenance
 
 import (
-	"log"
 	"os"
 
-	"github.com/CanastaWiki/Canasta-CLI/internal/config"
 	"github.com/spf13/cobra"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 )
 
 var (
@@ -18,7 +19,7 @@ var (
 func NewCmd() *cobra.Command {
 	workingDir, wdErr := os.Getwd()
 	if wdErr != nil {
-		log.Fatal(wdErr)
+		logging.Fatal(wdErr)
 	}
 	instance.Path = workingDir
 

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -3,7 +3,6 @@ package remove
 import (
 	"bufio"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 
@@ -25,7 +24,7 @@ func NewCmd() *cobra.Command {
 
 	workingDir, err := os.Getwd()
 	if err != nil {
-		log.Fatal(err)
+		logging.Fatal(err)
 	}
 	instance.Path = workingDir
 

--- a/cmd/restart/restart.go
+++ b/cmd/restart/restart.go
@@ -2,13 +2,13 @@ package restart
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
@@ -17,7 +17,7 @@ func NewCmd() *cobra.Command {
 
 	workingDir, err := os.Getwd()
 	if err != nil {
-		log.Fatal(err)
+		logging.Fatal(err)
 	}
 	instance.Path = workingDir
 

--- a/cmd/sitemap/sitemap.go
+++ b/cmd/sitemap/sitemap.go
@@ -1,13 +1,13 @@
 package sitemap
 
 import (
-	"log"
 	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
@@ -19,7 +19,7 @@ func NewCmd() *cobra.Command {
 
 	workingDir, wdErr := os.Getwd()
 	if wdErr != nil {
-		log.Fatal(wdErr)
+		logging.Fatal(wdErr)
 	}
 	instance.Path = workingDir
 

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -2,13 +2,13 @@ package start
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
@@ -16,7 +16,7 @@ func NewCmd() *cobra.Command {
 	var instance config.Installation
 	workingDir, err := os.Getwd()
 	if err != nil {
-		log.Fatal(err)
+		logging.Fatal(err)
 	}
 	instance.Path = workingDir
 

--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -2,13 +2,13 @@ package stop
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
@@ -16,7 +16,7 @@ func NewCmd() *cobra.Command {
 	var instance config.Installation
 	workingDir, err := os.Getwd()
 	if err != nil {
-		log.Fatal(err)
+		logging.Fatal(err)
 	}
 	instance.Path = workingDir
 

--- a/internal/extensionsskins/commands.go
+++ b/internal/extensionsskins/commands.go
@@ -2,7 +2,6 @@ package extensionsskins
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"strings"
 
@@ -10,6 +9,7 @@ import (
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
@@ -24,7 +24,7 @@ func NewCmd(constants Item) *cobra.Command {
 
 	workingDir, wdErr := os.Getwd()
 	if wdErr != nil {
-		log.Fatal(wdErr)
+		logging.Fatal(wdErr)
 	}
 	instance.Path = workingDir
 

--- a/internal/extensionsskins/extensionsskins.go
+++ b/internal/extensionsskins/extensionsskins.go
@@ -2,7 +2,6 @@ package extensionsskins
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
@@ -28,12 +27,12 @@ func Contains(list []string, element string) bool {
 }
 
 func List(instance config.Installation, orch orchestrators.Orchestrator, constants Item) error {
-	log.Printf("Available %s:\n", constants.Name)
+	fmt.Printf("Available %s:\n", constants.Name)
 	output, err := orch.ExecWithError(instance.Path, "web", "cd $MW_HOME/"+constants.RelativeInstallationPath+" && find -L * -maxdepth 0 -type d")
 	if err != nil {
 		return fmt.Errorf("failed to list %s: %s", constants.Name, output)
 	}
-	log.Print(output)
+	fmt.Print(output)
 	return nil
 }
 
@@ -50,7 +49,7 @@ func CheckInstalled(name string, instance config.Installation, orch orchestrator
 
 func Enable(name, wiki string, instance config.Installation, orch orchestrators.Orchestrator, constants Item) error {
 	if wiki == "" {
-		log.Println("You didn't specify a wiki. The extension or skin will affect all wikis in the corresponding Canasta instance.")
+		fmt.Println("You didn't specify a wiki. The extension or skin will affect all wikis in the corresponding Canasta instance.")
 	}
 
 	var filePath string
@@ -66,14 +65,14 @@ func Enable(name, wiki string, instance config.Installation, orch orchestrators.
 	output, err := orch.ExecWithError(instance.Path, "web", "ls "+filePath)
 
 	if err == nil {
-		log.Printf("%s %s is already enabled!\n", constants.Name, name)
+		fmt.Printf("%s %s is already enabled!\n", constants.Name, name)
 	} else if Contains(strings.Split(output, ":"), " No such file or directory\n") {
 		command := fmt.Sprintf(`echo -e "%s" > %s`, phpScript, filePath)
 		execOutput, execErr := orch.ExecWithError(instance.Path, "web", command)
 		if execErr != nil {
 			return fmt.Errorf("failed to enable %s %q for wiki %q: %s", constants.Name, name, wiki, execOutput)
 		}
-		log.Printf("%s %s enabled\n", constants.Name, name)
+		fmt.Printf("%s %s enabled\n", constants.Name, name)
 	}
 	return nil
 }
@@ -111,7 +110,7 @@ func CheckEnabled(name, wiki string, instance config.Installation, orch orchestr
 
 func Disable(name, wiki string, instance config.Installation, orch orchestrators.Orchestrator, constants Item) error {
 	if wiki == "" {
-		log.Println("You didn't specify a wiki. The common settings will disable the extension or skin in the corresponding Canasta instance.")
+		fmt.Println("You didn't specify a wiki. The common settings will disable the extension or skin in the corresponding Canasta instance.")
 	}
 
 	var filePath string
@@ -127,6 +126,6 @@ func Disable(name, wiki string, instance config.Installation, orch orchestrators
 	if err != nil {
 		return fmt.Errorf("failed to disable %s %q for wiki %q: %s", constants.Name, name, wiki, output)
 	}
-	log.Printf("%s %s disabled\n", constants.Name, name)
+	fmt.Printf("%s %s disabled\n", constants.Name, name)
 	return nil
 }


### PR DESCRIPTION
## Summary

- Replace `log.Print/Printf/Println` with `fmt.*` equivalents in `internal/extensionsskins/extensionsskins.go` — these are user-facing messages that should always print, not go through the log package
- Replace `log.Fatal` with `logging.Fatal` across all command packages so fatal errors print without a timestamp prefix
- Update imports accordingly (swap `"log"` for `"…/logging"` or remove `"log"` where `logging` was already imported)

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] `grep -rn 'log\.Fatal\|log\.Print' --include='*.go' | grep -v tools/docgen | grep -v internal/logging` returns nothing

Closes #408