### PR TITLE
Remove TestSlicesContains that tests Go standard library

### DIFF
--- a/internal/extensionsskins/extensionsskins_test.go
+++ b/internal/extensionsskins/extensionsskins_test.go
@@ -45,17 +45,6 @@ func TestValidateName(t *testing.T) {
 	}
 }
 
-func TestSlicesContains(t *testing.T) {
-	list := []string{"VisualEditor", "Cite", "ParserFunctions"}
-
-	if !slices.Contains(list, "Cite") {
-		t.Error("expected slices.Contains to return true for 'Cite'")
-	}
-	if slices.Contains(list, "Missing") {
-		t.Error("expected slices.Contains to return false for 'Missing'")
-	}
-}
-
 // --- YAML config helpers ---
 
 var extConstants = Item{


### PR DESCRIPTION
## Summary
- Remove `TestSlicesContains` from `extensionsskins_test.go` — it tests Go's `slices.Contains` function, not any project code

Relates to #241