### PR TITLE
Replace kirsle/configdir with stdlib os.UserConfigDir()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/CanastaWiki/Canasta-CLI
 go 1.24.0
 
 require (
-	github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f
 	github.com/schollz/progressbar/v3 v3.13.1
 	github.com/spf13/cobra v1.4.0
 	golang.org/x/crypto v0.48.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,6 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213/go.mod h1:vNUNkEQ1e29fT/6vq2aBdFsgNPmy8qMdSay1npru+Sw=
-github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f h1:dKccXx7xA56UNqOcFIbuqFjAWPVtP688j5QMgmo6OHU=
-github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f/go.mod h1:4rEELDSfUAlBSyUjPG0JnaNGjf13JySHFeRdD/3dLP0=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
 	"github.com/CanastaWiki/Canasta-CLI/internal/permissions"
-	"github.com/kirsle/configdir"
 )
 
 type Installation struct {
@@ -337,7 +336,11 @@ func read(details *Canasta) error {
 }
 
 func GetConfigDir() (string, error) {
-	dir := configdir.LocalConfig("canasta")
+	base, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("unable to determine config directory: %w", err)
+	}
+	dir := filepath.Join(base, "canasta")
 
 	// Checks if this is running as root
 	currentUser, err := user.Current()


### PR DESCRIPTION
## Summary

- Replace the stale `kirsle/configdir` dependency (last updated 2017, no tagged releases) with `os.UserConfigDir()` from the Go standard library (available since Go 1.13)
- `configdir.LocalConfig("canasta")` is replaced with `filepath.Join(os.UserConfigDir(), "canasta")`, which provides equivalent behavior on all platforms
- Removes one external dependency from `go.mod`

Fixes #430

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./...` all tests pass
- [x] `kirsle/configdir` removed from `go.mod` and `go.sum`
- [x] `canasta list` shows existing installations (config dir resolved correctly)
- [ ] `canasta create` creates new installation (config dir created if needed)