### PR TITLE
test: extend TestGetEnvVariable with edge case parsing

### DIFF
--- a/internal/canasta/canasta_test.go
+++ b/internal/canasta/canasta_test.go
@@ -13,7 +13,7 @@ func TestGetEnvVariable(t *testing.T) {
 	dir := t.TempDir()
 	envPath := filepath.Join(dir, ".env")
 
-	content := "KEY1=value1\nKEY2=value2\nKEY_WITH_EQUALS=abc=def\nQUOTED=\"hello world\"\n"
+	content := "KEY1=value1\n# this is a comment\nKEY2=value2\n\nEMPTY=\nKEY_WITH_EQUALS=abc=def\nKEY=a=b\nQUOTED=\"hello world\"\n"
 	if err := os.WriteFile(envPath, []byte(content), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -28,7 +28,9 @@ func TestGetEnvVariable(t *testing.T) {
 	}{
 		{"KEY1", "value1"},
 		{"KEY2", "value2"},
+		{"EMPTY", ""},
 		{"KEY_WITH_EQUALS", "abc=def"},
+		{"KEY", "a=b"},
 		{"QUOTED", "hello world"},
 	}
 


### PR DESCRIPTION
Extends `TestGetEnvVariable` in `internal/canasta/canasta_test.go` to cover additional parsing edge cases, addressing #491.

### Changes

- Extended existing test's `.env` content and assertions table, no new test functions

### Test cases added

- Comment lines (`# ...`); skipped, not present in result map
- Blank lines, skipped silently
- Empty value (`KEY=`) returns key with `""` value
- Value containing `=` (`KEY=a=b`), returns `"a=b"` via `SplitN` limit 2

### Testing
```bash
go test ./internal/canasta/ -run TestGetEnvVariable -v
```

### Test results

<img width="1508" height="329" alt="image" src="https://github.com/user-attachments/assets/c28ad2d5-fcf1-45b9-9392-452f0e4254e0" />

### Related

Closes #491  
Relates to #241