### PR TITLE
Resolve installation from subdirectories

### DIFF
--- a/docs/guide/general-concepts.md
+++ b/docs/guide/general-concepts.md
@@ -46,7 +46,7 @@ canasta start -i myinstance
 canasta extension list -i myinstance
 ```
 
-The `-i` flag is required for `canasta create` (since the installation directory doesn't exist yet). For all other commands, `-i` is optional if you run the command from within the installation directory.
+The `-i` flag is required for `canasta create` (since the installation directory doesn't exist yet). For all other commands, `-i` is optional if you run the command from within the installation directory or any of its subdirectories (e.g., `config/settings/`).
 
 Installation IDs must start and end with an alphanumeric character and may contain letters, digits, hyphens (`-`), and underscores (`_`).
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -230,13 +230,21 @@ func GetCanastaID(installPath string) (string, error) {
 	if err := ensureInitialized(); err != nil {
 		return "", err
 	}
-	var canastaID string
-	for _, installations := range existingInstallations.Installations {
-		if installations.Path == installPath {
-			return installations.Id, nil
+	// Walk up the directory tree to find an enclosing installation.
+	dir := installPath
+	for {
+		for _, inst := range existingInstallations.Installations {
+			if inst.Path == dir {
+				return inst.Id, nil
+			}
 		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
 	}
-	return canastaID, fmt.Errorf("No Canasta installations exist at %s", installPath)
+	return "", fmt.Errorf("No Canasta installations exist at %s", installPath)
 }
 
 func Add(details Installation) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -170,6 +170,41 @@ func TestGetCanastaID(t *testing.T) {
 	}
 }
 
+func TestGetCanastaIDFromSubdirectory(t *testing.T) {
+	setupTestDir(t)
+
+	inst := Installation{Id: "subdir-test", Path: "/srv/canasta/my-wiki", Orchestrator: "compose"}
+	if err := Add(inst); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		wantID  string
+		wantErr bool
+	}{
+		{"exact match", "/srv/canasta/my-wiki", "subdir-test", false},
+		{"one level deep", "/srv/canasta/my-wiki/config", "subdir-test", false},
+		{"two levels deep", "/srv/canasta/my-wiki/config/settings", "subdir-test", false},
+		{"unrelated path", "/srv/other/project", "", true},
+		{"parent of installation", "/srv/canasta", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, err := GetCanastaID(tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetCanastaID(%q) error = %v, wantErr %v", tt.path, err, tt.wantErr)
+				return
+			}
+			if id != tt.wantID {
+				t.Errorf("GetCanastaID(%q) = %q, want %q", tt.path, id, tt.wantID)
+			}
+		})
+	}
+}
+
 func TestAddOrchestratorSupported(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary

- `GetCanastaID()` now walks up the directory tree via `filepath.Dir()` to find an enclosing registered installation
- Running commands from a subdirectory (e.g. `config/settings/`) works without needing `-i`
- Adds table-driven tests covering exact match, nested subdirectories, unrelated paths, and parent-of-installation
- Updates the `-i` flag docs to mention subdirectory support

Closes #527

## Test plan

- [ ] Register an instance, `cd` into a subdirectory (e.g. `config/`), run `canasta start` without `-i` — should resolve
- [ ] From an unrelated directory with no `-i`, should still error
- [x] `go test ./internal/config/...`