### PR TITLE
Fix upgrade recreating deleted files and Caddyfile.custom migration

### DIFF
--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -78,7 +78,7 @@ func CopyInstallationTemplate(destPath string) error {
 }
 
 // UpdateInstallationTemplate re-applies the embedded template during upgrade.
-// User-editable files are only created if missing (no-clobber).
+// User-editable files are skipped entirely (they may have been intentionally deleted).
 // CLI-managed files (READMEs, etc.) are always updated to match the current CLI version.
 func UpdateInstallationTemplate(destPath string) error {
 	logging.Print("Updating installation template files\n")
@@ -86,8 +86,8 @@ func UpdateInstallationTemplate(destPath string) error {
 }
 
 // copyTemplate walks the embedded installation template and copies files to destPath.
-// If upgrading is true, CLI-managed files are force-updated while user-editable files
-// use no-clobber. If upgrading is false, all files use no-clobber.
+// If upgrading is true, CLI-managed files are force-updated and user-editable files
+// are skipped. If upgrading is false (create), all files use no-clobber.
 func copyTemplate(destPath string, upgrading bool) error {
 	return fs.WalkDir(installationTemplate, "installation-template", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -117,8 +117,14 @@ func copyTemplate(destPath string, upgrading bool) error {
 			return nil
 		}
 
-		// No-clobber for user-editable files (always) and all files (during create)
-		if !upgrading || userEditablePaths[relPath] {
+		// During upgrade, skip user-editable files entirely — they are only
+		// created during "canasta create". This avoids recreating files that
+		// the user intentionally deleted.
+		if upgrading && userEditablePaths[relPath] {
+			return nil
+		}
+		// During create, all files use no-clobber (skip if exists)
+		if !upgrading {
 			if _, err := os.Stat(targetPath); err == nil {
 				return nil
 			}

--- a/internal/orchestrators/compose.go
+++ b/internal/orchestrators/compose.go
@@ -725,20 +725,52 @@ func (c *ComposeOrchestrator) MigrateConfig(installPath string, dryRun bool) (bo
 	return changed, nil
 }
 
-// migrateCaddyFiles creates Caddyfile.site and Caddyfile.global if they don't exist
-// and rewrites the Caddyfile to include the import directives.
+// migrateCaddyFiles creates Caddyfile.site and Caddyfile.global if they don't exist,
+// renames legacy Caddyfile.custom to Caddyfile.site, and rewrites the Caddyfile to
+// use the current import directives.
 func (c *ComposeOrchestrator) migrateCaddyFiles(installPath string, dryRun bool) (bool, error) {
-	customPath := filepath.Join(installPath, "config", "Caddyfile.site")
+	sitePath := filepath.Join(installPath, "config", "Caddyfile.site")
 	globalPath := filepath.Join(installPath, "config", "Caddyfile.global")
+	legacyCustomPath := filepath.Join(installPath, "config", "Caddyfile.custom")
 
-	_, customErr := os.Stat(customPath)
+	changed := false
+
+	// Rename legacy Caddyfile.custom → Caddyfile.site if the old name exists
+	if _, err := os.Stat(legacyCustomPath); err == nil {
+		if dryRun {
+			fmt.Println("  Would rename config/Caddyfile.custom to config/Caddyfile.site")
+		} else {
+			fmt.Println("  Renaming config/Caddyfile.custom to config/Caddyfile.site")
+			if err := os.Rename(legacyCustomPath, sitePath); err != nil {
+				return false, fmt.Errorf("failed to rename Caddyfile.custom: %w", err)
+			}
+		}
+		changed = true
+	}
+
+	// Check whether the Caddyfile still references the old name
+	caddyfilePath := filepath.Join(installPath, "config", "Caddyfile")
+	if content, err := os.ReadFile(caddyfilePath); err == nil {
+		if strings.Contains(string(content), "Caddyfile.custom") {
+			changed = true
+		}
+	}
+
+	_, siteErr := os.Stat(sitePath)
 	_, globalErr := os.Stat(globalPath)
-	if customErr == nil && globalErr == nil {
+	if siteErr != nil {
+		changed = true
+	}
+	if globalErr != nil {
+		changed = true
+	}
+
+	if !changed {
 		return false, nil
 	}
 
 	if dryRun {
-		if customErr != nil {
+		if siteErr != nil {
 			fmt.Println("  Would create config/Caddyfile.site")
 		}
 		if globalErr != nil {
@@ -746,7 +778,7 @@ func (c *ComposeOrchestrator) migrateCaddyFiles(installPath string, dryRun bool)
 		}
 		fmt.Println("  Would update config/Caddyfile with import directives")
 	} else {
-		if customErr != nil {
+		if siteErr != nil {
 			fmt.Println("  Creating config/Caddyfile.site")
 			if err := canasta.CreateCaddyfileSite(installPath); err != nil {
 				return false, fmt.Errorf("failed to create Caddyfile.site: %w", err)


### PR DESCRIPTION
## Summary
- Handle `Caddyfile.custom` → `Caddyfile.site` rename during upgrade migration: rename the old file, detect stale references in the Caddyfile, and rewrite it
- Skip user-editable template files entirely during upgrade so intentionally deleted files (e.g., `Vector.php`, `CanastaFooterIcon.php`) are not recreated

## Context
Found during real-world upgrade from a pre-v1.107.0 installation. After upgrade, Caddy entered a restart loop because the Caddyfile still imported `Caddyfile.custom`. Separately, `Vector.php` and `CanastaFooterIcon.php` were recreated despite having been intentionally removed.

Fixes #517