### PR TITLE
Test: add table-driven tests for removeDuplicates

### DIFF
--- a/internal/canasta/canasta_test.go
+++ b/internal/canasta/canasta_test.go
@@ -3,6 +3,7 @@ package canasta
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -248,6 +249,24 @@ func TestContainsProfile(t *testing.T) {
 	for _, tt := range tests {
 		if got := ContainsProfile(tt.profiles, tt.target); got != tt.want {
 			t.Errorf("ContainsProfile(%q, %q) = %v, want %v", tt.profiles, tt.target, got, tt.want)
+		}
+	}
+}
+
+func TestRemoveDuplicates(t *testing.T) {
+	tests := []struct {
+		input []string
+		want  []string
+	}{
+		{[]string{"a", "b", "a", "c"}, []string{"a", "b", "c"}},
+		{[]string{"a", "b", "c"}, []string{"a", "b", "c"}},
+		{[]string{}, []string{}},
+		{[]string{"a"}, []string{"a"}},
+		{[]string{"x", "x", "x"}, []string{"x"}},
+	}
+	for _, tt := range tests {
+		if got := removeDuplicates(tt.input); !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("removeDuplicates(%v) = %v, want %v", tt.input, got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
Adds test coverage for `removeDuplicates()` in `internal/canasta/canasta_test.go`

### Changes

- Added `TestRemoveDuplicates` following the existing `TestContainsProfile` pattern
- Added `reflect` import for `DeepEqual` assertion

### Test cases covered

- Slice with duplicates order preserved, duplicates removed
- No duplicates returned unchanged
- Empty slice returns empty slice
- Single element returned unchanged
- All elements identical deduplicated to single element

### Testing
```bash
go test ./internal/canasta/ -run TestRemoveDuplicates -v
```

### Test result
<img width="1735" height="178" alt="image" src="https://github.com/user-attachments/assets/10b508cc-f622-4cdc-a5f1-1f076090b6ad" />


### Related

Closes #498  
Relates to #241