### PR TITLE
Support CANASTA_CONFIG_DIR environment variable

### DIFF
--- a/docs/guide/general-concepts.md
+++ b/docs/guide/general-concepts.md
@@ -105,6 +105,14 @@ The CLI maintains a registry of all installations in a `conf.json` file. The loc
 - **Linux (non-root)**: `~/.config/canasta/conf.json`
 - **macOS**: `~/Library/Application Support/canasta/conf.json`
 
+To override the default location, set the `CANASTA_CONFIG_DIR` environment variable. This takes priority over the platform defaults and is useful when multiple sysops need to share a single installation registry:
+
+```bash
+export CANASTA_CONFIG_DIR=/shared/canasta-config
+```
+
+The directory is created automatically if it does not exist.
+
 Example:
 
 ```json

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -336,20 +336,26 @@ func read(details *Canasta) error {
 }
 
 func GetConfigDir() (string, error) {
-	base, err := os.UserConfigDir()
-	if err != nil {
-		return "", fmt.Errorf("unable to determine config directory: %w", err)
-	}
-	dir := filepath.Join(base, "canasta")
+	var dir string
 
-	// Checks if this is running as root
-	currentUser, err := user.Current()
-	if err != nil {
-		return "", fmt.Errorf("Unable to get the current user: %s", err)
-	}
+	if envDir := os.Getenv("CANASTA_CONFIG_DIR"); envDir != "" {
+		dir = envDir
+	} else {
+		base, err := os.UserConfigDir()
+		if err != nil {
+			return "", fmt.Errorf("unable to determine config directory: %w", err)
+		}
+		dir = filepath.Join(base, "canasta")
 
-	if currentUser.Username == "root" {
-		dir = "/etc/canasta"
+		// Checks if this is running as root
+		currentUser, err := user.Current()
+		if err != nil {
+			return "", fmt.Errorf("Unable to get the current user: %s", err)
+		}
+
+		if currentUser.Username == "root" {
+			dir = "/etc/canasta"
+		}
 	}
 
 	fi, err := os.Stat(dir)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -249,6 +249,41 @@ func TestBuildFromOmittedWhenEmpty(t *testing.T) {
 	}
 }
 
+func TestGetConfigDirEnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CANASTA_CONFIG_DIR", dir)
+
+	got, err := GetConfigDir()
+	if err != nil {
+		t.Fatalf("GetConfigDir() error = %v", err)
+	}
+	if got != dir {
+		t.Errorf("GetConfigDir() = %q, want %q", got, dir)
+	}
+}
+
+func TestGetConfigDirEnvCreatesDir(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "custom-canasta")
+	t.Setenv("CANASTA_CONFIG_DIR", target)
+
+	got, err := GetConfigDir()
+	if err != nil {
+		t.Fatalf("GetConfigDir() error = %v", err)
+	}
+	if got != target {
+		t.Errorf("GetConfigDir() = %q, want %q", got, target)
+	}
+
+	fi, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("expected directory to be created: %v", err)
+	}
+	if !fi.IsDir() {
+		t.Error("expected target to be a directory")
+	}
+}
+
 func TestConfFileCreated(t *testing.T) {
 	dir := setupTestDir(t)
 


### PR DESCRIPTION
## Summary

- `GetConfigDir()` now checks the `CANASTA_CONFIG_DIR` environment variable first, before the root check and platform default
- The directory is created automatically if it does not exist
- Adds two tests for the env var override
- Documents the feature in the conf.json section of `docs/guide/general-concepts.md`

Closes #526

## Test plan

- [ ] `CANASTA_CONFIG_DIR=/tmp/test-canasta go run . list` — creates `/tmp/test-canasta/conf.json` and uses it
- [ ] Without the env var, behavior is unchanged
- [x] `go test ./internal/config/...`