### PR TITLE
Code consistency: filepath.Join, NormalizeWikiID, TrimSpace

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -167,7 +167,7 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
 				stopSpinner()
 				fmt.Print(err.Error(), "\n")
 				if !keepConfig {
-					deleteConfigAndContainers(path+"/"+canastaInfo.Id, orch)
+					deleteConfigAndContainers(filepath.Join(path, canastaInfo.Id), orch)
 					return fmt.Errorf("Installation failed and files were cleaned up")
 				}
 				return fmt.Errorf("Installation failed. Keeping all the containers and config files")
@@ -291,7 +291,7 @@ func createCanasta(opts createOptions) error {
 	// Always set CANASTA_IMAGE in .env so the installation is pinned to a
 	// specific image. For default installs this is the CLI's pinned version;
 	// for --canasta-image or --build-from it's the user-specified image.
-	if err := canasta.SaveEnvVariable(path+"/.env", "CANASTA_IMAGE", baseImage); err != nil {
+	if err := canasta.SaveEnvVariable(filepath.Join(path, ".env"), "CANASTA_IMAGE", baseImage); err != nil {
 		return err
 	}
 	if err := canasta.CopySettings(path); err != nil {
@@ -343,7 +343,7 @@ func createCanasta(opts createOptions) error {
 				return fmt.Errorf("failed to push image to registry: %w", err)
 			}
 			// Update .env so kustomization.yaml references the registry image
-			if err := canasta.SaveEnvVariable(path+"/.env", "CANASTA_IMAGE", remoteTag); err != nil {
+			if err := canasta.SaveEnvVariable(filepath.Join(path, ".env"), "CANASTA_IMAGE", remoteTag); err != nil {
 				return err
 			}
 		}
@@ -378,7 +378,7 @@ func createCanasta(opts createOptions) error {
 			return err
 		}
 
-		envVariables, envErr := canasta.GetEnvVariable(path + "/.env")
+		envVariables, envErr := canasta.GetEnvVariable(filepath.Join(path, ".env"))
 		if envErr != nil {
 			return envErr
 		}

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -338,8 +338,7 @@ func extractSecretKey(installPath string, dryRun bool) (bool, error) {
 	wikiIDs, _, _, err := farmsettings.ReadWikisYaml(yamlPath)
 	if err == nil {
 		for _, wikiID := range wikiIDs {
-			id := strings.ReplaceAll(wikiID, " ", "_")
-			id = regexp.MustCompile("[^a-zA-Z0-9_]+").ReplaceAllString(id, "")
+			id := canasta.NormalizeWikiID(wikiID)
 			// Check new path first, fall back to legacy (same pattern as canasta.go)
 			newPath := filepath.Join(installPath, "config", "settings", "wikis", id, "LocalSettings.php")
 			legacyPath := filepath.Join(installPath, "config", id, "LocalSettings.php")
@@ -409,9 +408,7 @@ func migrateDirectoryStructure(installPath string, dryRun bool) (bool, error) {
 	}
 
 	for _, wikiID := range wikiIDs {
-		// Normalize wikiID (same as in canasta.go)
-		id := strings.ReplaceAll(wikiID, " ", "_")
-		id = regexp.MustCompile("[^a-zA-Z0-9_]+").ReplaceAllString(id, "")
+		id := canasta.NormalizeWikiID(wikiID)
 
 		legacyPath := filepath.Join(installPath, "config", id)
 		newPath := filepath.Join(installPath, "config", "settings", "wikis", id)

--- a/internal/extensionsskins/commands.go
+++ b/internal/extensionsskins/commands.go
@@ -101,6 +101,7 @@ for a specific wiki only.`, constants.Plural, constants.Plural, article(constant
 		RunE: func(cmd *cobra.Command, args []string) error {
 			names := strings.Split(args[0], ",")
 			for _, name := range names {
+				name = strings.TrimSpace(name)
 				checkedName, err := CheckInstalled(name, *instance, *orch, *constants)
 				if err != nil {
 					fmt.Print(err.Error() + "\n")
@@ -141,6 +142,7 @@ for a specific wiki only.`, constants.Plural, constants.Plural, article(constant
 		RunE: func(cmd *cobra.Command, args []string) error {
 			names := strings.Split(args[0], ",")
 			for _, name := range names {
+				name = strings.TrimSpace(name)
 				checkedName, err := CheckEnabled(name, *wiki, *instance, *orch, *constants)
 				if err != nil {
 					fmt.Print(err.Error() + "\n")


### PR DESCRIPTION
## Summary
- Replace string concatenation with `filepath.Join()` in `cmd/create/create.go` and `internal/canasta/canasta.go`
- Move `NormalizeWikiID` regex to a package-level compiled `var` and replace inline duplicates in `cmd/upgrade/upgrade.go` with `canasta.NormalizeWikiID()`
- Add `strings.TrimSpace()` after comma split in the extension/skin enable and disable commands

Note: the `cmd/export/export.go` filepath.Join fix listed in #443 is included in PR #446 instead, co-located with the ShellQuote fix in that file to avoid conflicting diffs.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Verify `canasta create` works (filepath.Join changes)
- [x] Verify `canasta extension enable` accepts comma-separated names with whitespace

Fixes #443