### PR TITLE
Fix backup/restore shell command quoting

### DIFF
--- a/internal/orchestrators/backup.go
+++ b/internal/orchestrators/backup.go
@@ -45,7 +45,7 @@ func stageToVolume(volName string, volumes map[string]string) error {
 	}
 
 	shellCmd := "rm -rf /currentsnapshot/* && " + strings.Join(copyParts, " && ")
-	cmdArgs = append(cmdArgs, "alpine", "sh", "-c", "'"+shellCmd+"'")
+	cmdArgs = append(cmdArgs, "alpine", "sh", "-c", shellCmd)
 
 	err, output := execute.Run("", cmdArgs[0], cmdArgs[1:]...)
 	if err != nil {
@@ -100,7 +100,7 @@ func restoreFromVolume(volName, installPath string, dirs map[string]string) erro
 	}
 
 	shellCmd := strings.Join(copyParts, " && ")
-	cmdArgs = append(cmdArgs, "alpine", "sh", "-c", "'"+shellCmd+"'")
+	cmdArgs = append(cmdArgs, "alpine", "sh", "-c", shellCmd)
 
 	err, output := execute.Run("", cmdArgs[0], cmdArgs[1:]...)
 	if err != nil {

--- a/internal/orchestrators/backup_test.go
+++ b/internal/orchestrators/backup_test.go
@@ -1,6 +1,11 @@
 package orchestrators
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/execute"
+)
 
 func TestBackupVolumeName(t *testing.T) {
 	tests := []struct {
@@ -16,5 +21,58 @@ func TestBackupVolumeName(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("backupVolumeName(%q) = %q, want %q", tt.installPath, got, tt.want)
 		}
+	}
+}
+
+// captureShellArg installs a mock execute.Run that records the argument
+// passed to "sh -c" and returns it. The mock succeeds without error.
+func captureShellArg(t *testing.T) *string {
+	t.Helper()
+	var captured string
+	execute.Run = func(path, command string, args ...string) (error, string) {
+		for i, a := range args {
+			if a == "-c" && i > 0 && args[i-1] == "sh" && i+1 < len(args) {
+				captured = args[i+1]
+			}
+		}
+		return nil, ""
+	}
+	t.Cleanup(execute.ResetForTesting)
+	return &captured
+}
+
+func TestStageToVolumeNoQuotesAroundShellCmd(t *testing.T) {
+	shellArg := captureShellArg(t)
+
+	volumes := map[string]string{
+		"/host/images": "/currentsnapshot/images",
+	}
+	if err := stageToVolume("testvol", volumes); err != nil {
+		t.Fatalf("stageToVolume returned error: %v", err)
+	}
+
+	if strings.HasPrefix(*shellArg, "'") || strings.HasSuffix(*shellArg, "'") {
+		t.Errorf("shell command should not be wrapped in single quotes, got: %s", *shellArg)
+	}
+	if !strings.HasPrefix(*shellArg, "rm -rf /currentsnapshot/*") {
+		t.Errorf("unexpected shell command: %s", *shellArg)
+	}
+}
+
+func TestRestoreFromVolumeNoQuotesAroundShellCmd(t *testing.T) {
+	shellArg := captureShellArg(t)
+
+	dirs := map[string]string{
+		"/currentsnapshot/config": "/opt/wiki/config",
+	}
+	if err := restoreFromVolume("testvol", "/opt/wiki", dirs); err != nil {
+		t.Fatalf("restoreFromVolume returned error: %v", err)
+	}
+
+	if strings.HasPrefix(*shellArg, "'") || strings.HasSuffix(*shellArg, "'") {
+		t.Errorf("shell command should not be wrapped in single quotes, got: %s", *shellArg)
+	}
+	if !strings.Contains(*shellArg, "/currentsnapshot/config") {
+		t.Errorf("unexpected shell command: %s", *shellArg)
 	}
 }


### PR DESCRIPTION
## Summary
- Remove spurious single-quote wrapping around shell commands passed to `sh -c` in `stageToVolume` and `restoreFromVolume`, which caused both backup create and restore to fail with `not found` errors
- Add tests that verify the `sh -c` argument is not wrapped in quotes
- Use `--single-transaction` for `mariadb-dump` during backup to avoid `LOCK TABLES` (which fails on views with nonexistent definers and blocks writes on live wikis)

Fixes #480