### PR TITLE
Use ShellQuote for passwords in container shell commands

### DIFF
--- a/cmd/backup/create.go
+++ b/cmd/backup/create.go
@@ -61,7 +61,7 @@ func takeSnapshot(orch orchestrators.Orchestrator, instance config.Installation,
 	for _, id := range wikiIDs {
 		logging.Print(fmt.Sprintf("Dumping database for wiki '%s'...", id))
 		cmd := fmt.Sprintf("mysqldump -h db -u root -p%s --databases %s > %s",
-			EnvVariables["MYSQL_PASSWORD"], id, dumpPath(id))
+			orchestrators.ShellQuote(EnvVariables["MYSQL_PASSWORD"]), id, dumpPath(id))
 		_, err = orch.ExecWithError(instance.Path, "web", cmd)
 		if err != nil {
 			return fmt.Errorf("mysqldump failed for wiki '%s': %w", id, err)

--- a/cmd/backup/restore.go
+++ b/cmd/backup/restore.go
@@ -123,7 +123,7 @@ func restoreWiki(orch orchestrators.Orchestrator, instance config.Installation, 
 	// Import the database
 	logging.Print(fmt.Sprintf("Restoring database for wiki '%s'...", wikiID))
 	command := fmt.Sprintf("mysql -h db -u root -p%s < %s",
-		env["MYSQL_PASSWORD"], dumpPath(wikiID))
+		orchestrators.ShellQuote(env["MYSQL_PASSWORD"]), dumpPath(wikiID))
 	_, restoreErr := orch.ExecWithError(instance.Path, "web", command)
 	if restoreErr != nil {
 		os.RemoveAll(filepath.Join(instance.Path, "config", "backup"))
@@ -170,7 +170,7 @@ func restoreFull(orch orchestrators.Orchestrator, instance config.Installation, 
 	for _, id := range wikiIDs {
 		logging.Print(fmt.Sprintf("Restoring database for wiki '%s'...", id))
 		command := fmt.Sprintf("mysql -h db -u root -p%s < %s",
-			env["MYSQL_PASSWORD"], dumpPath(id))
+			orchestrators.ShellQuote(env["MYSQL_PASSWORD"]), dumpPath(id))
 		_, restoreErr := orch.ExecWithError(instance.Path, "web", command)
 		if restoreErr != nil {
 			return fmt.Errorf("Database restore failed for wiki '%s': %w", id, restoreErr)

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -105,13 +105,10 @@ func exportDatabase(instance config.Installation, wikiID, outputPath string) err
 		dbPassword = "mediawiki"
 	}
 
-	// Escape single quotes in password for shell safety
-	escapedPassword := strings.ReplaceAll(dbPassword, "'", "'\\''")
-
 	tempFile := fmt.Sprintf("/tmp/%s.sql", wikiID)
 
 	// Run mysqldump inside the db container (no --databases flag to avoid USE statements)
-	dumpCmd := fmt.Sprintf("mysqldump -u root -p'%s' %s > %s", escapedPassword, wikiID, tempFile)
+	dumpCmd := fmt.Sprintf("mysqldump -u root -p%s %s > %s", orchestrators.ShellQuote(dbPassword), wikiID, tempFile)
 	output, err := orch.ExecWithError(instance.Path, "db", dumpCmd)
 	if err != nil {
 		return fmt.Errorf("failed to export database: %s", output)

--- a/internal/mediawiki/mediawiki.go
+++ b/internal/mediawiki/mediawiki.go
@@ -61,8 +61,8 @@ func Install(path, yamlPath string, orch orchestrators.Orchestrator, canastaInfo
 		domainName := domainNames[i]
 
 		// Unset MW_SECRET_KEY so CanastaDefaultSettings.php doesn't think wiki is already configured
-		installCmd := fmt.Sprintf("env -u MW_SECRET_KEY php maintenance/install.php --skins='Vector' --dbserver=%s --dbname='%s' --confpath=%s --scriptpath=%s --server='https://%s' --installdbuser='%s' --installdbpass='%s' --dbuser='%s' --dbpass='%s' --pass='%s' '%s' '%s'",
-			dbServer, wikiID, confPath, scriptPath, domainName, "root", canastaInfo.RootDBPassword, canastaInfo.WikiDBUsername, canastaInfo.WikiDBPassword, canastaInfo.AdminPassword, wikiID, canastaInfo.AdminName)
+		installCmd := fmt.Sprintf("env -u MW_SECRET_KEY php maintenance/install.php --skins='Vector' --dbserver=%s --dbname=%s --confpath=%s --scriptpath=%s --server=%s --installdbuser='%s' --installdbpass=%s --dbuser='%s' --dbpass=%s --pass=%s %s %s",
+			dbServer, orchestrators.ShellQuote(wikiID), confPath, scriptPath, orchestrators.ShellQuote("https://"+domainName), "root", orchestrators.ShellQuote(canastaInfo.RootDBPassword), canastaInfo.WikiDBUsername, orchestrators.ShellQuote(canastaInfo.WikiDBPassword), orchestrators.ShellQuote(canastaInfo.AdminPassword), orchestrators.ShellQuote(wikiID), orchestrators.ShellQuote(canastaInfo.AdminName))
 
 		output, err := orch.ExecWithError(path, "web", installCmd)
 		if err != nil {
@@ -217,8 +217,8 @@ func InstallOne(installPath, id, domain, admin, adminPassword, dbuser, workingDi
 	} else {
 		installCmd = "php maintenance/install.php"
 	}
-	command := fmt.Sprintf("%s --skins='Vector' --dbserver=%s --dbname='%s' --confpath=%s --scriptpath=%s --server='https://%s' --installdbuser='%s' --installdbpass='%s' --dbuser='%s' --dbpass='%s'  --pass='%s' '%s' '%s'",
-		installCmd, dbServer, id, confPath, scriptPath, domain, installdbuser, installdbpass, dbuser, dbpass, adminPassword, id, admin)
+	command := fmt.Sprintf("%s --skins='Vector' --dbserver=%s --dbname=%s --confpath=%s --scriptpath=%s --server=%s --installdbuser='%s' --installdbpass=%s --dbuser='%s' --dbpass=%s --pass=%s %s %s",
+		installCmd, dbServer, orchestrators.ShellQuote(id), confPath, scriptPath, orchestrators.ShellQuote("https://"+domain), installdbuser, orchestrators.ShellQuote(installdbpass), dbuser, orchestrators.ShellQuote(dbpass), orchestrators.ShellQuote(adminPassword), orchestrators.ShellQuote(id), orchestrators.ShellQuote(admin))
 	output, err := orch.ExecWithError(installPath, "web", command)
 	if err != nil {
 		return fmt.Errorf("failed to run install.php for wiki %q: %s", id, output)
@@ -262,7 +262,7 @@ func RemoveDatabase(installPath, id string, orch orchestrators.Orchestrator) err
 	if err != nil {
 		return err
 	}
-	command := fmt.Sprintf("echo 'DROP DATABASE IF EXISTS %s;' | mysql -h db -u root -p'%s'", id, envVariables["MYSQL_PASSWORD"])
+	command := fmt.Sprintf("echo 'DROP DATABASE IF EXISTS %s;' | mysql -h db -u root -p%s", id, orchestrators.ShellQuote(envVariables["MYSQL_PASSWORD"]))
 	output, err := orch.ExecWithError(installPath, "db", command)
 	if err != nil {
 		return fmt.Errorf("Error while dropping database '%s': %v. Output: %s", id, err, output)

--- a/internal/orchestrators/orchestrator.go
+++ b/internal/orchestrators/orchestrator.go
@@ -113,7 +113,7 @@ func ImportDatabase(orch Orchestrator, databaseName, databasePath, dbPassword st
 		dbPassword = "mediawiki"
 	}
 
-	escapedPassword := strings.ReplaceAll(dbPassword, "'", "'\\''")
+	quotedPassword := ShellQuote(dbPassword)
 
 	isCompressed := strings.HasSuffix(databasePath, ".sql.gz")
 
@@ -142,13 +142,13 @@ func ImportDatabase(orch Orchestrator, databaseName, databasePath, dbPassword st
 		}
 	}
 
-	createCmdStr := fmt.Sprintf("mysql --no-defaults -u%s -p'%s' -e 'CREATE DATABASE IF NOT EXISTS %s'", dbUser, escapedPassword, databaseName)
+	createCmdStr := fmt.Sprintf("mysql --no-defaults -u%s -p%s -e 'CREATE DATABASE IF NOT EXISTS %s'", dbUser, quotedPassword, databaseName)
 	_, err = orch.ExecWithError(instance.Path, "db", createCmdStr)
 	if err != nil {
 		return fmt.Errorf("error creating database: %w", err)
 	}
 
-	importCmdStr := fmt.Sprintf("mysql --no-defaults -u%s -p'%s' %s < /tmp/%s.sql", dbUser, escapedPassword, databaseName, databaseName)
+	importCmdStr := fmt.Sprintf("mysql --no-defaults -u%s -p%s %s < /tmp/%s.sql", dbUser, quotedPassword, databaseName, databaseName)
 	_, err = orch.ExecWithError(instance.Path, "db", importCmdStr)
 	if err != nil {
 		return fmt.Errorf("error importing database: %w", err)

--- a/internal/orchestrators/shellquote.go
+++ b/internal/orchestrators/shellquote.go
@@ -1,0 +1,13 @@
+package orchestrators
+
+import "strings"
+
+// ShellQuote wraps a value in single quotes for safe use in a shell command
+// string passed to bash -c (e.g., via ExecWithError). Within single quotes,
+// bash does not expand variables, backticks, or other metacharacters. The only
+// character that cannot appear inside single quotes is a single quote itself,
+// which is handled by ending the quoted string, inserting an escaped single
+// quote, and reopening the quoted string: ' → '\''
+func ShellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/orchestrators/shellquote_test.go
+++ b/internal/orchestrators/shellquote_test.go
@@ -1,0 +1,29 @@
+package orchestrators
+
+import "testing"
+
+func TestShellQuote(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"simple", "'simple'"},
+		{"with space", "'with space'"},
+		{"has'quote", `'has'\''quote'`},
+		{"$HOME", "'$HOME'"},
+		{"`whoami`", "'`whoami`'"},
+		{"$(id)", "'$(id)'"},
+		{"back\\slash", "'back\\slash'"},
+		{"semi;colon", "'semi;colon'"},
+		{"", "''"},
+		{"multi'ple'quotes", `'multi'\''ple'\''quotes'`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := ShellQuote(tt.input)
+			if got != tt.want {
+				t.Errorf("ShellQuote(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `ShellQuote()` helper that wraps values in single quotes with proper escaping of embedded single quotes — the only character that can break single-quoted strings in bash
- Apply it to all password interpolations in container commands passed to `ExecWithError()`, which runs them through `bash -c` inside the container
- Remove ad-hoc single-quote escaping in `export.go` and `orchestrator.go` that this supersedes

### Files changed

- `internal/orchestrators/shellquote.go` — new helper + tests
- `internal/mediawiki/mediawiki.go` — `Install()`, `InstallOne()`, `RemoveDatabase()`
- `internal/orchestrators/orchestrator.go` — `ImportDatabase()`
- `cmd/export/export.go` — `exportDatabase()`
- `cmd/backup/create.go` — `takeSnapshot()`
- `cmd/backup/restore.go` — `restoreWiki()`, `restoreFull()`

## Test plan

- [x] `canasta create` — exercises install.php with password args
- [x] `canasta export` — exercises mysqldump with password
- [x] `canasta import` — exercises ImportDatabase with password
- [x] `canasta delete` — exercises RemoveDatabase with password
- [ ] `canasta backup create` / `canasta backup restore` — requires restic repository

Fixes #424