### PR TITLE
Apply ShellQuote to unquoted values in shell commands

### DIFF
--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -133,7 +134,7 @@ func RemoveWiki(instance config.Installation, wikiID string, yes bool) error {
 
 	// Remove the Images (from inside container first to handle www-data ownership on Linux)
 	if containersRunning {
-		cleanupCmd := fmt.Sprintf("rm -rf /mediawiki/images/%s", wikiID)
+		cleanupCmd := fmt.Sprintf("rm -rf %s", orchestrators.ShellQuote(filepath.Join("/mediawiki/images", wikiID)))
 		_, _ = orch.ExecWithError(instance.Path, orchestrators.ServiceWeb, cleanupCmd)
 	}
 	err = canasta.RemoveImages(instance.Path, wikiID)

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -134,7 +133,7 @@ func RemoveWiki(instance config.Installation, wikiID string, yes bool) error {
 
 	// Remove the Images (from inside container first to handle www-data ownership on Linux)
 	if containersRunning {
-		cleanupCmd := fmt.Sprintf("rm -rf %s", orchestrators.ShellQuote(filepath.Join("/mediawiki/images", wikiID)))
+		cleanupCmd := fmt.Sprintf("rm -rf %s", orchestrators.ShellQuote("/mediawiki/images/"+wikiID))
 		_, _ = orch.ExecWithError(instance.Path, orchestrators.ServiceWeb, cleanupCmd)
 	}
 	err = canasta.RemoveImages(instance.Path, wikiID)

--- a/cmd/sitemap/remove.go
+++ b/cmd/sitemap/remove.go
@@ -86,7 +86,7 @@ func runRemove(instance config.Installation, orch orchestrators.Orchestrator, wi
 	}
 
 	for _, id := range wikiIDs {
-		fspath := "/mediawiki/public_assets/" + id + "/sitemap"
+		fspath := orchestrators.ShellQuote("/mediawiki/public_assets/" + id + "/sitemap")
 		rmCmd := fmt.Sprintf("find %s -mindepth 1 -delete 2>/dev/null; true", fspath)
 		if _, err := orch.ExecWithError(instance.Path, orchestrators.ServiceWeb, rmCmd); err != nil {
 			return fmt.Errorf("failed to remove sitemap files for wiki '%s': %w", id, err)


### PR DESCRIPTION
## Summary
- Quote `wikiID` in `rm -rf` command in `cmd/remove/remove.go`
- Quote wiki ID-derived path in `find` command in `cmd/sitemap/remove.go`
- Quote `logPath` in `find` command in `cmd/backup/schedule.go` (would break if installation path contains spaces)

Fixes #454
Part of #453

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] Verify ShellQuote is applied consistently to all interpolated values in shell commands