### PR TITLE
Add extension/skin name validation and refactor InstallOne()

### DIFF
--- a/internal/extensionsskins/extensionsskins_test.go
+++ b/internal/extensionsskins/extensionsskins_test.go
@@ -1,0 +1,53 @@
+package extensionsskins
+
+import "testing"
+
+func TestValidateName(t *testing.T) {
+	constants := Item{CmdName: "extension"}
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"simple name", "VisualEditor", false},
+		{"underscore", "Semantic_MediaWiki", false},
+		{"hyphen", "My-Extension", false},
+		{"dot", "Auth.v2", false},
+		{"digits", "Extension123", false},
+		{"starts with digit", "3DAlloy", false},
+		{"empty", "", true},
+		{"shell metachar backtick", "ext`id`", true},
+		{"shell metachar dollar", "ext$(cmd)", true},
+		{"semicolon", "ext;rm -rf /", true},
+		{"space", "Visual Editor", true},
+		{"single quote", "ext'name", true},
+		{"double quote", `ext"name`, true},
+		{"slash", "ext/name", true},
+		{"starts with hyphen", "-extension", true},
+		{"starts with dot", ".hidden", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateName(tt.input, constants)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateName(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestContains(t *testing.T) {
+	list := []string{"VisualEditor", "Cite", "ParserFunctions"}
+
+	if !Contains(list, "Cite") {
+		t.Error("expected Contains to return true for 'Cite'")
+	}
+	if Contains(list, "Missing") {
+		t.Error("expected Contains to return false for 'Missing'")
+	}
+	if Contains(nil, "anything") {
+		t.Error("expected Contains to return false for nil list")
+	}
+}


### PR DESCRIPTION
## Summary

- **Extension/skin name validation (#432):** Add `ValidateName()` to the `extensionsskins` package that rejects names containing shell metacharacters (backticks, `$()`, semicolons, quotes, slashes, spaces, etc.). Names must match `^[a-zA-Z0-9][a-zA-Z0-9_.\-]*$`. Validation is called in `CheckInstalled`, `CheckEnabled`, `Enable`, and `Disable`.
- **InstallOne refactor (#431):** Extract the legacy settings detection, backup, and restore logic from `InstallOne()` into two helper functions: `backupLegacySettings()` and `restoreLegacySettings()`. This reduces `InstallOne()` from ~123 lines to ~65 lines and isolates the three-architecture branching (wikis.yaml vs CommonSettings.php vs LocalSettings.php).
- New test file `extensionsskins_test.go` with tests for `ValidateName()` and `Contains()`.

Fixes #431, #432

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./...` all tests pass
- [x] `canasta extension enable VisualEditor` — valid name accepted
- [x] `canasta extension enable "ext;rm -rf /"` — rejected with validation error
- [x] `canasta add -w newwiki` — InstallOne still works correctly for adding wikis