### PR TITLE
Add integration testing infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,23 +20,3 @@ jobs:
       run: go vet ./...
     - name: Test
       run: go test ./...
-
-  integration:
-    runs-on: ubuntu-latest
-    needs: test
-    timeout-minutes: 30
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.25'
-    - name: Add runner to www-data group
-      # Canasta containers run as www-data, so bind-mounted directories
-      # (e.g. config/) become owned by that group. The host user must be
-      # in the www-data group to write files back into them.
-      run: sudo usermod -aG www-data $(whoami)
-    - name: Run integration tests
-      # sg runs the command under the www-data group (usermod doesn't
-      # take effect in the current shell session).
-      run: sg www-data -c "go test -tags integration -timeout 20m -v ./tests/integration/..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,16 @@ jobs:
       run: go vet ./...
     - name: Test
       run: go test ./...
+
+  integration:
+    runs-on: ubuntu-latest
+    needs: test
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.25'
+    - name: Run integration tests
+      run: go test -tags integration -timeout 20m -v ./tests/integration/...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,12 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: '1.25'
+    - name: Add runner to www-data group
+      # Canasta containers run as www-data, so bind-mounted directories
+      # (e.g. config/) become owned by that group. The host user must be
+      # in the www-data group to write files back into them.
+      run: sudo usermod -aG www-data $(whoami)
     - name: Run integration tests
-      run: go test -tags integration -timeout 20m -v ./tests/integration/...
+      # sg runs the command under the www-data group (usermod doesn't
+      # take effect in the current shell session).
+      run: sg www-data -c "go test -tags integration -timeout 20m -v ./tests/integration/..."

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,6 +3,7 @@ name: Integration Tests
 on:
   push:
     branches: [main]
+  pull_request: # TODO: remove before merging
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,26 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.25'
+    - name: Add runner to www-data group
+      # Canasta containers run as www-data, so bind-mounted directories
+      # (e.g. config/) become owned by that group. The host user must be
+      # in the www-data group to write files back into them.
+      run: sudo usermod -aG www-data $(whoami)
+    - name: Run integration tests
+      # sg runs the command under the www-data group (usermod doesn't
+      # take effect in the current shell session).
+      run: sg www-data -c "go test -tags integration -timeout 20m -v ./tests/integration/..."

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,7 +3,6 @@ name: Integration Tests
 on:
   push:
     branches: [main]
-  pull_request: # TODO: remove before merging
   workflow_dispatch:
 
 jobs:

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -40,11 +41,7 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "failed to read VERSION file: %v\n", err)
 		os.Exit(1)
 	}
-	imageTag := string(versionBytes)
-	// Trim newline
-	for len(imageTag) > 0 && (imageTag[len(imageTag)-1] == '\n' || imageTag[len(imageTag)-1] == '\r') {
-		imageTag = imageTag[:len(imageTag)-1]
-	}
+	imageTag := strings.TrimSpace(string(versionBytes))
 
 	ldflags := fmt.Sprintf("-X 'github.com/CanastaWiki/Canasta-CLI/internal/canasta.DefaultImageTag=%s'", imageTag)
 	cmd := exec.Command("go", "build", "-ldflags", ldflags, "-o", binPath, "../../canasta.go")
@@ -170,7 +167,8 @@ func waitForWiki(t *testing.T, httpPort string, timeout time.Duration) {
 			t.Fatalf("failed to create request: %v", reqErr)
 		}
 		req.Host = "localhost"
-		resp, err := http.DefaultClient.Do(req)
+		client := &http.Client{Timeout: 10 * time.Second}
+		resp, err := client.Do(req)
 		if err != nil {
 			lastErr = fmt.Sprintf("connection error: %v", err)
 			time.Sleep(5 * time.Second)

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -156,27 +156,44 @@ func runCanasta(t *testing.T, configDir string, args ...string) (string, error) 
 }
 
 // waitForWiki polls the MediaWiki API until it gets a valid siteinfo response
