### PR TITLE
Remove --all flag from maintenance commands, default to all wikis

### DIFF
--- a/cmd/maintenanceUpdate/extension_test.go
+++ b/cmd/maintenanceUpdate/extension_test.go
@@ -168,7 +168,7 @@ func TestListExtensionsWithMaintenance(t *testing.T) {
 	}
 	inst := config.Installation{Path: "/test"}
 	// Pass a specific wiki to avoid needing wikis.yaml
-	err := listExtensionsWithMaintenanceWith(mock, inst, "main", false)
+	err := listExtensionsWithMaintenanceWith(mock, inst, "main")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -184,7 +184,7 @@ func TestListExtensionsFiltersToLoaded(t *testing.T) {
 	}
 	inst := config.Installation{Path: "/test"}
 	// We can't easily capture stdout in this test, but at least verify no error
-	err := listExtensionsWithMaintenanceWith(mock, inst, "main", false)
+	err := listExtensionsWithMaintenanceWith(mock, inst, "main")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -213,7 +213,7 @@ extensions/SemanticMediaWiki/maintenance/setupStore.php`,
 		},
 	}
 	inst := config.Installation{Path: "/test"}
-	err := listExtensionScriptsWith(mock, inst, "SemanticMediaWiki", "main", false)
+	err := listExtensionScriptsWith(mock, inst, "SemanticMediaWiki", "main")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -226,7 +226,7 @@ func TestListExtensionScriptsNotLoaded(t *testing.T) {
 		},
 	}
 	inst := config.Installation{Path: "/test"}
-	err := listExtensionScriptsWith(mock, inst, "SemanticMediaWiki", "main", false)
+	err := listExtensionScriptsWith(mock, inst, "SemanticMediaWiki", "main")
 	if err == nil {
 		t.Fatal("expected error for extension not loaded")
 	}
@@ -242,7 +242,7 @@ func TestListExtensionScriptsNotFound(t *testing.T) {
 		},
 	}
 	inst := config.Installation{Path: "/test"}
-	err := listExtensionScriptsWith(mock, inst, "NonExistent", "main", false)
+	err := listExtensionScriptsWith(mock, inst, "NonExistent", "main")
 	if err == nil {
 		t.Fatal("expected error for non-existent extension")
 	}

--- a/cmd/maintenanceUpdate/maintenance.go
+++ b/cmd/maintenanceUpdate/maintenance.go
@@ -13,7 +13,6 @@ func NewCmd() *cobra.Command {
 	var (
 		instance config.Installation
 		wiki     string
-		all      bool
 	)
 
 	workingDir, wdErr := os.Getwd()
@@ -30,13 +29,12 @@ group provides subcommands to run the standard update sequence, execute
 arbitrary core maintenance scripts, or run extension-specific maintenance scripts.`,
 	}
 
-	maintenanceCmd.AddCommand(newUpdateCmd(&instance, &wiki, &all))
+	maintenanceCmd.AddCommand(newUpdateCmd(&instance, &wiki))
 	maintenanceCmd.AddCommand(newScriptCmd(&instance, &wiki))
-	maintenanceCmd.AddCommand(newExtensionCmd(&instance, &wiki, &all))
+	maintenanceCmd.AddCommand(newExtensionCmd(&instance, &wiki))
 	maintenanceCmd.AddCommand(newExecCmd(&instance))
 
 	maintenanceCmd.PersistentFlags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
-	maintenanceCmd.PersistentFlags().StringVarP(&wiki, "wiki", "w", "", "Wiki ID to run maintenance on")
-	maintenanceCmd.PersistentFlags().BoolVar(&all, "all", false, "Run for all wikis in the farm")
+	maintenanceCmd.PersistentFlags().StringVarP(&wiki, "wiki", "w", "", "Wiki ID to run maintenance on (default: all wikis)")
 	return maintenanceCmd
 }

--- a/cmd/maintenanceUpdate/maintenance_test.go
+++ b/cmd/maintenanceUpdate/maintenance_test.go
@@ -36,7 +36,6 @@ func TestMaintenancePersistentFlags(t *testing.T) {
 	}{
 		{"id", "i"},
 		{"wiki", "w"},
-		{"all", ""},
 	}
 
 	for _, f := range flags {
@@ -106,22 +105,3 @@ func TestUpdateFlagParsing(t *testing.T) {
 	}
 }
 
-func TestWikiAndAllConflict(t *testing.T) {
-	cmd := NewCmd()
-	updateCmd := findSubcommand(cmd, "update")
-	if updateCmd == nil {
-		t.Fatal("update subcommand not found")
-	}
-
-	// Override PreRunE to skip CheckCanastaId
-	updateCmd.PreRunE = nil
-
-	cmd.SetArgs([]string{"update", "--wiki=docs", "--all"})
-	err := cmd.Execute()
-	if err == nil {
-		t.Fatal("expected error when --wiki and --all are both set")
-	}
-	if err.Error() != "cannot use --wiki with --all" {
-		t.Errorf("unexpected error: %v", err)
-	}
-}


### PR DESCRIPTION
## Summary
- Remove the `--all` persistent flag from `canasta maintenance`
- When `--wiki` is not specified, maintenance commands now run on all wikis by default
- Simplifies the interface: `--wiki=X` targets one wiki, omitting it targets all
- Update help text, examples, and tests accordingly

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (29 maintenance tests)
- [x] `canasta maintenance --help` shows no `--all` flag
- [x] `canasta maintenance update --help` describes default-to-all behavior

Fixes #451