### PR TITLE
tests: add table-driven tests for getRepoURL

### DIFF
--- a/cmd/backup/backup_test.go
+++ b/cmd/backup/backup_test.go
@@ -184,3 +184,56 @@ func TestRestorePreservesDBPasswords(t *testing.T) {
 		t.Errorf("expected MW_SITE_SERVER from backup to be preserved, got:\n%s", content)
 	}
 }
+
+func TestGetRepoURL(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		env  map[string]string
+		want string
+	}{
+		{
+			name: "RESTIC_REPOSITORY is set",
+			env: map[string]string{
+				"RESTIC_REPOSITORY": "rest:http://repo.example/repo",
+				"RESTIC_REPO":       "rest:http://repo.example/other",
+				"AWS_S3_API":        "https://s3.example",
+				"AWS_S3_BUCKET":     "bucket",
+			},
+			want: "rest:http://repo.example/repo",
+		},
+		{
+			name: "RESTIC_REPO is set",
+			env: map[string]string{
+				"RESTIC_REPO":   "rest:http://repo.example/repo",
+				"AWS_S3_API":    "https://s3.example",
+				"AWS_S3_BUCKET": "bucket",
+			},
+			want: "rest:http://repo.example/repo",
+		},
+		{
+			name: "AWS S3 settings are set",
+			env: map[string]string{
+				"AWS_S3_API":    "https://s3.example",
+				"AWS_S3_BUCKET": "bucket",
+			},
+			want: "s3:https://s3.example/bucket",
+		},
+		{
+			name: "all vars empty",
+			env: map[string]string{
+				"RESTIC_REPOSITORY": "",
+				"RESTIC_REPO":       "",
+				"AWS_S3_API":        "",
+				"AWS_S3_BUCKET":     "",
+			},
+			want: "s3:/",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := getRepoURL(tc.env)
+			if got != tc.want {
+				t.Errorf("getRepoURL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/backup/backup_test.go
+++ b/cmd/backup/backup_test.go
@@ -204,6 +204,7 @@ func TestGetRepoURL(t *testing.T) {
 		{
 			name: "RESTIC_REPO is set",
 			env: map[string]string{
+				"RESTIC_REPOSITORY": "",
 				"RESTIC_REPO":   "rest:http://repo.example/repo",
 				"AWS_S3_API":    "https://s3.example",
 				"AWS_S3_BUCKET": "bucket",
@@ -219,13 +220,32 @@ func TestGetRepoURL(t *testing.T) {
 			want: "s3:https://s3.example/bucket",
 		},
 		{
-			name: "all vars empty",
+			name: "only AWS_S3_API is set",
+			env: map[string]string{
+				"AWS_S3_API": "https://s3.example",
+			},
+			want: "s3:https://s3.example/",
+		},
+		{
+			name: "only AWS_S3_BUCKET is set",
+			env: map[string]string{
+				"AWS_S3_BUCKET": "bucket",
+			},
+			want: "s3:/bucket",
+		},
+		{
+			name: "all vars empty strings",
 			env: map[string]string{
 				"RESTIC_REPOSITORY": "",
 				"RESTIC_REPO":       "",
 				"AWS_S3_API":        "",
 				"AWS_S3_BUCKET":     "",
 			},
+			want: "s3:/",
+		},
+		{
+			name: "all vars absent",
+			env:  map[string]string{},
 			want: "s3:/",
 		},
 	} {


### PR DESCRIPTION
Adds test coverage for `getRepoURL()` in `cmd/backup/backup_test.go`

### Changes

- Added TestGetRepoURL using the existing table-driven pattern in the file

### Test cases covered

- `RESTIC_REPOSITORY` set, takes precedence over all other vars
- `RESTIC_REPO` set, used when `RESTIC_REPOSITORY` is absent
- AWS S3 vars set, constructs `s3:<api>/<bucket>`
- All vars empty, graceful fallback to `s3:/`

### Testing

```bash
go test ./cmd/backup/ -run TestGetRepoURL -v
```


test result
<img width="1391" height="411" alt="image" src="https://github.com/user-attachments/assets/4cc809f7-e364-416f-99ee-10abf1d0463d" />

### Related

Closes #489
Relates to #241
