### PR TITLE
Test:  add table-driven tests for NormalizeWikiID

### DIFF
--- a/internal/canasta/canasta_test.go
+++ b/internal/canasta/canasta_test.go
@@ -428,3 +428,26 @@ func TestEnsureObservabilityCredentials_PartialCredentials(t *testing.T) {
 		t.Error("expected OS_PASSWORD_HASH to be generated")
 	}
 }
+
+
+func TestNormalizeWikiID(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{"spaces to underscores", "my wiki", "my_wiki"},
+		{"strip non alphanumeric", "my@wiki!", "mywiki"},
+		{"already normalized", "my_wiki", "my_wiki"},
+		{"empty", "", ""},
+		{"multiple spaces", "my  wiki  name", "my__wiki__name"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NormalizeWikiID(tc.id); got != tc.want {
+				t.Errorf("NormalizeWikiID(%q) = %q, want %q", tc.id, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/canasta/canasta_test.go
+++ b/internal/canasta/canasta_test.go
@@ -429,18 +429,17 @@ func TestEnsureObservabilityCredentials_PartialCredentials(t *testing.T) {
 	}
 }
 
-
 func TestNormalizeWikiID(t *testing.T) {
 	tests := []struct {
 		name string
 		id   string
 		want string
 	}{
-		{"spaces to underscores", "my wiki", "my_wiki"},
-		{"strip non alphanumeric", "my@wiki!", "mywiki"},
-		{"already normalized", "my_wiki", "my_wiki"},
-		{"empty", "", ""},
-		{"multiple spaces", "my  wiki  name", "my__wiki__name"},
+		{name: "spaces to underscores", id: "my wiki", want: "my_wiki"},
+		{name: "strip non alphanumeric", id: "my@wiki!", want: "mywiki"},
+		{name: "already normalized", id: "my_wiki", want: "my_wiki"},
+		{name: "empty", id: "", want: ""},
+		{name: "multiple spaces", id: "my  wiki  name", want: "my__wiki__name"},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Adds test coverage for `NormalizeWikiID()` in `internal/canasta/canasta_test.go`

### Changes

- Added `TestNormalizeWikiID` using the existing table-driven pattern in the file
- Used named struct fields for consistency with `TestIsObservabilityEnabled`

### Test cases covered

- Spaces converted to underscores `"my wiki"` -> `"my_wiki"`
- Non-alphanumeric characters stripped `"my@wiki!"` -> `"mywiki"`
- Already normalized returned unchanged
- Empty string returns `""`
- Multiple spaces `"my  wiki  name"` -> `"my__wiki__name"`

### Testing
```bash
go test ./internal/canasta/ -run TestNormalizeWikiID -v
```

### Test results

<img width="1495" height="471" alt="image" src="https://github.com/user-attachments/assets/10d7dab3-6fbe-4db4-8e36-effdc2fee248" />

### Related

Closes #490  
Relates to #241