### PR TITLE
Tests: add table-driven tests for article

### DIFF
--- a/internal/extensionsskins/extensionsskins_test.go
+++ b/internal/extensionsskins/extensionsskins_test.go
@@ -45,6 +45,31 @@ func TestValidateName(t *testing.T) {
 	}
 }
 
+func TestArticle(t *testing.T) {
+	gotests := []struct {
+		input string
+		want  string
+	}{
+		{"extension", "an"},
+		{"skin", "a"},
+		{"apple", "an"},
+		{"Extension", "an"},
+		{"item", "an"},
+		{"Object", "an"},
+		{"umbrella", "an"},
+		{"Umbrella", "an"},
+		{"wiki", "a"},
+		{"", "a"},
+	}
+
+	for _, tt := range gotests {
+		got := article(tt.input)
+		if got != tt.want {
+			t.Errorf("article(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
 // --- YAML config helpers ---
 
 var extConstants = Item{


### PR DESCRIPTION
Adds test coverage for `article()` in `internal/extensionsskins/extensionsskins_test.go`, addressing #499.

### Changes

- Added `TestArticle` following the existing table-driven pattern in the file

### Test cases covered

- Consonant start returns `"a"`
- All lowercase vowels (a, e, i, u) returns `"an"`
- Uppercase vowels (E, O, U) returns `"an"`
- Empty string returns `"a"`

### Testing
```bash
go test ./internal/extensionsskins/ -run TestArticle -v
```

### Test results
<img width="1586" height="172" alt="image" src="https://github.com/user-attachments/assets/68656830-5615-4877-a104-b14be355dc2d" />


### Related

Closes #499  
Relates to #241