### PR TITLE
Skip directory creation in UpdateStackFiles during dry run

### DIFF
--- a/internal/orchestrators/compose.go
+++ b/internal/orchestrators/compose.go
@@ -77,7 +77,10 @@ func (c *ComposeOrchestrator) UpdateStackFiles(installPath string, dryRun bool) 
 		}
 		targetPath := filepath.Join(installPath, relPath)
 		if d.IsDir() {
-			return os.MkdirAll(targetPath, permissions.DirectoryPermission)
+			if !dryRun {
+				return os.MkdirAll(targetPath, permissions.DirectoryPermission)
+			}
+			return nil
 		}
 		if d.Name() == ".gitkeep" {
 			return nil

--- a/internal/orchestrators/kubernetes.go
+++ b/internal/orchestrators/kubernetes.go
@@ -77,7 +77,10 @@ func (k *KubernetesOrchestrator) UpdateStackFiles(installPath string, dryRun boo
 		}
 		targetPath := filepath.Join(installPath, relPath)
 		if d.IsDir() {
-			return os.MkdirAll(targetPath, permissions.DirectoryPermission)
+			if !dryRun {
+				return os.MkdirAll(targetPath, permissions.DirectoryPermission)
+			}
+			return nil
 		}
 		if d.Name() == ".gitkeep" {
 			return nil


### PR DESCRIPTION
## Summary
- Skip `os.MkdirAll` calls in `UpdateStackFiles()` when `dryRun` is true
- Fixes both Compose and Kubernetes orchestrators

`canasta upgrade --dry-run` was failing with "permission denied" when embedded stack files included directories not yet present in the installation (e.g., `config/logstash`). Dry run should be read-only.

Fixes #507