### PR TITLE
Use --single-transaction for database dumps during backup

### DIFF
--- a/cmd/backup/create.go
+++ b/cmd/backup/create.go
@@ -60,7 +60,7 @@ func takeSnapshot(orch orchestrators.Orchestrator, instance config.Installation,
 
 	for _, id := range wikiIDs {
 		logging.Print(fmt.Sprintf("Dumping database for wiki '%s'...", id))
-		cmd := fmt.Sprintf("mariadb-dump -h db -u root -p%s --databases %s > %s",
+		cmd := fmt.Sprintf("mariadb-dump -h db -u root -p%s --single-transaction --databases %s > %s",
 			orchestrators.ShellQuote(envVariables["MYSQL_PASSWORD"]), orchestrators.ShellQuote(id), dumpPath(id))
 		_, err = orch.ExecWithError(instance.Path, orchestrators.ServiceWeb, cmd)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Add `--single-transaction` to `mariadb-dump` in `canasta backup create` to use a consistent InnoDB snapshot instead of `LOCK TABLES`
- Fixes backup failures on databases with views referencing nonexistent definers (common after migrating a database from another server)
- Avoids blocking writes on the wiki during backup

Fixes #486