### PR TITLE
Scope package-level vars and log cleanup errors

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -422,15 +422,21 @@ func createCanasta(opts createOptions) error {
 
 func deleteConfigAndContainers(installationDir string, orch orchestrators.Orchestrator) {
 	fmt.Println("Removing containers")
-	_, _ = orch.Destroy(installationDir)
+	if _, err := orch.Destroy(installationDir); err != nil {
+		fmt.Printf("Warning: failed to remove containers: %v\n", err)
+	}
 	// Clean up any kind cluster created during this attempt.
 	// KindClusterName derives the name from the directory basename (the ID).
 	// DeleteKindCluster is a no-op if the cluster doesn't exist.
 	if _, ok := orch.(*orchestrators.KubernetesOrchestrator); ok {
 		clusterName := orchestrators.KindClusterName(filepath.Base(installationDir))
-		_ = orchestrators.DeleteKindCluster(clusterName)
+		if err := orchestrators.DeleteKindCluster(clusterName); err != nil {
+			fmt.Printf("Warning: failed to delete kind cluster: %v\n", err)
+		}
 	}
 	fmt.Println("Deleting config files")
-	_, _ = orchestrators.DeleteConfig(installationDir)
+	if _, err := orchestrators.DeleteConfig(installationDir); err != nil {
+		fmt.Printf("Warning: failed to delete config files: %v\n", err)
+	}
 	fmt.Println("Deleted all containers and config files")
 }

--- a/cmd/maintenanceUpdate/maintenanceUpdate.go
+++ b/cmd/maintenanceUpdate/maintenanceUpdate.go
@@ -13,12 +13,11 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-var (
-	skipJobs bool
-	skipSMW  bool
-)
-
 func newUpdateCmd(instance *config.Installation, wiki *string) *cobra.Command {
+	var (
+		skipJobs bool
+		skipSMW  bool
+	)
 
 	updateCmd := &cobra.Command{
 		Use:   "update",
@@ -42,14 +41,14 @@ specific wiki.`,
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if *wiki != "" {
-				return runMaintenanceUpdate(*instance, *wiki)
+				return runMaintenanceUpdate(*instance, *wiki, skipJobs, skipSMW)
 			}
 			wikiIDs, err := getWikiIDs(*instance)
 			if err != nil {
 				return err
 			}
 			for _, id := range wikiIDs {
-				if err := runMaintenanceUpdate(*instance, id); err != nil {
+				if err := runMaintenanceUpdate(*instance, id, skipJobs, skipSMW); err != nil {
 					return err
 				}
 			}
@@ -72,7 +71,7 @@ func getWikiIDs(instance config.Installation) ([]string, error) {
 	return ids, nil
 }
 
-func runMaintenanceUpdate(instance config.Installation, wikiID string) error {
+func runMaintenanceUpdate(instance config.Installation, wikiID string, skipJobs, skipSMW bool) error {
 	orch, err := orchestrators.New(instance.Orchestrator)
 	if err != nil {
 		return err

--- a/cmd/maintenanceUpdate/maintenance_test.go
+++ b/cmd/maintenanceUpdate/maintenance_test.go
@@ -89,19 +89,24 @@ func TestUpdateFlagParsing(t *testing.T) {
 		t.Fatal("update subcommand not found")
 	}
 
-	// Reset package-level variables
-	skipJobs = false
-	skipSMW = false
-
 	if err := updateCmd.ParseFlags([]string{"--skip-jobs", "--skip-smw"}); err != nil {
 		t.Fatalf("ParseFlags error: %v", err)
 	}
 
+	skipJobs, err := updateCmd.Flags().GetBool("skip-jobs")
+	if err != nil {
+		t.Fatalf("GetBool skip-jobs error: %v", err)
+	}
 	if !skipJobs {
-		t.Error("--skip-jobs should set skipJobs to true")
+		t.Error("--skip-jobs should be true after parsing")
+	}
+
+	skipSMW, err := updateCmd.Flags().GetBool("skip-smw")
+	if err != nil {
+		t.Fatalf("GetBool skip-smw error: %v", err)
 	}
 	if !skipSMW {
-		t.Error("--skip-smw should set skipSMW to true")
+		t.Error("--skip-smw should be true after parsing")
 	}
 }
 

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -22,9 +22,9 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/selfupdate"
 )
 
-var dryRun bool
-
 func NewCmd() *cobra.Command {
+	var dryRun bool
+
 	var upgradeCmd = &cobra.Command{
 		Use:   "upgrade",
 		Short: "Upgrade the Canasta CLI and all registered installations",


### PR DESCRIPTION
## Summary
- Move `dryRun` from package level into `NewCmd()` in `cmd/upgrade/upgrade.go`
- Move `skipJobs`/`skipSMW` from package level into `newUpdateCmd()` in `cmd/maintenanceUpdate/maintenanceUpdate.go`, passing them as parameters to `runMaintenanceUpdate()`
- Log warnings when `Destroy()` or `DeleteConfig()` fail during cleanup in `cmd/create/create.go` instead of silently discarding errors

Fixes #457
Part of #453

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] Verify `skipJobs`/`skipSMW` and `dryRun` are no longer package-level vars
- [x] Verify cleanup errors in `deleteConfigAndContainers` produce warning messages