### PR TITLE
Minor fixes: version.go, devmode.go, compose.go, Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,12 @@ build:
 		@./build.sh
 		@go mod tidy
 		@go mod verify
-		@sudo cp ${OUTPUT} /usr/local/bin/${APP_NAME}
 		@echo "Build complete: ${OUTPUT}"
+		@echo "To run the CLI, use \033[0;32m./${APP_NAME}\033[0m or run 'make install' to install system-wide"
+
+install: build
+		@sudo cp ${OUTPUT} /usr/local/bin/${APP_NAME}
 		@echo "Installed to: /usr/local/bin/${APP_NAME}"
-		@echo "To run the CLI, use \033[0;32m${APP_NAME}\033[0m"
 
 clean:
 		@echo "Cleaning build artifacts..."
@@ -35,6 +37,7 @@ help:
 		@printf "\n"
 		@printf "\e[1mBuild\e[0m\n"
 		@printf "  \e[36mbuild\e[0m                    Build binary (outputs to build/ directory and creates symlink).\n"
+		@printf "  \e[36minstall\e[0m                  Build and install to /usr/local/bin/ (requires sudo).\n"
 		@printf "  \e[36mclean\e[0m                    Remove build artifacts and symlink.\n"
 		@printf "\n"
 		@printf "\e[1mTest\e[0m\n"
@@ -42,4 +45,4 @@ help:
 		@printf "  \e[36mlint\e[0m                     Run lint.\n"
 		@printf "\n"
 
-.PHONY: build clean prepare-lint lint help
+.PHONY: build install clean prepare-lint lint help

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -2,7 +2,6 @@ package version
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -27,7 +26,6 @@ Shows "dev" if the binary was built without version information.`,
 				v = "dev"
 			}
 			fmt.Printf("Canasta CLI %s (commit %s, built %s)\n", v, sha1, buildTime)
-			os.Exit(0)
 			return nil
 		},
 	}

--- a/internal/devmode/devmode.go
+++ b/internal/devmode/devmode.go
@@ -106,6 +106,10 @@ func ExtractMediaWikiCode(installPath, baseImage string) error {
 	// Start a container and run the symlinks script to create extension/skin symlinks
 	// (normally /create-symlinks.sh runs as part of the entrypoint, but we bypass it with sleep)
 	containerName := "canasta-code-extract-temp"
+
+	// Remove any orphaned container from a previous failed extraction
+	_, _ = execute.Run("", "docker", "rm", "-f", containerName)
+
 	logging.Print("Starting temporary container for code extraction...\n")
 	if err, output := execute.Run("", "docker", "run", "-d", "--name", containerName, baseImage, "sleep", "infinity"); err != nil {
 		return fmt.Errorf("failed to start temporary container: %s", output)

--- a/internal/orchestrators/compose.go
+++ b/internal/orchestrators/compose.go
@@ -340,7 +340,9 @@ func (c *ComposeOrchestrator) Destroy(installPath string) (string, error) {
 	}
 
 	// Remove the backup staging volume (not part of docker-compose.yml)
-	execute.Run("", "docker", "volume", "rm", backupVolumeName(installPath))
+	if rmErr, rmOutput := execute.Run("", "docker", "volume", "rm", backupVolumeName(installPath)); rmErr != nil {
+		logging.Print(fmt.Sprintf("Warning: failed to remove backup volume: %s\n", rmOutput))
+	}
 
 	return output, nil
 }


### PR DESCRIPTION
## Summary
- Remove `os.Exit(0)` before unreachable `return nil` in `cmd/version/version.go`
- Add `docker rm -f` cleanup for orphaned temp containers in `internal/devmode/devmode.go`
- Log warning on volume removal failure in `internal/orchestrators/compose.go` Destroy()
- Split Makefile `build` (compile only) and `install` (build + sudo copy) targets

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Verify `canasta version` works
- [x] Verify `canasta devmode` registers correctly
- [x] Verify `make build` no longer requires sudo

Fixes #445