### PR TITLE
Add Special:Random cache bypass to default.vcl

### DIFF
--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -373,6 +373,15 @@ func runMigration(installPath string, orch orchestrators.Orchestrator, dryRun bo
 		changed = true
 	}
 
+	// Step 9: Add Special:Random cache bypass to default.vcl
+	vclChanged, err := addVclSpecialRandomBypass(installPath, dryRun)
+	if err != nil {
+		return false, err
+	}
+	if vclChanged {
+		changed = true
+	}
+
 	if !changed {
 		fmt.Println("No config migrations needed.")
 	} else if dryRun {
@@ -658,6 +667,50 @@ func removeSkipBinaryAsHex(installPath string, dryRun bool) (bool, error) {
 		if err := os.WriteFile(mycnfPath, []byte(newContent), permissions.FilePermission); err != nil {
 			return false, fmt.Errorf("failed to update my.cnf: %w", err)
 		}
+	}
+
+	return true, nil
+}
+
+// addVclSpecialRandomBypass patches default.vcl to bypass Varnish cache for
+// Special:Random. Without this, Varnish caches the redirect and every user
+// gets the same "random" page until the cache TTL expires.
+func addVclSpecialRandomBypass(installPath string, dryRun bool) (bool, error) {
+	vclPath := filepath.Join(installPath, "config", "default.vcl")
+
+	content, err := os.ReadFile(vclPath)
+	if err != nil {
+		return false, nil // File doesn't exist, nothing to patch
+	}
+
+	if strings.Contains(string(content), "Special:Random") {
+		return false, nil // Already has the bypass
+	}
+
+	// Insert the bypass block after the "Pass API" block
+	marker := `if (req.url ~ "/w/api.php") {
+        return(pass);
+    }`
+	bypass := marker + `
+
+    # Bypass cache for Special:Random
+    if (req.url ~ "^/(w/index\.php\?title=|wiki/)Special:Random") {
+        return (pass);
+    }`
+
+	if !strings.Contains(string(content), marker) {
+		// VCL has been customized beyond recognition, skip
+		return false, nil
+	}
+
+	if dryRun {
+		fmt.Println("  Would add Special:Random cache bypass to default.vcl")
+	} else {
+		newContent := strings.Replace(string(content), marker, bypass, 1)
+		if err := os.WriteFile(vclPath, []byte(newContent), permissions.FilePermission); err != nil {
+			return false, fmt.Errorf("failed to update default.vcl: %w", err)
+		}
+		fmt.Println("  Added Special:Random cache bypass to default.vcl")
 	}
 
 	return true, nil

--- a/cmd/upgrade/upgrade_test.go
+++ b/cmd/upgrade/upgrade_test.go
@@ -347,3 +347,132 @@ func TestRemoveEmptyComposerLocalPreservesPopulated(t *testing.T) {
 		t.Error("file content should be unchanged")
 	}
 }
+
+func TestAddVclSpecialRandomBypass(t *testing.T) {
+	vclWithoutBypass := `vcl 4.0;
+
+backend default {
+    .host = "web";
+    .port = "80";
+}
+
+sub vcl_recv {
+    # Pass API
+    if (req.url ~ "/w/api.php") {
+        return(pass);
+    }
+
+    call mobile_detect;
+}`
+
+	vclWithBypass := `vcl 4.0;
+
+backend default {
+    .host = "web";
+    .port = "80";
+}
+
+sub vcl_recv {
+    if (req.url ~ "Special:Random") {
+        return (pass);
+    }
+}`
+
+	tests := []struct {
+		name        string
+		content     string
+		wantChanged bool
+	}{
+		{
+			name:        "missing file",
+			content:     "",
+			wantChanged: false,
+		},
+		{
+			name:        "needs bypass",
+			content:     vclWithoutBypass,
+			wantChanged: true,
+		},
+		{
+			name:        "already has bypass",
+			content:     vclWithBypass,
+			wantChanged: false,
+		},
+		{
+			name:        "customized beyond recognition",
+			content:     "vcl 4.0;\n# completely custom config\n",
+			wantChanged: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			configDir := filepath.Join(tmpDir, "config")
+			if err := os.MkdirAll(configDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+
+			vclPath := filepath.Join(configDir, "default.vcl")
+			if tt.content != "" {
+				if err := os.WriteFile(vclPath, []byte(tt.content), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			changed, err := addVclSpecialRandomBypass(tmpDir, false)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if changed != tt.wantChanged {
+				t.Errorf("changed = %v, want %v", changed, tt.wantChanged)
+			}
+
+			if tt.wantChanged {
+				got, err := os.ReadFile(vclPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !strings.Contains(string(got), "Special:Random") {
+					t.Error("expected default.vcl to contain Special:Random bypass")
+				}
+			}
+		})
+	}
+}
+
+func TestAddVclSpecialRandomBypassDryRun(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "config")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	content := `sub vcl_recv {
+    if (req.url ~ "/w/api.php") {
+        return(pass);
+    }
+
+    call mobile_detect;
+}`
+	vclPath := filepath.Join(configDir, "default.vcl")
+	if err := os.WriteFile(vclPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := addVclSpecialRandomBypass(tmpDir, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Error("dry run should report changed = true")
+	}
+
+	got, err := os.ReadFile(vclPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != content {
+		t.Error("dry run should not modify file")
+	}
+}

--- a/internal/canasta/installation-template/config/default.vcl
+++ b/internal/canasta/installation-template/config/default.vcl
@@ -55,6 +55,11 @@ sub vcl_recv {
         return(pass);
     }
 
+    # Bypass cache for Special:Random
+    if (req.url ~ "^/(w/index\.php\?title=|wiki/)Special:Random") {
+        return (pass);
+    }
+
     call mobile_detect;
 
     # Pass requests from logged-in users directly.


### PR DESCRIPTION
## Summary

- Adds the `Special:Random` Varnish cache bypass to the CLI's embedded `default.vcl` template (for new installations)
- Adds an upgrade migration step that patches the bypass into existing installations' `default.vcl`
- The migration safely skips files that already have the bypass or have been customized beyond recognition
- This fix was already in CanastaBase but never took effect because the CLI's mounted copy overrides it

Fixes #534

## Test plan

- [x] Create a new installation and verify `config/default.vcl` contains the `Special:Random` bypass
- [x] Run `canasta upgrade` on an existing installation and verify the bypass is added to `config/default.vcl`
- [x] Run `canasta upgrade --dry-run` and verify it reports "Would add Special:Random cache bypass to default.vcl"
- [x] Visit `Special:Random` multiple times and confirm different pages are returned
- [x] `go test ./cmd/upgrade/...`
- [x] `go test ./...`