### PR TITLE
Run update.php automatically after enabling extensions/skins

### DIFF
--- a/cmd/maintenanceUpdate/extension.go
+++ b/cmd/maintenanceUpdate/extension.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	maint "github.com/CanastaWiki/Canasta-CLI/internal/maintenance"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
@@ -309,7 +310,7 @@ func resolveWikiIDs(inst config.Installation, wikiFlag string) ([]string, error)
 	if wikiFlag != "" {
 		return []string{wikiFlag}, nil
 	}
-	return getWikiIDs(inst)
+	return maint.GetWikiIDs(inst)
 }
 
 // getLoadedExtensions queries MediaWiki for the list of extensions currently

--- a/cmd/maintenanceUpdate/extension.go
+++ b/cmd/maintenanceUpdate/extension.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
-	maint "github.com/CanastaWiki/Canasta-CLI/internal/maintenance"
+	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
@@ -310,7 +310,7 @@ func resolveWikiIDs(inst config.Installation, wikiFlag string) ([]string, error)
 	if wikiFlag != "" {
 		return []string{wikiFlag}, nil
 	}
-	return maint.GetWikiIDs(inst)
+	return farmsettings.GetWikiIDs(inst.Path)
 }
 
 // getLoadedExtensions queries MediaWiki for the list of extensions currently

--- a/cmd/maintenanceUpdate/maintenanceUpdate.go
+++ b/cmd/maintenanceUpdate/maintenanceUpdate.go
@@ -2,14 +2,13 @@ package maintenance
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
-	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
+	maint "github.com/CanastaWiki/Canasta-CLI/internal/maintenance"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
@@ -43,7 +42,7 @@ specific wiki.`,
 			if *wiki != "" {
 				return runMaintenanceUpdate(*instance, *wiki, skipJobs, skipSMW)
 			}
-			wikiIDs, err := getWikiIDs(*instance)
+			wikiIDs, err := maint.GetWikiIDs(*instance)
 			if err != nil {
 				return err
 			}
@@ -62,18 +61,13 @@ specific wiki.`,
 	return updateCmd
 }
 
