### PR TITLE
Fix staticcheck lint violations

### DIFF
--- a/cmd/maintenance/maintenance_test.go
+++ b/cmd/maintenance/maintenance_test.go
@@ -69,6 +69,7 @@ func TestScriptAcceptsZeroArgs(t *testing.T) {
 	scriptCmd := findSubcommand(cmd, "script")
 	if scriptCmd == nil {
 		t.Fatal("script subcommand not found")
+		return
 	}
 
 	// script accepts 0 args (lists scripts) or 1 arg (runs a script)

--- a/cmd/sitemap/sitemap_test.go
+++ b/cmd/sitemap/sitemap_test.go
@@ -67,7 +67,8 @@ func TestGenerateCmd(t *testing.T) {
 
 	wikiFlag := cmd.Flags().Lookup("wiki")
 	if wikiFlag == nil {
-		t.Error("expected flag 'wiki'")
+		t.Fatal("expected flag 'wiki'")
+		return
 	}
 	if wikiFlag.Shorthand != "w" {
 		t.Errorf("expected wiki shorthand 'w', got %q", wikiFlag.Shorthand)
@@ -84,7 +85,8 @@ func TestRemoveCmd(t *testing.T) {
 
 	wikiFlag := cmd.Flags().Lookup("wiki")
 	if wikiFlag == nil {
-		t.Error("expected flag 'wiki'")
+		t.Fatal("expected flag 'wiki'")
+		return
 	}
 	if wikiFlag.Shorthand != "w" {
 		t.Errorf("expected wiki shorthand 'w', got %q", wikiFlag.Shorthand)
@@ -92,7 +94,8 @@ func TestRemoveCmd(t *testing.T) {
 
 	yesFlag := cmd.Flags().Lookup("yes")
 	if yesFlag == nil {
-		t.Error("expected flag 'yes'")
+		t.Fatal("expected flag 'yes'")
+		return
 	}
 	if yesFlag.Shorthand != "y" {
 		t.Errorf("expected yes shorthand 'y', got %q", yesFlag.Shorthand)


### PR DESCRIPTION
Closes #554

## Summary

All 18 staticcheck violations were SA5011 (possible nil pointer dereference) in test files where `t.Fatal` guards a nil check but staticcheck doesn't recognize it as a terminating call.

Fixed by:
- Adding explicit `return` after `t.Fatal` to make control flow clear to staticcheck
- Upgrading `t.Error` to `t.Fatal` where the pointer is dereferenced on the next line

2 files changed, 7 insertions, 3 deletions. Part of the lint cleanup tracked in #542.