### PR TITLE
Backfill CANASTA_IMAGE in .env during upgrade

### DIFF
--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -364,6 +364,15 @@ func runMigration(installPath string, orch orchestrators.Orchestrator, dryRun bo
 		changed = true
 	}
 
+	// Step 8: Backfill CANASTA_IMAGE in .env for legacy installations
+	imageChanged, err := backfillCanastaImage(installPath, dryRun)
+	if err != nil {
+		return false, err
+	}
+	if imageChanged {
+		changed = true
+	}
+
 	if !changed {
 		fmt.Println("No config migrations needed.")
 	} else if dryRun {
@@ -672,6 +681,34 @@ func removeLegacyGitDir(installPath string, dryRun bool) (bool, error) {
 		if err := os.RemoveAll(gitDir); err != nil {
 			return false, fmt.Errorf("failed to remove .git directory: %w", err)
 		}
+	}
+
+	return true, nil
+}
+
+// backfillCanastaImage sets CANASTA_IMAGE in .env for installations that
+// predate the canasta create change that writes it. Without this variable,
+// docker-compose falls back to the "latest" tag, bypassing version pinning.
+func backfillCanastaImage(installPath string, dryRun bool) (bool, error) {
+	envPath := filepath.Join(installPath, ".env")
+
+	envVars, err := canasta.GetEnvVariable(envPath)
+	if err != nil {
+		return false, err
+	}
+	if val, ok := envVars["CANASTA_IMAGE"]; ok && val != "" {
+		return false, nil
+	}
+
+	image := canasta.GetDefaultImage()
+
+	if dryRun {
+		fmt.Printf("  Would set CANASTA_IMAGE=%s in .env\n", image)
+	} else {
+		if err := canasta.SaveEnvVariable(envPath, "CANASTA_IMAGE", image); err != nil {
+			return false, fmt.Errorf("failed to set CANASTA_IMAGE in .env: %w", err)
+		}
+		fmt.Printf("  Set CANASTA_IMAGE=%s in .env\n", image)
 	}
 
 	return true, nil

--- a/cmd/upgrade/upgrade_test.go
+++ b/cmd/upgrade/upgrade_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -223,6 +224,84 @@ func TestRemoveEmptyComposerLocalDryRun(t *testing.T) {
 	// File should still exist after dry run
 	if _, err := os.Stat(filePath); err != nil {
 		t.Error("file should still exist after dry run")
+	}
+}
+
+func TestBackfillCanastaImage(t *testing.T) {
+	tests := []struct {
+		name        string
+		envContent  string
+		wantChanged bool
+	}{
+		{
+			name:        "missing CANASTA_IMAGE",
+			envContent:  "MW_SITE_SERVER=https://localhost\nMYSQL_PASSWORD=secret\n",
+			wantChanged: true,
+		},
+		{
+			name:        "already set",
+			envContent:  "CANASTA_IMAGE=ghcr.io/canastawiki/canasta:3.3.1\nMYSQL_PASSWORD=secret\n",
+			wantChanged: false,
+		},
+		{
+			name:        "empty value",
+			envContent:  "CANASTA_IMAGE=\nMYSQL_PASSWORD=secret\n",
+			wantChanged: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			envPath := filepath.Join(tmpDir, ".env")
+			if err := os.WriteFile(envPath, []byte(tt.envContent), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			changed, err := backfillCanastaImage(tmpDir, false)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if changed != tt.wantChanged {
+				t.Errorf("changed = %v, want %v", changed, tt.wantChanged)
+			}
+
+			if tt.wantChanged {
+				got, err := os.ReadFile(envPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !strings.Contains(string(got), "CANASTA_IMAGE=ghcr.io/canastawiki/canasta:") {
+					t.Errorf("expected CANASTA_IMAGE to be set, got:\n%s", string(got))
+				}
+			}
+		})
+	}
+}
+
+func TestBackfillCanastaImageDryRun(t *testing.T) {
+	tmpDir := t.TempDir()
+	envPath := filepath.Join(tmpDir, ".env")
+	content := "MW_SITE_SERVER=https://localhost\n"
+	if err := os.WriteFile(envPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := backfillCanastaImage(tmpDir, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Error("dry run should report changed = true")
+	}
+
+	// File should be unchanged after dry run
+	got, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != content {
+		t.Errorf("dry run should not modify file, got %q", string(got))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds migration step 8 to `canasta upgrade`: when `CANASTA_IMAGE` is missing or empty in `.env`, set it to the CLI's default versioned image (e.g. `ghcr.io/canastawiki/canasta:3.3.2`)
- Fixes legacy installations that fall back to the `latest` tag, bypassing version pinning
- Includes tests for missing, already-set, empty-value, and dry-run cases

Closes #530

## Test plan

- [x] Create an installation with no `CANASTA_IMAGE` in `.env`, run `canasta upgrade --dry-run` — should report "Would set CANASTA_IMAGE=..."
- [x] Run `canasta upgrade` — should write `CANASTA_IMAGE` to `.env` with the versioned tag
- [x] Run `canasta upgrade` again — should report no migrations needed (already set)
- [x] `go test ./cmd/upgrade/...`