### PR TITLE
Test: strengthen password assertions in TestGenerateAdminAndDBPasswords

### DIFF
--- a/internal/canasta/canasta_test.go
+++ b/internal/canasta/canasta_test.go
@@ -135,6 +135,27 @@ func TestGenerateAdminAndDBPasswords(t *testing.T) {
 		if strings.Contains(pw, "$") {
 			t.Errorf("password contains $: %s", pw)
 		}
+
+		digits := 0
+		for _, c := range pw {
+			if c >= '0' && c <= '9' {
+				digits++
+			}
+		}
+
+		symbols := 0
+		for _, c := range pw {
+			if strings.ContainsRune("@%^-_+.,:", c) {
+				symbols++
+			}
+		}
+
+		if digits < 4 {
+			t.Errorf("password has %d digits, want >= 4: %s", digits, pw)
+		}
+		if symbols < 6 {
+			t.Errorf("password has %d symbols, want >= 6: %s", symbols, pw)
+		}
 	}
 }
 


### PR DESCRIPTION
Strengthens existing password assertions in `TestGenerateAdminAndDBPasswords` to verify generator constraints are met, addressing

### Changes

- Added digit count assertion (`>= 4`) inside the existing password loop
- Added symbol count assertion (`>= 6`) against the safe symbol set `@%^-_+.,:` inside the existing password loop

### Testing
```bash
go test ./internal/canasta/ -run TestGenerateAdminAndDBPasswords -v
```
### Test results
<img width="2051" height="295" alt="image" src="https://github.com/user-attachments/assets/5a2b93c4-abe2-4ae7-ba5e-693688f2ef6e" />


### Related
Closes #493  
Relates to #241