### PR TITLE
Code quality: dead code, naming, filepath.Join, RemoveAll warnings

### DIFF
--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -123,7 +123,7 @@ an existing database dump instead of running the installer.`,
 
 			// Generate admin password only if not importing and admin is provided
 			if databasePath == "" && adminPassword == "" {
-				adminPassword, err = canasta.GeneratePassword("admin")
+				adminPassword, err = canasta.GeneratePassword()
 				if err != nil {
 					return err
 				}

--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -41,12 +41,12 @@ and RESTIC_PASSWORD to be configured in the installation's .env file.`,
 			if err != nil {
 				return err
 			}
-			envPath = instance.Path + "/.env"
-			EnvVariables, envErr := canasta.GetEnvVariable(envPath)
+			envPath = filepath.Join(instance.Path, ".env")
+			envVariables, envErr := canasta.GetEnvVariable(envPath)
 			if envErr != nil {
 				return envErr
 			}
-			repoURL = getRepoURL(EnvVariables)
+			repoURL = getRepoURL(envVariables)
 
 			orch, err = orchestrators.New(instance.Orchestrator)
 			if err != nil {

--- a/cmd/import/import.go
+++ b/cmd/import/import.go
@@ -1,3 +1,5 @@
+// Package importcmd implements the "canasta import" command.
+// The name avoids conflicting with Go's "import" keyword.
 package importcmd
 
 import (

--- a/internal/canasta/canasta_test.go
+++ b/internal/canasta/canasta_test.go
@@ -99,15 +99,20 @@ func TestSaveEnvVariable(t *testing.T) {
 	}
 }
 
-func TestGeneratePasswords(t *testing.T) {
+func TestGenerateAdminAndDBPasswords(t *testing.T) {
 	info := CanastaVariables{
 		Id:        "test",
 		AdminName: "admin",
 	}
 
-	result, err := GeneratePasswords(t.TempDir(), info)
+	result, err := GenerateAdminPassword(info)
 	if err != nil {
-		t.Fatalf("GeneratePasswords() error = %v", err)
+		t.Fatalf("GenerateAdminPassword() error = %v", err)
+	}
+
+	result, err = GenerateDBPasswords(result)
+	if err != nil {
+		t.Fatalf("GenerateDBPasswords() error = %v", err)
 	}
 
 	// Check admin password
@@ -142,9 +147,14 @@ func TestGeneratePasswordsPreserveExisting(t *testing.T) {
 		WikiDBPassword: "mywikipass",
 	}
 
-	result, err := GeneratePasswords(t.TempDir(), info)
+	result, err := GenerateAdminPassword(info)
 	if err != nil {
-		t.Fatalf("GeneratePasswords() error = %v", err)
+		t.Fatalf("GenerateAdminPassword() error = %v", err)
+	}
+
+	result, err = GenerateDBPasswords(result)
+	if err != nil {
+		t.Fatalf("GenerateDBPasswords() error = %v", err)
 	}
 
 	if result.AdminPassword != "myadminpass" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -158,7 +158,7 @@ func ListAll() error {
 			continue
 		}
 
-		if _, err := os.Stat(installation.Path + "/config/wikis.yaml"); os.IsNotExist(err) {
+		if _, err := os.Stat(filepath.Join(installation.Path, "config", "wikis.yaml")); os.IsNotExist(err) {
 			// File does not exist, print only installation info
 			fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\n",
 				installation.Id,
@@ -170,7 +170,7 @@ func ListAll() error {
 			continue
 		}
 
-		ids, serverNames, paths, err := farmsettings.ReadWikisYaml(installation.Path + "/config/wikis.yaml")
+		ids, serverNames, paths, err := farmsettings.ReadWikisYaml(filepath.Join(installation.Path, "config", "wikis.yaml"))
 		if err != nil {
 			fmt.Printf("Error reading wikis.yaml for installation ID '%s': %s\n", installation.Id, err)
 			continue

--- a/internal/mediawiki/mediawiki.go
+++ b/internal/mediawiki/mediawiki.go
@@ -135,7 +135,7 @@ func InstallOne(installPath, id, domain, admin, adminPassword, dbuser, workingDi
 	var err error
 	logging.Print("Configuring MediaWiki Installation\n")
 	logging.Print("Running install.php\n")
-	envVariables, err := canasta.GetEnvVariable(installPath + "/.env")
+	envVariables, err := canasta.GetEnvVariable(filepath.Join(installPath, ".env"))
 	if err != nil {
 		return err
 	}
@@ -257,7 +257,7 @@ func InstallOne(installPath, id, domain, admin, adminPassword, dbuser, workingDi
 }
 
 func RemoveDatabase(installPath, id string, orch orchestrators.Orchestrator) error {
-	envVariables, err := canasta.GetEnvVariable(installPath + "/.env")
+	envVariables, err := canasta.GetEnvVariable(filepath.Join(installPath, ".env"))
 	if err != nil {
 		return err
 	}

--- a/internal/orchestrators/compose.go
+++ b/internal/orchestrators/compose.go
@@ -553,7 +553,7 @@ func (c *ComposeOrchestrator) CopyOverrideFile(installPath, sourceFilename, work
 		if !filepath.IsAbs(sourceFilename) {
 			sourceFilename = filepath.Join(workingDir, sourceFilename)
 		}
-		var overrideFilename = installPath + "/docker-compose.override.yml"
+		var overrideFilename = filepath.Join(installPath, "docker-compose.override.yml")
 		logging.Print(fmt.Sprintf("Copying %s to %s\n", sourceFilename, overrideFilename))
 		err, output := execute.Run("", "cp", sourceFilename, overrideFilename)
 		if err != nil {

--- a/internal/orchestrators/kind.go
+++ b/internal/orchestrators/kind.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"text/template"
@@ -186,7 +187,7 @@ func GetPortsFromEnv(installPath string) (httpPort int, httpsPort int) {
 	httpPort = 80
 	httpsPort = 443
 
-	envPath := installPath + "/.env"
+	envPath := filepath.Join(installPath, ".env")
 	envVars, err := canasta.GetEnvVariable(envPath)
 	if err != nil {
 		return


### PR DESCRIPTION
## Summary

Grouped small code quality fixes from audit #423:

- **Dead code removal (#426):** Remove unused `GeneratePasswords()` wrapper (only called from tests) and unused `purpose` parameter from `GeneratePassword()`. Tests updated to call `GenerateAdminPassword()`/`GenerateDBPasswords()` directly.
- **Naming fixes (#427):** Fix `snake_case` locals in `GetEnvVariable()` (`file_data` → `fileData`, `variable_list` → `variableList`) and PascalCase locals in backup commands (`EnvVariables` → `envVariables`). Add package comment for `importcmd` explaining the Go keyword conflict.
- **filepath.Join (#429):** Replace `installPath + "/..."` string concatenation with `filepath.Join()` in `canasta.go`, `mediawiki.go`, `config.go`, `compose.go`, `kind.go`, and `backup.go`.
- **RemoveAll warnings (#433):** Log warnings for previously-ignored `os.RemoveAll()` errors in backup create and restore via a shared `cleanupBackupDir()` helper.

Fixes #426, #427, #429, #433

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./...` all tests pass (including updated `TestGenerateAdminAndDBPasswords`)
- [x] `canasta create` / `canasta delete` — verify path handling works correctly
- [ ] `canasta backup create` / `canasta backup restore` — verify backup operations (requires backup infrastructure)