### PR TITLE
Replace string concatenation with filepath.Join for .env paths

### DIFF
--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	urlpkg "net/url"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -227,7 +228,7 @@ func AddWiki(opts AddWikiOptions) error {
 
 	// Import the database if databasePath is specified
 	if opts.DatabasePath != "" {
-		envVariables, envErr := canasta.GetEnvVariable(opts.Instance.Path + "/.env")
+		envVariables, envErr := canasta.GetEnvVariable(filepath.Join(opts.Instance.Path, ".env"))
 		if envErr != nil {
 			return envErr
 		}

--- a/cmd/devmode/enable.go
+++ b/cmd/devmode/enable.go
@@ -2,6 +2,7 @@ package devmode
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -26,7 +27,7 @@ the instance with dev mode compose files. Only supported with Docker Compose.`,
 
 			// Determine the base image: check .env for CANASTA_IMAGE, fall back to default
 			baseImage := canasta.GetDefaultImage()
-			envVars, envErr := canasta.GetEnvVariable(instance.Path + "/.env")
+			envVars, envErr := canasta.GetEnvVariable(filepath.Join(instance.Path, ".env"))
 			if envErr == nil {
 				if img, ok := envVars["CANASTA_IMAGE"]; ok && img != "" {
 					baseImage = img

--- a/cmd/import/import.go
+++ b/cmd/import/import.go
@@ -5,6 +5,7 @@ package importcmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -100,7 +101,7 @@ To create a new wiki from a database dump, use the --database flag with
 
 func importDatabase(orch orchestrators.Orchestrator, instance config.Installation, wikiID, databasePath, settingsPath, workingDir string) error {
 	// Read database password from .env
-	envVariables, err := canasta.GetEnvVariable(instance.Path + "/.env")
+	envVariables, err := canasta.GetEnvVariable(filepath.Join(instance.Path, ".env"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- Replace `instance.Path + "/.env"` with `filepath.Join(instance.Path, ".env")` in:
  - `cmd/import/import.go`
  - `cmd/add/add.go`
  - `cmd/devmode/enable.go`

Fixes #456
Part of #453

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes