### PR TITLE
tests: add tests for IsDevModeSetup

### DIFF
--- a/internal/devmode/devmode_test.go
+++ b/internal/devmode/devmode_test.go
@@ -1,0 +1,55 @@
+package devmode
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsDevModeSetup(t *testing.T) {
+	gotests := []struct {
+		name  string
+		setup func(dir string)
+		want  bool
+	}{
+		{
+			name: "both files present",
+			setup: func(dir string) {
+				os.WriteFile(filepath.Join(dir, "docker-compose.dev.yml"), []byte{}, 0644)
+				os.WriteFile(filepath.Join(dir, "Dockerfile.xdebug"), []byte{}, 0644)
+			},
+			want: true,
+		},
+		{
+			name: "neither file present",
+			setup: func(dir string) {
+			},
+			want: false,
+		},
+		{
+			name: "only docker-compose.dev.yml present",
+			setup: func(dir string) {
+				os.WriteFile(filepath.Join(dir, "docker-compose.dev.yml"), []byte{}, 0644)
+			},
+			want: false,
+		},
+		{
+			name: "only Dockerfile.xdebug present",
+			setup: func(dir string) {
+				os.WriteFile(filepath.Join(dir, "Dockerfile.xdebug"), []byte{}, 0644)
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range gotests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tt.setup(dir)
+
+			if got := IsDevModeSetup(dir); got != tt.want {
+				t.Errorf("IsDevModeSetup(%q) = %v, want %v", dir, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds test coverage for `IsDevModeSetup()` in a new `internal/devmode/devmode_test.go`

### Changes

- Created `devmode_test.go` with `TestIsDevModeSetup`

### Test cases covered

- Both marker files present returns `true`
- Neither file present returns `false`
- Only `docker-compose.dev.yml` returns `false`
- Only `Dockerfile.xdebug` returns `false`

### Testing
```bash
go test ./internal/devmode/ -run TestIsDevModeSetup -v
```

### test results
<img width="1647" height="405" alt="image" src="https://github.com/user-attachments/assets/afedbb21-c353-4c5e-acd2-0439f5d47d87" />


### Related

Closes #500  
Relates to #241
