### PR TITLE
Use direct exec instead of bash -c in execute.Run()

### DIFF
--- a/internal/devmode/devmode.go
+++ b/internal/devmode/devmode.go
@@ -120,7 +120,7 @@ func ExtractMediaWikiCode(installPath, baseImage string) error {
 
 	// Copy code from container to host, preserving symlinks
 	// CanastaBase uses relative symlinks (../canasta-extensions/X, ../user-extensions/X)
-	// Note: Can't use execute.Run here because it wraps commands in bash -c which breaks pipes
+	// Uses bash -c directly because this command requires a shell pipe
 	logging.Print(fmt.Sprintf("Copying MediaWiki code to %s...\n", codeDir))
 	tarCmd := fmt.Sprintf("docker exec %s tar -cf - -C /var/www/mediawiki/w . | tar -xf - -C %s", containerName, codeDir)
 	cmd := exec.Command("bash", "-c", tarCmd)

--- a/internal/execute/execute.go
+++ b/internal/execute/execute.go
@@ -45,7 +45,7 @@ func defaultRun(path, command string, cmdArgs ...string) (error, string) {
 	}
 
 	logging.Print(fmt.Sprint(command, " ", strings.Join(cmdArgs, " ")))
-	cmd := exec.Command("bash", "-c", command+" "+strings.Join(cmdArgs, " "))
+	cmd := exec.Command(command, cmdArgs...)
 	cmd.Stdout = io.MultiWriter(outWriter)
 	cmd.Stderr = io.MultiWriter(errWriter)
 

--- a/internal/execute/execute_test.go
+++ b/internal/execute/execute_test.go
@@ -1,0 +1,47 @@
+package execute
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRunExecutesDirect(t *testing.T) {
+	// Run a simple command and check output
+	err, output := Run("", "echo", "hello", "world")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got := strings.TrimSpace(output); got != "hello world" {
+		t.Errorf("Run() output = %q, want %q", got, "hello world")
+	}
+}
+
+func TestRunNoShellInterpretation(t *testing.T) {
+	// Verify that shell metacharacters are NOT interpreted.
+	// If Run still used bash -c, $HOME would be expanded by the shell.
+	err, output := Run("", "echo", "$HOME")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got := strings.TrimSpace(output); got != "$HOME" {
+		t.Errorf("Run() expanded shell variable: output = %q, want literal %q", got, "$HOME")
+	}
+}
+
+func TestRunWithPath(t *testing.T) {
+	dir := t.TempDir()
+	err, output := Run(dir, "pwd")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got := strings.TrimSpace(output); got != dir {
+		t.Errorf("Run() dir = %q, want %q", got, dir)
+	}
+}
+
+func TestRunCommandNotFound(t *testing.T) {
+	err, _ := Run("", "nonexistent-command-12345")
+	if err == nil {
+		t.Error("Run() expected error for nonexistent command, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- `execute.Run()` previously concatenated all arguments into a single string and passed them through `bash -c`, meaning every caller was subject to shell interpretation even though they pass arguments separately — a latent injection risk
- Switch to `exec.Command(command, cmdArgs...)` which executes directly without shell evaluation
- All existing callers already pass simple commands (`cp`, `rm`, `mv`, `docker`) with explicit arguments, so no behavioral change is expected
- Add tests verifying direct execution and that shell metacharacters are not interpreted

## Test plan

- [x] `canasta create -i test -w test -n localhost` — exercises `cp`, `docker compose up`, `install.php`
- [x] `canasta stop -i test` / `canasta start -i test` — docker compose lifecycle
- [x] `canasta extension list -i test` — exec into container
- [ ] `canasta backup create -i test -t test-backup` — mysqldump, restic (requires restic repository)
- [ ] `canasta backup restore -i test -s <snapshot>` — mysql restore, file copies (requires restic repository)
- [x] `canasta export -i test -w test` / `canasta import -i test -w test -d dump.sql` — mysqldump, file copy to/from container, mysql import
- [x] `canasta delete -i test` — docker compose down, `rm -rf`
- [ ] `canasta create` with dev mode enabled — exercises `devmode` code paths (separate setup required)

Fixes #425