### PR TITLE
Fix docgen empty backticks for flags without shorthand

### DIFF
--- a/tools/docgen/main.go
+++ b/tools/docgen/main.go
@@ -150,10 +150,10 @@ func flagsToTable(flags *pflag.FlagSet) string {
 
 		shorthand := ""
 		if flag.Shorthand != "" {
-			shorthand = "-" + flag.Shorthand
+			shorthand = "`-" + flag.Shorthand + "`"
 		}
 
-		name := "--" + flag.Name
+		name := "`--" + flag.Name + "`"
 
 		// Escape pipe characters in description
 		description := strings.ReplaceAll(flag.Usage, "|", "\\|")
@@ -165,7 +165,7 @@ func flagsToTable(flags *pflag.FlagSet) string {
 			defaultVal = "`" + flag.DefValue + "`"
 		}
 
-		buf.WriteString(fmt.Sprintf("| `%s` | `%s` | %s | %s |\n", name, shorthand, description, defaultVal))
+		buf.WriteString(fmt.Sprintf("| %s | %s | %s | %s |\n", name, shorthand, description, defaultVal))
 	})
 
 	return buf.String()


### PR DESCRIPTION
## Summary

- Apply backticks conditionally in the shorthand and flag name columns of the flag table, matching the pattern already used for the default value column
- Flags without a shorthand now produce an empty table cell instead of ` `` `

Resolves #466

## Test plan

- [x] `go build ./...` and `go vet ./...` pass
- [x] Regenerated docs with `cd tools/docgen && go run .` — no empty backticks in any flag table