### PR TITLE
Fix db container health check stalling on restart

### DIFF
--- a/cmd/upgrade/upgrade_test.go
+++ b/cmd/upgrade/upgrade_test.go
@@ -25,28 +25,33 @@ func TestRemoveSkipBinaryAsHex(t *testing.T) {
 			wantChanged: false,
 		},
 		{
-			name:        "in mysql section",
+			name:        "in mysql section preserved",
 			content:     "[mysql]\nskip-binary-as-hex = true\n",
-			wantChanged: true,
-			wantContent: "[mysql]\n",
+			wantChanged: false,
 		},
 		{
-			name:        "in client section",
+			name:        "in client section removed",
 			content:     "[client]\nskip-binary-as-hex = true\nport=3306\n",
 			wantChanged: true,
 			wantContent: "[client]\nport=3306\n",
 		},
 		{
-			name:        "in multiple sections",
+			name:        "in both sections only client removed",
 			content:     "[mysql]\nskip-binary-as-hex = true\n[client]\nskip-binary-as-hex = true\n",
 			wantChanged: true,
-			wantContent: "[mysql]\n[client]\n",
+			wantContent: "[mysql]\nskip-binary-as-hex = true\n[client]\n",
 		},
 		{
-			name:        "loose prefixed variant",
-			content:     "[mysql]\nloose-skip-binary-as-hex = true\n",
+			name:        "before any section header removed",
+			content:     "skip-binary-as-hex = true\n[mysql]\nport=3306\n",
 			wantChanged: true,
-			wantContent: "[mysql]\n",
+			wantContent: "[mysql]\nport=3306\n",
+		},
+		{
+			name:        "in mysqld section removed",
+			content:     "[mysqld]\nskip-binary-as-hex = true\nmax_connections=100\n",
+			wantChanged: true,
+			wantContent: "[mysqld]\nmax_connections=100\n",
 		},
 	}
 
@@ -85,7 +90,7 @@ func TestRemoveSkipBinaryAsHex(t *testing.T) {
 func TestRemoveSkipBinaryAsHexDryRun(t *testing.T) {
 	tmpDir := t.TempDir()
 	filePath := filepath.Join(tmpDir, "my.cnf")
-	content := "[mysql]\nskip-binary-as-hex = true\n"
+	content := "[client]\nskip-binary-as-hex = true\n"
 	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/canasta/installation-template/my.cnf
+++ b/internal/canasta/installation-template/my.cnf
@@ -1,2 +1,2 @@
-[mysql]
-skip-binary-as-hex = true
+# MySQL/MariaDB configuration
+# See https://dev.mysql.com/doc/refman/8.0/en/option-files.html

--- a/internal/canasta/installation-template/my.cnf
+++ b/internal/canasta/installation-template/my.cnf
@@ -1,2 +1,2 @@
-# MySQL/MariaDB configuration
-# See https://dev.mysql.com/doc/refman/8.0/en/option-files.html
+[mysql]
+skip-binary-as-hex = true

--- a/internal/orchestrators/compose/files/docker-compose.yml
+++ b/internal/orchestrators/compose/files/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - MYSQL_ROOT_HOST=%
       - MYSQL_ROOT_PASSWORD=${MYSQL_PASSWORD}
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u root -p$$MYSQL_ROOT_PASSWORD"]
       interval: 10s
       timeout: 5s
       retries: 30


### PR DESCRIPTION
Fixes #471

## Summary

- Switch db health check from `CMD` to `CMD-SHELL` so `$MYSQL_ROOT_PASSWORD` is evaluated inside the container where it's defined, not on the host where only `MYSQL_PASSWORD` exists in `.env`
- Add upgrade migration to remove `skip-binary-as-hex` from non-`[mysql]` sections of existing installations' `my.cnf` (not recognized by `mysqladmin`, breaks health check) - to fix old Canasta installations

## Test plan

- [x] Migration preserves `skip-binary-as-hex` in `[mysql]` section
- [x] Migration removes `skip-binary-as-hex` from `[client]`, `[mysqld]`, and other sections
- [x] Migration removes `skip-binary-as-hex` appearing before any section header
- [x] Migration is a no-op when `skip-binary-as-hex` is absent or file is missing
- [x] `canasta upgrade --dry-run` reports the migration without applying it
- [ ] `canasta restart` completes without the db health check stalling