### PR TITLE
Refactor maintenance package to use closure-scoped state

### DIFF
--- a/cmd/maintenanceUpdate/exec.go
+++ b/cmd/maintenanceUpdate/exec.go
@@ -7,10 +7,11 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
+	"github.com/CanastaWiki/Canasta-CLI/internal/config"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-func newExecCmd() *cobra.Command {
+func newExecCmd(instance *config.Installation) *cobra.Command {
 	var service string
 
 	cmd := &cobra.Command{
@@ -36,7 +37,8 @@ The default service is "web" (the MediaWiki container).`,
   # Default service is "web", so this also works
   canasta maintenance exec -i myinstance -- php -v`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			instance, err = canasta.CheckCanastaId(instance)
+			var err error
+			*instance, err = canasta.CheckCanastaId(*instance)
 			return err
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -47,7 +49,7 @@ The default service is "web" (the MediaWiki container).`,
 
 			// No service flag and no args: list services
 			if service == "" && len(args) == 0 {
-				services, err := orch.ListServices(instance)
+				services, err := orch.ListServices(*instance)
 				if err != nil {
 					return err
 				}
@@ -69,7 +71,7 @@ The default service is "web" (the MediaWiki container).`,
 			}
 
 			// Ensure containers are running
-			if err := orch.CheckRunningStatus(instance); err != nil {
+			if err := orch.CheckRunningStatus(*instance); err != nil {
 				return fmt.Errorf("containers are not running: %w", err)
 			}
 
@@ -85,7 +87,7 @@ The default service is "web" (the MediaWiki container).`,
 				command = []string{"/bin/bash"}
 			}
 
-			return orch.ExecInteractive(instance, service, command)
+			return orch.ExecInteractive(*instance, service, command)
 		},
 	}
 

--- a/cmd/maintenanceUpdate/maintenance.go
+++ b/cmd/maintenanceUpdate/maintenance.go
@@ -9,14 +9,13 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 )
 
-var (
-	instance config.Installation
-	wiki     string
-	all      bool
-	err      error
-)
-
 func NewCmd() *cobra.Command {
+	var (
+		instance config.Installation
+		wiki     string
+		all      bool
+	)
+
 	workingDir, wdErr := os.Getwd()
 	if wdErr != nil {
 		logging.Fatal(wdErr)
@@ -31,10 +30,10 @@ group provides subcommands to run the standard update sequence, execute
 arbitrary core maintenance scripts, or run extension-specific maintenance scripts.`,
 	}
 
-	maintenanceCmd.AddCommand(newUpdateCmd())
-	maintenanceCmd.AddCommand(newScriptCmd())
-	maintenanceCmd.AddCommand(newExtensionCmd())
-	maintenanceCmd.AddCommand(newExecCmd())
+	maintenanceCmd.AddCommand(newUpdateCmd(&instance, &wiki, &all))
+	maintenanceCmd.AddCommand(newScriptCmd(&instance, &wiki))
+	maintenanceCmd.AddCommand(newExtensionCmd(&instance, &wiki, &all))
+	maintenanceCmd.AddCommand(newExecCmd(&instance))
 
 	maintenanceCmd.PersistentFlags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
 	maintenanceCmd.PersistentFlags().StringVarP(&wiki, "wiki", "w", "", "Wiki ID to run maintenance on")

--- a/cmd/maintenanceUpdate/maintenanceScript.go
+++ b/cmd/maintenanceUpdate/maintenanceScript.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newScriptCmd() *cobra.Command {
+func newScriptCmd(instance *config.Installation, wiki *string) *cobra.Command {
 
 	scriptCmd := &cobra.Command{
 		Use:   `script ["scriptname.php [args]"]`,
@@ -35,14 +35,15 @@ Use --wiki to target a specific wiki in a farm.`,
   canasta maintenance script "rebuildrecentchanges.php" -i myinstance --wiki=docs`,
 		Args: cobra.RangeArgs(0, 1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			instance, err = canasta.CheckCanastaId(instance)
+			var err error
+			*instance, err = canasta.CheckCanastaId(*instance)
 			return err
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return listMaintenanceScripts(instance)
+				return listMaintenanceScripts(*instance)
 			}
-			return runMaintenanceScript(instance, args[0], wiki)
+			return runMaintenanceScript(*instance, args[0], *wiki)
 		},
 	}
 

--- a/cmd/maintenanceUpdate/maintenanceUpdate.go
+++ b/cmd/maintenanceUpdate/maintenanceUpdate.go
@@ -18,7 +18,7 @@ var (
 	skipSMW  bool
 )
 
-func newUpdateCmd() *cobra.Command {
+func newUpdateCmd(instance *config.Installation, wiki *string, all *bool) *cobra.Command {
 
 	updateCmd := &cobra.Command{
 		Use:   "update",
@@ -38,34 +38,35 @@ automatically.`,
   canasta maintenance update -i myinstance --all
   canasta maintenance update -i myinstance --skip-jobs --skip-smw`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			instance, err = canasta.CheckCanastaId(instance)
+			var err error
+			*instance, err = canasta.CheckCanastaId(*instance)
 			return err
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if wiki != "" && all {
+			if *wiki != "" && *all {
 				return fmt.Errorf("cannot use --wiki with --all")
 			}
-			if all {
-				wikiIDs, err := getWikiIDs(instance)
+			if *all {
+				wikiIDs, err := getWikiIDs(*instance)
 				if err != nil {
 					return err
 				}
 				for _, id := range wikiIDs {
-					if err := runMaintenanceUpdate(instance, id); err != nil {
+					if err := runMaintenanceUpdate(*instance, id); err != nil {
 						return err
 					}
 				}
-			} else if wiki != "" {
-				if err := runMaintenanceUpdate(instance, wiki); err != nil {
+			} else if *wiki != "" {
+				if err := runMaintenanceUpdate(*instance, *wiki); err != nil {
 					return err
 				}
 			} else {
-				wikiIDs, err := getWikiIDs(instance)
+				wikiIDs, err := getWikiIDs(*instance)
 				if err != nil {
 					return err
 				}
 				if len(wikiIDs) == 1 {
-					if err := runMaintenanceUpdate(instance, wikiIDs[0]); err != nil {
+					if err := runMaintenanceUpdate(*instance, wikiIDs[0]); err != nil {
 						return err
 					}
 				} else {

--- a/cmd/maintenanceUpdate/maintenance_test.go
+++ b/cmd/maintenanceUpdate/maintenance_test.go
@@ -116,14 +116,6 @@ func TestWikiAndAllConflict(t *testing.T) {
 	// Override PreRunE to skip CheckCanastaId
 	updateCmd.PreRunE = nil
 
-	// Set wiki and all flags, then execute
-	wiki = "docs"
-	all = true
-	defer func() {
-		wiki = ""
-		all = false
-	}()
-
 	cmd.SetArgs([]string{"update", "--wiki=docs", "--all"})
 	err := cmd.Execute()
 	if err == nil {


### PR DESCRIPTION
## Summary
- Move package-level `instance`, `wiki`, `all`, and `err` variables in `cmd/maintenanceUpdate/` into `NewCmd()` as local variables
- Pass them as pointers to subcommand constructors (`newUpdateCmd`, `newScriptCmd`, `newExtensionCmd`, `newExecCmd`)
- This follows the pattern used by other command packages and eliminates the package-level `var err` that shadows the built-in

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (including `TestWikiAndAllConflict`)
- [x] Verify `canasta maintenance update/script/extension/exec` subcommands register correctly

Fixes #444