### PR TITLE
Fix package declaration bug and ShellQuote wiki IDs

### DIFF
--- a/cmd/backup/create.go
+++ b/cmd/backup/create.go
@@ -61,7 +61,7 @@ func takeSnapshot(orch orchestrators.Orchestrator, instance config.Installation,
 	for _, id := range wikiIDs {
 		logging.Print(fmt.Sprintf("Dumping database for wiki '%s'...", id))
 		cmd := fmt.Sprintf("mysqldump -h db -u root -p%s --databases %s > %s",
-			orchestrators.ShellQuote(envVariables["MYSQL_PASSWORD"]), id, dumpPath(id))
+			orchestrators.ShellQuote(envVariables["MYSQL_PASSWORD"]), orchestrators.ShellQuote(id), dumpPath(id))
 		_, err = orch.ExecWithError(instance.Path, orchestrators.ServiceWeb, cmd)
 		if err != nil {
 			return fmt.Errorf("mysqldump failed for wiki '%s': %w", id, err)

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -1,4 +1,4 @@
-package start
+package delete
 
 import (
 	"bufio"

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -3,6 +3,7 @@ package export
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -96,7 +97,7 @@ func exportDatabase(instance config.Installation, wikiID, outputPath string) err
 	}
 
 	// Read the database password from .env
-	envVariables, err := canasta.GetEnvVariable(instance.Path + "/.env")
+	envVariables, err := canasta.GetEnvVariable(filepath.Join(instance.Path, ".env"))
 	if err != nil {
 		return err
 	}
@@ -108,7 +109,7 @@ func exportDatabase(instance config.Installation, wikiID, outputPath string) err
 	tempFile := fmt.Sprintf("/tmp/%s.sql", wikiID)
 
 	// Run mysqldump inside the db container (no --databases flag to avoid USE statements)
-	dumpCmd := fmt.Sprintf("mysqldump -u root -p%s %s > %s", orchestrators.ShellQuote(dbPassword), wikiID, tempFile)
+	dumpCmd := fmt.Sprintf("mysqldump -u root -p%s %s > %s", orchestrators.ShellQuote(dbPassword), orchestrators.ShellQuote(wikiID), tempFile)
 	output, err := orch.ExecWithError(instance.Path, orchestrators.ServiceDB, dumpCmd)
 	if err != nil {
 		return fmt.Errorf("failed to export database: %s", output)

--- a/internal/mediawiki/mediawiki.go
+++ b/internal/mediawiki/mediawiki.go
@@ -272,7 +272,7 @@ func RemoveDatabase(installPath, id string, orch orchestrators.Orchestrator) err
 	if err != nil {
 		return err
 	}
-	command := fmt.Sprintf("echo 'DROP DATABASE IF EXISTS %s;' | mysql -h db -u root -p%s", id, orchestrators.ShellQuote(envVariables["MYSQL_PASSWORD"]))
+	command := fmt.Sprintf("echo 'DROP DATABASE IF EXISTS %s;' | mysql -h db -u root -p%s", orchestrators.ShellQuote(id), orchestrators.ShellQuote(envVariables["MYSQL_PASSWORD"]))
 	output, err := orch.ExecWithError(installPath, orchestrators.ServiceDB, command)
 	if err != nil {
 		return fmt.Errorf("Error while dropping database '%s': %v. Output: %s", id, err, output)

--- a/internal/orchestrators/orchestrator.go
+++ b/internal/orchestrators/orchestrator.go
@@ -120,6 +120,7 @@ func ImportDatabase(orch Orchestrator, databaseName, databasePath, dbPassword st
 	}
 
 	quotedPassword := ShellQuote(dbPassword)
+	quotedDBName := ShellQuote(databaseName)
 
 	isCompressed := strings.HasSuffix(databasePath, ".sql.gz")
 
@@ -148,13 +149,13 @@ func ImportDatabase(orch Orchestrator, databaseName, databasePath, dbPassword st
 		}
 	}
 
-	createCmdStr := fmt.Sprintf("mysql --no-defaults -u%s -p%s -e 'CREATE DATABASE IF NOT EXISTS %s'", dbUser, quotedPassword, databaseName)
+	createCmdStr := fmt.Sprintf("mysql --no-defaults -u%s -p%s -e 'CREATE DATABASE IF NOT EXISTS %s'", dbUser, quotedPassword, quotedDBName)
 	_, err = orch.ExecWithError(instance.Path, ServiceDB, createCmdStr)
 	if err != nil {
 		return fmt.Errorf("error creating database: %w", err)
 	}
 
-	importCmdStr := fmt.Sprintf("mysql --no-defaults -u%s -p%s %s < /tmp/%s.sql", dbUser, quotedPassword, databaseName, databaseName)
+	importCmdStr := fmt.Sprintf("mysql --no-defaults -u%s -p%s %s < /tmp/%s.sql", dbUser, quotedPassword, quotedDBName, databaseName)
 	_, err = orch.ExecWithError(instance.Path, ServiceDB, importCmdStr)
 	if err != nil {
 		return fmt.Errorf("error importing database: %w", err)


### PR DESCRIPTION
## Summary
- Fix wrong `package start` declaration in `cmd/delete/delete.go` → `package delete`
- Apply `ShellQuote()` to wiki IDs and database names in shell commands across `cmd/export/export.go`, `cmd/backup/create.go`, `internal/orchestrators/orchestrator.go`, and `internal/mediawiki/mediawiki.go`
- Replace `instance.Path + "/.env"` with `filepath.Join()` in `cmd/export/export.go` (co-located with the ShellQuote fix in that file)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Verify `canasta delete` still works (package rename)
- [x] Verify database export/backup/import commands handle wiki IDs with special characters

Fixes #441