### PR TITLE
Fix unparam lint violations

### DIFF
--- a/cmd/upgrade/mysql_to_mariadb.go
+++ b/cmd/upgrade/mysql_to_mariadb.go
@@ -25,6 +25,9 @@ func composeVolumeName(installPath, volume string) string {
 // detectMySQL8Data checks whether the MySQL data volume contains MySQL 8.0
 // binary data (mysql.ibd). This is a read-only check that can run while the
 // database container is still running.
+// Error return kept for future-proofing.
+//
+//nolint:unparam
 func detectMySQL8Data(installPath string) (bool, error) {
 	volName := composeVolumeName(installPath, "mysql-data-volume")
 	err, _ := execute.Run("", "docker", "run", "--rm",

--- a/internal/extensionsskins/commands.go
+++ b/internal/extensionsskins/commands.go
@@ -56,6 +56,9 @@ a specific wiki in a farm.`, constants.Plural, constants.Plural),
 	return cmd
 }
 
+// Consistent signature with newEnableCmd/newDisableCmd.
+//
+//nolint:unparam
 func newListCmd(instance *config.Installation, orch *orchestrators.Orchestrator, wiki *string, constants *Item) *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
@@ -136,6 +139,9 @@ database changes. Use --skip-update to skip this step.`, constants.Plural, const
 	return cmd
 }
 
+// Consistent signature with newEnableCmd/newListCmd.
+//
+//nolint:unparam
 func newDisableCmd(instance *config.Installation, orch *orchestrators.Orchestrator, wiki *string, constants *Item) *cobra.Command {
 	// Build the Use string with an appropriate argument placeholder
 	argName := strings.ToUpper(constants.CmdName)

--- a/internal/orchestrators/kubernetes_test.go
+++ b/internal/orchestrators/kubernetes_test.go
@@ -316,9 +316,9 @@ func TestInitConfigNamespaceFromPath(t *testing.T) {
 
 // setupTestInstallation creates a minimal installation directory for testing
 // generateKustomization. Returns the install path.
-func setupTestInstallation(t *testing.T, name string) string {
+func setupTestInstallation(t *testing.T) string {
 	t.Helper()
-	dir := filepath.Join(t.TempDir(), name)
+	dir := filepath.Join(t.TempDir(), "test-wiki")
 	configDir := filepath.Join(dir, "config")
 	globalDir := filepath.Join(configDir, "settings", "global")
 	if err := os.MkdirAll(globalDir, 0755); err != nil {
@@ -341,7 +341,7 @@ func setupTestInstallation(t *testing.T, name string) string {
 }
 
 func TestGenerateKustomizationGlobalSettings(t *testing.T) {
-	dir := setupTestInstallation(t, "test-wiki")
+	dir := setupTestInstallation(t)
 
 	k := &KubernetesOrchestrator{}
 	if err := k.generateKustomization(dir, false); err != nil {
@@ -381,7 +381,7 @@ func TestGenerateKustomizationGlobalSettings(t *testing.T) {
 }
 
 func TestGenerateKustomizationCustomGlobalFile(t *testing.T) {
-	dir := setupTestInstallation(t, "test-wiki")
+	dir := setupTestInstallation(t)
 
 	// Add a custom PHP file
 	globalDir := filepath.Join(dir, "config", "settings", "global")
@@ -413,7 +413,7 @@ func TestGenerateKustomizationCustomGlobalFile(t *testing.T) {
 }
 
 func TestGenerateKustomizationPerWikiSettings(t *testing.T) {
-	dir := setupTestInstallation(t, "test-wiki")
+	dir := setupTestInstallation(t)
 
 	// Create per-wiki settings directory with a file
 	wikiDir := filepath.Join(dir, "config", "settings", "wikis", "main")
@@ -450,7 +450,7 @@ func TestGenerateKustomizationPerWikiSettings(t *testing.T) {
 }
 
 func TestGenerateKustomizationEmptyWikiDir(t *testing.T) {
-	dir := setupTestInstallation(t, "test-wiki")
+	dir := setupTestInstallation(t)
 
 	// Create wiki settings directory with only a README (should be excluded)
 	wikiDir := filepath.Join(dir, "config", "settings", "wikis", "main")
@@ -479,7 +479,7 @@ func TestGenerateKustomizationEmptyWikiDir(t *testing.T) {
 }
 
 func TestGenerateKustomizationLocalSettings(t *testing.T) {
-	dir := setupTestInstallation(t, "test-wiki")
+	dir := setupTestInstallation(t)
 
 	// Create LocalSettings.php
 	if err := os.WriteFile(filepath.Join(dir, "config", "LocalSettings.php"), []byte("<?php\n"), 0644); err != nil {
@@ -509,7 +509,7 @@ func TestGenerateKustomizationLocalSettings(t *testing.T) {
 }
 
 func TestGenerateKustomizationNoLocalSettings(t *testing.T) {
-	dir := setupTestInstallation(t, "test-wiki")
+	dir := setupTestInstallation(t)
 
 	k := &KubernetesOrchestrator{}
 	if err := k.generateKustomization(dir, false); err != nil {
@@ -529,7 +529,7 @@ func TestGenerateKustomizationNoLocalSettings(t *testing.T) {
 }
 
 func TestGenerateKustomizationNodePort(t *testing.T) {
-	dir := setupTestInstallation(t, "test-wiki")
+	dir := setupTestInstallation(t)
 
 	k := &KubernetesOrchestrator{}
 	if err := k.generateKustomization(dir, true); err != nil {
@@ -551,7 +551,7 @@ func TestGenerateKustomizationNodePort(t *testing.T) {
 }
 
 func TestGenerateKustomizationNoNodePort(t *testing.T) {
-	dir := setupTestInstallation(t, "test-wiki")
+	dir := setupTestInstallation(t)
 
 	k := &KubernetesOrchestrator{}
 	if err := k.generateKustomization(dir, false); err != nil {
@@ -581,7 +581,7 @@ func TestRunBackupRejectsLocalRepo(t *testing.T) {
 }
 
 func TestGenerateKustomizationObservabilityEnabled(t *testing.T) {
-	dir := setupTestInstallation(t, "test-wiki")
+	dir := setupTestInstallation(t)
 	// Enable observability
 	envPath := filepath.Join(dir, ".env")
 	os.WriteFile(envPath, []byte("MW_SITE_SERVER=https://example.com\nCANASTA_ENABLE_OBSERVABILITY=true\n"), 0644)
@@ -624,7 +624,7 @@ func TestGenerateKustomizationObservabilityEnabled(t *testing.T) {
 }
 
 func TestGenerateKustomizationObservabilityDisabled(t *testing.T) {
-	dir := setupTestInstallation(t, "test-wiki")
+	dir := setupTestInstallation(t)
 
 	k := &KubernetesOrchestrator{}
 	if err := k.generateKustomization(dir, false); err != nil {
@@ -647,7 +647,7 @@ func TestGenerateKustomizationObservabilityDisabled(t *testing.T) {
 }
 
 func TestKubernetesMigrateConfigObservability(t *testing.T) {
-	dir := setupTestInstallation(t, "test-wiki")
+	dir := setupTestInstallation(t)
 	// Enable observability but don't provide credentials
 	envPath := filepath.Join(dir, ".env")
 	os.WriteFile(envPath, []byte("CANASTA_ENABLE_OBSERVABILITY=true\n"), 0644)
@@ -676,7 +676,7 @@ func TestKubernetesMigrateConfigObservability(t *testing.T) {
 }
 
 func TestKubernetesMigrateConfigNoObservability(t *testing.T) {
-	dir := setupTestInstallation(t, "test-wiki")
+	dir := setupTestInstallation(t)
 
 	k := &KubernetesOrchestrator{}
 	changed, err := k.MigrateConfig(dir, false)
@@ -689,7 +689,7 @@ func TestKubernetesMigrateConfigNoObservability(t *testing.T) {
 }
 
 func TestGenerateKustomizationElasticsearchEnabled(t *testing.T) {
-	dir := setupTestInstallation(t, "test-wiki")
+	dir := setupTestInstallation(t)
 	// Enable Elasticsearch
 	envPath := filepath.Join(dir, ".env")
 	os.WriteFile(envPath, []byte("MW_SITE_SERVER=https://example.com\nCANASTA_ENABLE_ELASTICSEARCH=true\n"), 0644)
@@ -717,7 +717,7 @@ func TestGenerateKustomizationElasticsearchEnabled(t *testing.T) {
 }
 
 func TestGenerateKustomizationElasticsearchDisabled(t *testing.T) {
-	dir := setupTestInstallation(t, "test-wiki")
+	dir := setupTestInstallation(t)
 
 	k := &KubernetesOrchestrator{}
 	if err := k.generateKustomization(dir, false); err != nil {


### PR DESCRIPTION
Closes #552

## Summary

- Add `//nolint:unparam` to three functions where unused parameters are intentional:
  - `detectMySQL8Data`: error return kept for future-proofing
  - `newListCmd`: `wiki` unused but signature kept consistent with `newEnableCmd`/`newDisableCmd`
  - `newDisableCmd`: `orch` unused but signature kept consistent with `newEnableCmd`/`newListCmd`
- Inline `"test-wiki"` in `setupTestInstallation` since all 15 callers pass the same value

Part of the lint cleanup tracked in #542.