### PR TITLE
Remove Postfix references from CLI

### DIFF
--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -64,8 +64,6 @@ var knownKeys = map[string]bool{
 	"CANASTA_ENABLE_ELASTICSEARCH":  true,
 	"CANASTA_ENABLE_OBSERVABILITY":  true,
 	"CANASTA_ENABLE_WIKI_DIRECTORY": true,
-	// Email
-	"MW_ENABLE_POSTFIX": true,
 	// Caddy / TLS
 	"CADDY_AUTO_HTTPS": true,
 	// Docker Image

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -173,7 +173,7 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
 				return fmt.Errorf("Installation failed. Keeping all the containers and config files")
 			}
 			stopSpinner()
-			fmt.Println("\033[32mEmail is sent via the built-in mail server, which works but messages may be flagged as spam. To improve deliverability, you can configure $wgSMTP to use an authenticated SMTP provider instead. See https://mediawiki.org/wiki/Manual:$wgSMTP\033[0m")
+			fmt.Println("\033[32mPlease note that mailing does not currently work on this wiki, because Canasta requires $wgSMTP to be set in order to send emails (see https://www.mediawiki.org/wiki/Manual:$wgSMTP).\033[0m")
 			fmt.Println("Done.")
 			return nil
 		},


### PR DESCRIPTION
## Summary

- Update installation completion message to indicate mailing requires `$wgSMTP`
- Remove `MW_ENABLE_POSTFIX` from `knownKeys` allowlist in `cmd/config/set.go`
- Rewrite `docs/guide/email.md` to remove Postfix references and document `$wgSMTP` as required

Companion PR: https://github.com/CanastaWiki/CanastaBase/pull/120

Closes #473