-// or the timeout expires.
+// or the timeout expires. Uses 127.0.0.1 instead of localhost to avoid IPv6
+// resolution issues (Docker binds to 0.0.0.0, not [::]).
 func waitForWiki(t *testing.T, httpPort string, timeout time.Duration) {
 	t.Helper()
-	url := fmt.Sprintf("http://localhost:%s/w/api.php?action=query&meta=siteinfo&format=json", httpPort)
+	apiURL := fmt.Sprintf("http://127.0.0.1:%s/w/api.php?action=query&meta=siteinfo&format=json", httpPort)
 	deadline := time.Now().Add(timeout)
 
+	var lastErr string
 	for time.Now().Before(deadline) {
-		resp, err := http.Get(url)
-		if err == nil {
-			defer resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				var result map[string]interface{}
-				if json.NewDecoder(resp.Body).Decode(&result) == nil {
-					if _, ok := result["query"]; ok {
-						t.Logf("Wiki is up at port %s", httpPort)
-						return
-					}
-				}
-			}
+		resp, err := http.Get(apiURL)
+		if err != nil {
+			lastErr = fmt.Sprintf("connection error: %v", err)
+			time.Sleep(5 * time.Second)
+			continue
 		}
+		var result map[string]interface{}
+		decodeErr := json.NewDecoder(resp.Body).Decode(&result)
+		resp.Body.Close()
+		if decodeErr != nil {
+			lastErr = fmt.Sprintf("HTTP %d, decode error: %v", resp.StatusCode, decodeErr)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		if _, ok := result["query"]; ok {
+			t.Logf("Wiki is up at port %s", httpPort)
+			return
+		}
+		lastErr = fmt.Sprintf("HTTP %d, no 'query' key in response", resp.StatusCode)
 		time.Sleep(5 * time.Second)
+	}
+
+	// Dump diagnostics before failing
+	t.Logf("waitForWiki timed out (last: %s). Dumping diagnostics:", lastErr)
+	if out, err := exec.Command("docker", "ps", "-a").CombinedOutput(); err == nil {
+		t.Logf("docker ps -a:\n%s", out)
+	}
+	if out, err := exec.Command("docker", "logs", "--tail=50", "caddy").CombinedOutput(); err == nil {
+		t.Logf("caddy logs:\n%s", out)
 	}
 	t.Fatalf("wiki did not become ready at port %s within %v", httpPort, timeout)
 }

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -1,0 +1,187 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// canastaBin is the path to the built CLI binary, set once in TestMain.
+var canastaBin string
+
+// portCounter is an atomic counter for assigning unique ports to each test instance.
+var portCounter uint32 = 10080
+
+func TestMain(m *testing.M) {
+	// Build the CLI binary once for all integration tests.
+	// We use a dev build (no Version ldflags) so that `canasta upgrade`
+	// skips the CLI self-update. We do set DefaultImageTag so the correct
+	// Canasta image is pulled.
+	tmpDir, err := os.MkdirTemp("", "canasta-integration-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create temp dir: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	binPath := filepath.Join(tmpDir, "canasta")
+
+	// Read the VERSION file to set DefaultImageTag
+	versionBytes, err := os.ReadFile("../../VERSION")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read VERSION file: %v\n", err)
+		os.Exit(1)
+	}
+	imageTag := string(versionBytes)
+	// Trim newline
+	for len(imageTag) > 0 && (imageTag[len(imageTag)-1] == '\n' || imageTag[len(imageTag)-1] == '\r') {
+		imageTag = imageTag[:len(imageTag)-1]
+	}
+
+	ldflags := fmt.Sprintf("-X 'github.com/CanastaWiki/Canasta-CLI/internal/canasta.DefaultImageTag=%s'", imageTag)
+	cmd := exec.Command("go", "build", "-ldflags", ldflags, "-o", binPath, "../../canasta.go")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build canasta binary: %v\n", err)
+		os.Exit(1)
+	}
+
+	canastaBin = binPath
+	os.Exit(m.Run())
+}
+
+// testInstance holds the state for an isolated integration test instance.
+type testInstance struct {
+	ID        string
+	WorkDir   string // temp directory for the installation
+	ConfigDir string // isolated config directory (CANASTA_CONFIG_DIR)
+	HTTPPort  string
+	HTTPSPort string
+	EnvFile   string // path to the test .env file
+}
+
+// nextPort returns the next available port pair (HTTP, HTTPS) for test isolation.
+func nextPort() (httpPort, httpsPort string) {
+	base := atomic.AddUint32(&portCounter, 10)
+	return fmt.Sprintf("%d", base), fmt.Sprintf("%d", base+1)
+}
+
+// createTestInstance sets up an isolated test instance with unique ports and config dir.
+// It registers a cleanup function that runs `canasta delete -y` even on test failure.
+//
+// workDir is created manually (not via t.TempDir) because containers create files
+// owned by www-data inside the installation directory. Go's TempDir cleanup uses
+// os.RemoveAll which would fail on those files. Instead, cleanup uses sudo rm -rf
+// as a fallback after canasta delete.
+func createTestInstance(t *testing.T, id string) *testInstance {
+	t.Helper()
+
+	workDir, err := os.MkdirTemp("", "canasta-int-work-*")
+	if err != nil {
+		t.Fatalf("failed to create work dir: %v", err)
+	}
+	// configDir only contains conf.json written by the CLI (host-owned), so t.TempDir is fine
+	configDir := t.TempDir()
+	httpPort, httpsPort := nextPort()
+
+	// Write a test .env file with isolated ports and HTTPS off for health checks
+	envFile := filepath.Join(workDir, "test.env")
+	envContent := fmt.Sprintf(
+		"HTTP_PORT=%s\nHTTPS_PORT=%s\nCADDY_AUTO_HTTPS=off\n",
+		httpPort, httpsPort,
+	)
+	if err := os.WriteFile(envFile, []byte(envContent), 0644); err != nil {
+		t.Fatalf("failed to write test .env: %v", err)
+	}
+
+	inst := &testInstance{
+		ID:        id,
+		WorkDir:   workDir,
+		ConfigDir: configDir,
+		HTTPPort:  httpPort,
+		HTTPSPort: httpsPort,
+		EnvFile:   envFile,
+	}
+
+	// Register cleanup to delete the instance even if the test fails or panics.
+	// canasta delete handles most www-data owned files by cleaning from inside the
+	// container, but sudo rm -rf is used as a fallback for any leftovers.
+	t.Cleanup(func() {
+		t.Logf("Cleanup: deleting instance %s", id)
+		out, err := inst.run(t, "delete", "-i", id, "-y")
+		if err != nil {
+			t.Logf("Cleanup delete failed (may already be deleted): %s\n%s", err, out)
+		}
+		// Force-remove the work dir: containers create files owned by www-data
+		// that os.RemoveAll cannot delete without group membership.
+		rmCmd := exec.Command("sudo", "rm", "-rf", workDir)
+		if out, err := rmCmd.CombinedOutput(); err != nil {
+			t.Logf("sudo rm -rf %s failed: %v\n%s", workDir, err, out)
+		}
+	})
+
+	return inst
+}
+
+// run executes the canasta binary with the given arguments, using the instance's
+// isolated config directory. Returns combined output and any error.
+func (inst *testInstance) run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := exec.Command(canastaBin, args...)
+	cmd.Env = append(os.Environ(), "CANASTA_CONFIG_DIR="+inst.ConfigDir)
+	cmd.Dir = inst.WorkDir
+	out, err := cmd.CombinedOutput()
+	t.Logf("canasta %v:\n%s", args, string(out))
+	return string(out), err
+}
+
+// runCanasta executes the canasta binary with the given arguments (without a testInstance).
+// Useful for commands that don't need instance isolation.
+func runCanasta(t *testing.T, configDir string, args ...string) (string, error) {
+	t.Helper()
+	cmd := exec.Command(canastaBin, args...)
+	cmd.Env = append(os.Environ(), "CANASTA_CONFIG_DIR="+configDir)
+	out, err := cmd.CombinedOutput()
+	t.Logf("canasta %v:\n%s", args, string(out))
+	return string(out), err
+}
+
+// waitForWiki polls the MediaWiki API until it gets a valid siteinfo response
+// or the timeout expires.
+func waitForWiki(t *testing.T, httpPort string, timeout time.Duration) {
+	t.Helper()
+	url := fmt.Sprintf("http://localhost:%s/w/api.php?action=query&meta=siteinfo&format=json", httpPort)
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err == nil {
+			defer resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				var result map[string]interface{}
+				if json.NewDecoder(resp.Body).Decode(&result) == nil {
+					if _, ok := result["query"]; ok {
+						t.Logf("Wiki is up at port %s", httpPort)
+						return
+					}
+				}
+			}
+		}
+		time.Sleep(5 * time.Second)
+	}
+	t.Fatalf("wiki did not become ready at port %s within %v", httpPort, timeout)
+}
+
+// instanceEnvPath returns the path to the .env file inside the installation directory.
+func (inst *testInstance) instanceEnvPath() string {
+	return filepath.Join(inst.WorkDir, inst.ID, ".env")
+}

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -156,8 +156,8 @@ func runCanasta(t *testing.T, configDir string, args ...string) (string, error) 
 }
 
 // waitForWiki polls the MediaWiki API until it gets a valid siteinfo response
