### PR TITLE
Reject empty string in ValidateWikiID

### DIFF
--- a/internal/farmsettings/farmsettings.go
+++ b/internal/farmsettings/farmsettings.go
@@ -27,6 +27,10 @@ var reservedNames = []string{"settings", "images", "w", "wiki", "wikis"}
 
 // ValidateWikiID validates that wikiID doesn't contain invalid characters or reserved names
 func ValidateWikiID(wikiID string) error {
+	if wikiID == "" {
+		return fmt.Errorf("wikiID cannot be empty")
+	}
+
 	// Check if wikiID contains a hyphen (-)
 	if strings.Contains(wikiID, "-") {
 		return fmt.Errorf("The character '-' is not allowed in wikiID")


### PR DESCRIPTION
## Summary
- `ValidateWikiID()` accepted an empty string as valid. Add an early return with an error for empty input.

## Test plan
- [x] `go test ./internal/farmsettings/...` passes
- [x] Existing behavior for valid IDs, reserved names, and hyphens is unchanged

Fixes #536