-func getWikiIDs(instance config.Installation) ([]string, error) {
-	yamlPath := filepath.Join(instance.Path, "config", "wikis.yaml")
-	ids, _, _, err := farmsettings.ReadWikisYaml(yamlPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read wikis.yaml: %v", err)
-	}
-	return ids, nil
-}
-
 func runMaintenanceUpdate(instance config.Installation, wikiID string, skipJobs, skipSMW bool) error {
 	orch, err := orchestrators.New(instance.Orchestrator)
 	if err != nil {
+		return err
+	}
+
+	if err := maint.RunUpdatePhp(instance, orch, wikiID); err != nil {
 		return err
 	}
 
@@ -84,12 +78,6 @@ func runMaintenanceUpdate(instance config.Installation, wikiID string, skipJobs,
 	wikiMsg := ""
 	if wikiID != "" {
 		wikiMsg = " for wiki '" + wikiID + "'"
-	}
-
-	fmt.Printf("Running update.php%s...\n", wikiMsg)
-	if err := orch.ExecStreaming(instance.Path, orchestrators.ServiceWeb,
-		"php maintenance/update.php --quick"+wikiFlag); err != nil {
-		return fmt.Errorf("update.php failed%s: %v", wikiMsg, err)
 	}
 
 	if !skipJobs {

--- a/cmd/maintenanceUpdate/maintenanceUpdate.go
+++ b/cmd/maintenanceUpdate/maintenanceUpdate.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
 	maint "github.com/CanastaWiki/Canasta-CLI/internal/maintenance"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
@@ -42,7 +43,7 @@ specific wiki.`,
 			if *wiki != "" {
 				return runMaintenanceUpdate(*instance, *wiki, skipJobs, skipSMW)
 			}
-			wikiIDs, err := maint.GetWikiIDs(*instance)
+			wikiIDs, err := farmsettings.GetWikiIDs(instance.Path)
 			if err != nil {
 				return err
 			}

--- a/internal/farmsettings/farmsettings.go
+++ b/internal/farmsettings/farmsettings.go
@@ -124,6 +124,16 @@ func ReadWikisYaml(filePath string) ([]string, []string, []string, error) {
 	return ids, serverNames, paths, nil
 }
 
+// GetWikiIDs returns the list of wiki IDs from the installation's wikis.yaml.
+func GetWikiIDs(installPath string) ([]string, error) {
+	filePath := filepath.Join(installPath, "config", "wikis.yaml")
+	ids, _, _, err := ReadWikisYaml(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read wikis.yaml: %v", err)
+	}
+	return ids, nil
+}
+
 // WikiIDExists checks if a wiki with the given wikiID exists in the installation
 func WikiIDExists(installPath, wikiID string) (bool, error) {
 	// Get the absolute path to the wikis.yaml file

--- a/internal/maintenance/update.go
+++ b/internal/maintenance/update.go
@@ -1,0 +1,57 @@
+package maintenance
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
+	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
+)
+
+// GetWikiIDs returns the list of wiki IDs from the instance's wikis.yaml.
+func GetWikiIDs(instance config.Installation) ([]string, error) {
+	yamlPath := filepath.Join(instance.Path, "config", "wikis.yaml")
+	ids, _, _, err := farmsettings.ReadWikisYaml(yamlPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read wikis.yaml: %v", err)
+	}
+	return ids, nil
+}
+
+// RunUpdatePhp runs update.php --quick for a single wiki.
+func RunUpdatePhp(instance config.Installation, orch orchestrators.Orchestrator, wikiID string) error {
+	wikiFlag := ""
+	if wikiID != "" {
+		wikiFlag = " --wiki=" + wikiID
+	}
+	wikiMsg := ""
+	if wikiID != "" {
+		wikiMsg = " for wiki '" + wikiID + "'"
+	}
+
+	fmt.Printf("Running update.php%s...\n", wikiMsg)
+	if err := orch.ExecStreaming(instance.Path, orchestrators.ServiceWeb,
+		"php maintenance/update.php --quick"+wikiFlag); err != nil {
+		return fmt.Errorf("update.php failed%s: %v", wikiMsg, err)
+	}
+	return nil
+}
+
+// RunUpdateAllWikis runs update.php --quick. If wiki is non-empty, runs only
+// for that wiki. Otherwise runs for all wikis from wikis.yaml.
+func RunUpdateAllWikis(instance config.Installation, orch orchestrators.Orchestrator, wiki string) error {
+	if wiki != "" {
+		return RunUpdatePhp(instance, orch, wiki)
+	}
+	wikiIDs, err := GetWikiIDs(instance)
+	if err != nil {
+		return err
+	}
+	for _, id := range wikiIDs {
+		if err := RunUpdatePhp(instance, orch, id); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/maintenance/update.go
+++ b/internal/maintenance/update.go
@@ -2,22 +2,11 @@ package maintenance
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
 	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
-
-// GetWikiIDs returns the list of wiki IDs from the instance's wikis.yaml.
-func GetWikiIDs(instance config.Installation) ([]string, error) {
-	yamlPath := filepath.Join(instance.Path, "config", "wikis.yaml")
-	ids, _, _, err := farmsettings.ReadWikisYaml(yamlPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read wikis.yaml: %v", err)
-	}
-	return ids, nil
-}
 
 // RunUpdatePhp runs update.php --quick for a single wiki.
 func RunUpdatePhp(instance config.Installation, orch orchestrators.Orchestrator, wikiID string) error {
@@ -44,7 +33,7 @@ func RunUpdateAllWikis(instance config.Installation, orch orchestrators.Orchestr
 	if wiki != "" {
 		return RunUpdatePhp(instance, orch, wiki)
 	}
-	wikiIDs, err := GetWikiIDs(instance)
+	wikiIDs, err := farmsettings.GetWikiIDs(instance.Path)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- Extracts reusable maintenance update functions (`RunUpdatePhp`, `RunUpdateAllWikis`) into a new `internal/maintenance` package
- Moves `GetWikiIDs` to `internal/farmsettings` where it belongs alongside the other wiki-config functions
- After enabling extensions or skins, `update.php --quick` is automatically run for all relevant wikis to apply any required database schema changes
- Adds `--skip-update` flag to bypass the automatic `update.php` run

Resolves #464
See also CanastaWiki/Canasta-DockerCompose#67

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] `canasta extension enable VisualEditor -i <instance>` enables the extension and runs `update.php`
- [x] `canasta extension enable VisualEditor -i <instance> --skip-update` enables without running `update.php`
- [x] `canasta skin enable Timeless -i <instance>` enables the skin and runs `update.php`
- [x] `canasta maintenance update -i <instance>` still works as before
- [x] `canasta extension enable VisualEditor -i <instance> -w docs` runs `update.php` only for the specified wiki