### PR TITLE
Increase memory requirement from 2 GB to 4 GB

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -56,8 +56,8 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
   # Create with an existing database dump
   canasta create -i myinstance -w main -d /path/to/dump.sql -n example.com`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Check if the system has at least 2GB of memory
-			if err := system.CheckMemoryInGB(2); err != nil {
+			// Check if the system has at least 4GB of memory
+			if err := system.CheckMemoryInGB(4); err != nil {
 				return err
 			}
 			// Validate wiki ID if yamlPath not provided

--- a/docs/guide/general-concepts.md
+++ b/docs/guide/general-concepts.md
@@ -4,6 +4,7 @@ This page covers foundational concepts that apply to all Canasta installations, 
 
 ## Contents
 
+- [System requirements](#system-requirements)
 - [Installation IDs](#installation-ids)
 - [Wiki IDs](#wiki-ids)
 - [Installation directory structure](#installation-directory-structure)
@@ -18,6 +19,14 @@ This page covers foundational concepts that apply to all Canasta installations, 
 - [Custom Canasta images](#custom-canasta-images)
 - [Deploying behind a reverse proxy](#deploying-behind-a-reverse-proxy)
 - [Running on non-standard ports](#running-on-non-standard-ports)
+
+---
+
+## System requirements
+
+Canasta requires at least **4 GB of available memory** to run. The `canasta create` command checks available memory before proceeding and will exit with an error if the system does not meet this requirement.
+
+For production use, 8 GB or more of total system memory is recommended, especially if Elasticsearch is enabled.
 
 ---
 


### PR DESCRIPTION
## Summary

- Increase the minimum available memory check in `canasta create` from 2 GB to 4 GB
- Add a system requirements section to the general concepts docs

Closes #470