-// or the timeout expires. Uses 127.0.0.1 instead of localhost to avoid IPv6
-// resolution issues (Docker binds to 0.0.0.0, not [::]).
+// or the timeout expires. Uses 127.0.0.1 to avoid IPv6 resolution issues, and
+// sets Host: localhost so Caddy matches the request to the wiki site block.
 func waitForWiki(t *testing.T, httpPort string, timeout time.Duration) {
 	t.Helper()
 	apiURL := fmt.Sprintf("http://127.0.0.1:%s/w/api.php?action=query&meta=siteinfo&format=json", httpPort)
@@ -165,7 +165,12 @@ func waitForWiki(t *testing.T, httpPort string, timeout time.Duration) {
 
 	var lastErr string
 	for time.Now().Before(deadline) {
-		resp, err := http.Get(apiURL)
+		req, reqErr := http.NewRequest("GET", apiURL, nil)
+		if reqErr != nil {
+			t.Fatalf("failed to create request: %v", reqErr)
+		}
+		req.Host = "localhost"
+		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			lastErr = fmt.Sprintf("connection error: %v", err)
 			time.Sleep(5 * time.Second)

--- a/tests/integration/lifecycle_test.go
+++ b/tests/integration/lifecycle_test.go
@@ -1,0 +1,60 @@
+//go:build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestLifecycle_CreateStartStopDelete exercises the full lifecycle:
+// create → verify wiki is up → stop → start → verify wiki is back → delete → verify removed.
+func TestLifecycle_CreateStartStopDelete(t *testing.T) {
+	inst := createTestInstance(t, "inttest-lifecycle")
+
+	// Create the instance
+	out, err := inst.run(t, "create",
+		"-i", inst.ID,
+		"-w", "main",
+		"-n", "localhost",
+		"-p", inst.WorkDir,
+		"-e", inst.EnvFile,
+	)
+	if err != nil {
+		t.Fatalf("canasta create failed: %v\n%s", err, out)
+	}
+
+	// Verify the wiki is accessible
+	waitForWiki(t, inst.HTTPPort, 5*time.Minute)
+
+	// Stop the instance
+	out, err = inst.run(t, "stop", "-i", inst.ID)
+	if err != nil {
+		t.Fatalf("canasta stop failed: %v\n%s", err, out)
+	}
+
+	// Start the instance again
+	out, err = inst.run(t, "start", "-i", inst.ID)
+	if err != nil {
+		t.Fatalf("canasta start failed: %v\n%s", err, out)
+	}
+
+	// Verify the wiki comes back
+	waitForWiki(t, inst.HTTPPort, 5*time.Minute)
+
+	// Delete the instance
+	out, err = inst.run(t, "delete", "-i", inst.ID, "-y")
+	if err != nil {
+		t.Fatalf("canasta delete failed: %v\n%s", err, out)
+	}
+
+	// Verify the instance is gone from the list
+	out, err = runCanasta(t, inst.ConfigDir, "list")
+	if err != nil {
+		t.Fatalf("canasta list failed: %v\n%s", err, out)
+	}
+	if strings.Contains(out, inst.ID) {
+		t.Errorf("instance %s still appears in list after delete:\n%s", inst.ID, out)
+	}
+}

--- a/tests/integration/upgrade_test.go
+++ b/tests/integration/upgrade_test.go
@@ -1,0 +1,72 @@
+//go:build integration
+
+package integration
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestUpgrade_MigrationsRun creates a fresh instance, simulates a pre-migration
+// state by removing CANASTA_IMAGE from .env, then runs upgrade and verifies
+// that migrations run and the wiki is still accessible afterward.
+func TestUpgrade_MigrationsRun(t *testing.T) {
+	inst := createTestInstance(t, "inttest-upgrade")
+
+	// Create the instance
+	out, err := inst.run(t, "create",
+		"-i", inst.ID,
+		"-w", "main",
+		"-n", "localhost",
+		"-p", inst.WorkDir,
+		"-e", inst.EnvFile,
+	)
+	if err != nil {
+		t.Fatalf("canasta create failed: %v\n%s", err, out)
+	}
+
+	// Verify the wiki is accessible
+	waitForWiki(t, inst.HTTPPort, 5*time.Minute)
+
+	// Simulate a pre-migration state: remove CANASTA_IMAGE from .env
+	// so that the backfillCanastaImage migration will run during upgrade.
+	envPath := inst.instanceEnvPath()
+	envContent, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatalf("failed to read .env: %v", err)
+	}
+	var filteredLines []string
+	for _, line := range strings.Split(string(envContent), "\n") {
+		if !strings.HasPrefix(line, "CANASTA_IMAGE=") {
+			filteredLines = append(filteredLines, line)
+		}
+	}
+	if err := os.WriteFile(envPath, []byte(strings.Join(filteredLines, "\n")), 0644); err != nil {
+		t.Fatalf("failed to write modified .env: %v", err)
+	}
+
+	// Run upgrade
+	out, err = inst.run(t, "upgrade")
+	if err != nil {
+		t.Fatalf("canasta upgrade failed: %v\n%s", err, out)
+	}
+
+	// Verify migrations ran — output should mention CANASTA_IMAGE being set
+	if !strings.Contains(out, "CANASTA_IMAGE") {
+		t.Errorf("upgrade output does not mention CANASTA_IMAGE migration:\n%s", out)
+	}
+
+	// Verify CANASTA_IMAGE was backfilled in .env
+	envContent, err = os.ReadFile(envPath)
+	if err != nil {
+		t.Fatalf("failed to read .env after upgrade: %v", err)
+	}
+	if !strings.Contains(string(envContent), "CANASTA_IMAGE=") {
+		t.Errorf(".env does not contain CANASTA_IMAGE after upgrade:\n%s", string(envContent))
+	}
+
+	// Verify the wiki is still accessible after upgrade
+	waitForWiki(t, inst.HTTPPort, 5*time.Minute)
+}


### PR DESCRIPTION
Closes #538

## Summary

- Adds integration test framework that exercises the CLI against a real Docker Compose stack
- Tests gated behind `//go:build integration` so `go test ./...` continues to skip them
- Infrastructure (`helpers_test.go`): TestMain builds binary once, testInstance provides isolated work/config dirs and unique ports, cleanup handles www-data owned files via `sudo rm -rf`, waitForWiki polls the MediaWiki API
- Two example tests: lifecycle (create → start → stop → start → delete) and upgrade (create → remove CANASTA_IMAGE → upgrade → verify migration)
- CI: adds separate `integration.yml` workflow

**Note:** Integration tests run post-merge (on push to main) and on-demand via workflow_dispatch. They do not block PR merges — they serve as a safety net. To run them before merging a specific PR, use the "Run workflow" button in the Actions UI and select the PR branch.

## Test plan

- [x] `go test ./...` still passes (integration tests excluded by build tag)
- [x] `go test -tags integration -timeout 20m -v ./tests/integration/...` passes (requires Docker)
- [x] CI `integration` job runs and passes