### PR TITLE
Lint cleanup: fix all errcheck violations

### DIFF
--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -163,7 +163,9 @@ func TestUpdateWikisYamlPorts(t *testing.T) {
 	// Create a temp dir with a wikis.yaml and .env
 	tmpDir := t.TempDir()
 	configDir := filepath.Join(tmpDir, "config")
-	os.MkdirAll(configDir, 0755)
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
 
 	wikisYaml := `wikis:
 - id: main
@@ -173,10 +175,14 @@ func TestUpdateWikisYamlPorts(t *testing.T) {
   url: dev.example.com:8443/wiki
   name: Dev Wiki
 `
-	os.WriteFile(filepath.Join(configDir, "wikis.yaml"), []byte(wikisYaml), 0644)
+	if err := os.WriteFile(filepath.Join(configDir, "wikis.yaml"), []byte(wikisYaml), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	envContent := "MW_SITE_SERVER=https://example.com:8443\nMW_SITE_FQDN=example.com:8443\n"
-	os.WriteFile(filepath.Join(tmpDir, ".env"), []byte(envContent), 0644)
+	if err := os.WriteFile(filepath.Join(tmpDir, ".env"), []byte(envContent), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	inst := config.Installation{Path: tmpDir}
 

--- a/cmd/upgrade/mysql_to_mariadb.go
+++ b/cmd/upgrade/mysql_to_mariadb.go
@@ -66,7 +66,7 @@ func dumpMySQL8Data(installPath string) (string, error) {
 
 	// Always clean up the temporary container
 	defer func() {
-		execute.Run("", "docker", "rm", "-f", containerName)
+		_, _ = execute.Run("", "docker", "rm", "-f", containerName)
 	}()
 
 	// Wait for MySQL to be ready

--- a/internal/canasta/canasta_test.go
+++ b/internal/canasta/canasta_test.go
@@ -475,7 +475,9 @@ func TestIsObservabilityEnabled(t *testing.T) {
 func TestEnsureObservabilityCredentials_NotObservable(t *testing.T) {
 	dir := t.TempDir()
 	envPath := filepath.Join(dir, ".env")
-	os.WriteFile(envPath, []byte("COMPOSE_PROFILES=web\n"), 0644)
+	if err := os.WriteFile(envPath, []byte("COMPOSE_PROFILES=web\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	active, err := EnsureObservabilityCredentials(dir)
 	if err != nil {
@@ -489,7 +491,9 @@ func TestEnsureObservabilityCredentials_NotObservable(t *testing.T) {
 func TestEnsureObservabilityCredentials_GeneratesCredentials(t *testing.T) {
 	dir := t.TempDir()
 	envPath := filepath.Join(dir, ".env")
-	os.WriteFile(envPath, []byte("CANASTA_ENABLE_OBSERVABILITY=true\n"), 0644)
+	if err := os.WriteFile(envPath, []byte("CANASTA_ENABLE_OBSERVABILITY=true\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	active, err := EnsureObservabilityCredentials(dir)
 	if err != nil {
@@ -514,7 +518,9 @@ func TestEnsureObservabilityCredentials_GeneratesCredentials(t *testing.T) {
 func TestEnsureObservabilityCredentials_PreservesExisting(t *testing.T) {
 	dir := t.TempDir()
 	envPath := filepath.Join(dir, ".env")
-	os.WriteFile(envPath, []byte("CANASTA_ENABLE_OBSERVABILITY=true\nOS_USER=myuser\nOS_PASSWORD=mypass\nOS_PASSWORD_HASH=$2a$10$fakehash\n"), 0644)
+	if err := os.WriteFile(envPath, []byte("CANASTA_ENABLE_OBSERVABILITY=true\nOS_USER=myuser\nOS_PASSWORD=mypass\nOS_PASSWORD_HASH=$2a$10$fakehash\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	active, err := EnsureObservabilityCredentials(dir)
 	if err != nil {
@@ -539,9 +545,15 @@ func TestEnsureObservabilityCredentials_PreservesExisting(t *testing.T) {
 func TestRewriteCaddy_Observable(t *testing.T) {
 	dir := t.TempDir()
 	configDir := filepath.Join(dir, "config")
-	os.MkdirAll(configDir, 0755)
-	os.WriteFile(filepath.Join(configDir, "wikis.yaml"), []byte("wikis:\n  - id: main\n    url: example.com\n"), 0644)
-	os.WriteFile(filepath.Join(dir, ".env"), []byte("CANASTA_ENABLE_OBSERVABILITY=true\nOS_USER=admin\nOS_PASSWORD_HASH=$2a$10$testhash\n"), 0644)
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "wikis.yaml"), []byte("wikis:\n  - id: main\n    url: example.com\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("CANASTA_ENABLE_OBSERVABILITY=true\nOS_USER=admin\nOS_PASSWORD_HASH=$2a$10$testhash\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := RewriteCaddy(dir); err != nil {
 		t.Fatalf("RewriteCaddy() error = %v", err)
@@ -570,9 +582,15 @@ func TestRewriteCaddy_Observable(t *testing.T) {
 func TestRewriteCaddy_ObservableMissingCredentials(t *testing.T) {
 	dir := t.TempDir()
 	configDir := filepath.Join(dir, "config")
-	os.MkdirAll(configDir, 0755)
-	os.WriteFile(filepath.Join(configDir, "wikis.yaml"), []byte("wikis:\n  - id: main\n    url: example.com\n"), 0644)
-	os.WriteFile(filepath.Join(dir, ".env"), []byte("CANASTA_ENABLE_OBSERVABILITY=true\n"), 0644)
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "wikis.yaml"), []byte("wikis:\n  - id: main\n    url: example.com\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("CANASTA_ENABLE_OBSERVABILITY=true\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	err := RewriteCaddy(dir)
 	if err == nil {
@@ -586,7 +604,9 @@ func TestRewriteCaddy_ObservableMissingCredentials(t *testing.T) {
 func TestEnsureObservabilityCredentials_ValidBcryptHash(t *testing.T) {
 	dir := t.TempDir()
 	envPath := filepath.Join(dir, ".env")
-	os.WriteFile(envPath, []byte("CANASTA_ENABLE_OBSERVABILITY=true\n"), 0644)
+	if err := os.WriteFile(envPath, []byte("CANASTA_ENABLE_OBSERVABILITY=true\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	_, err := EnsureObservabilityCredentials(dir)
 	if err != nil {
@@ -604,7 +624,9 @@ func TestEnsureObservabilityCredentials_PartialCredentials(t *testing.T) {
 	dir := t.TempDir()
 	envPath := filepath.Join(dir, ".env")
 	// OS_USER set but OS_PASSWORD and OS_PASSWORD_HASH missing
-	os.WriteFile(envPath, []byte("CANASTA_ENABLE_OBSERVABILITY=true\nOS_USER=customuser\n"), 0644)
+	if err := os.WriteFile(envPath, []byte("CANASTA_ENABLE_OBSERVABILITY=true\nOS_USER=customuser\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	active, err := EnsureObservabilityCredentials(dir)
 	if err != nil {

--- a/internal/devmode/devmode_test.go
+++ b/internal/devmode/devmode_test.go
@@ -9,34 +9,42 @@ import (
 func TestIsDevModeSetup(t *testing.T) {
 	gotests := []struct {
 		name  string
-		setup func(dir string)
+		setup func(t *testing.T, dir string)
 		want  bool
 	}{
 		{
 			name: "both files present",
-			setup: func(dir string) {
-				os.WriteFile(filepath.Join(dir, "docker-compose.dev.yml"), []byte{}, 0644)
-				os.WriteFile(filepath.Join(dir, "Dockerfile.xdebug"), []byte{}, 0644)
+			setup: func(t *testing.T, dir string) {
+				if err := os.WriteFile(filepath.Join(dir, "docker-compose.dev.yml"), []byte{}, 0644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "Dockerfile.xdebug"), []byte{}, 0644); err != nil {
+					t.Fatal(err)
+				}
 			},
 			want: true,
 		},
 		{
 			name: "neither file present",
-			setup: func(dir string) {
+			setup: func(t *testing.T, dir string) {
 			},
 			want: false,
 		},
 		{
 			name: "only docker-compose.dev.yml present",
-			setup: func(dir string) {
-				os.WriteFile(filepath.Join(dir, "docker-compose.dev.yml"), []byte{}, 0644)
+			setup: func(t *testing.T, dir string) {
+				if err := os.WriteFile(filepath.Join(dir, "docker-compose.dev.yml"), []byte{}, 0644); err != nil {
+					t.Fatal(err)
+				}
 			},
 			want: false,
 		},
 		{
 			name: "only Dockerfile.xdebug present",
-			setup: func(dir string) {
-				os.WriteFile(filepath.Join(dir, "Dockerfile.xdebug"), []byte{}, 0644)
+			setup: func(t *testing.T, dir string) {
+				if err := os.WriteFile(filepath.Join(dir, "Dockerfile.xdebug"), []byte{}, 0644); err != nil {
+					t.Fatal(err)
+				}
 			},
 			want: false,
 		},
@@ -45,7 +53,7 @@ func TestIsDevModeSetup(t *testing.T) {
 	for _, tt := range gotests {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
-			tt.setup(dir)
+			tt.setup(t, dir)
 
 			if got := IsDevModeSetup(dir); got != tt.want {
 				t.Errorf("IsDevModeSetup(%q) = %v, want %v", dir, got, tt.want)

--- a/internal/orchestrators/compose_config_test.go
+++ b/internal/orchestrators/compose_config_test.go
@@ -77,8 +77,12 @@ func TestComposeMigrateConfig_NothingToMigrate(t *testing.T) {
 	dir := setupTestInstall(t, "COMPOSE_PROFILES=web\n", "wikis:\n  - id: main\n    url: example.com\n")
 
 	// Create both Caddyfiles so no migration is needed
-	os.WriteFile(filepath.Join(dir, "config", "Caddyfile.site"), []byte("# site"), 0644)
-	os.WriteFile(filepath.Join(dir, "config", "Caddyfile.global"), []byte("# global"), 0644)
+	if err := os.WriteFile(filepath.Join(dir, "config", "Caddyfile.site"), []byte("# site"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config", "Caddyfile.global"), []byte("# global"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	c := &ComposeOrchestrator{}
 	changed, err := c.MigrateConfig(dir, false)
@@ -172,8 +176,12 @@ func TestComposeMigrateConfig_Observable(t *testing.T) {
 	dir := setupTestInstall(t, "CANASTA_ENABLE_OBSERVABILITY=true\n", "wikis:\n  - id: main\n    url: example.com\n")
 
 	// Create Caddyfiles so caddy migration doesn't trigger
-	os.WriteFile(filepath.Join(dir, "config", "Caddyfile.site"), []byte("# site"), 0644)
-	os.WriteFile(filepath.Join(dir, "config", "Caddyfile.global"), []byte("# global"), 0644)
+	if err := os.WriteFile(filepath.Join(dir, "config", "Caddyfile.site"), []byte("# site"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config", "Caddyfile.global"), []byte("# global"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	c := &ComposeOrchestrator{}
 	changed, err := c.MigrateConfig(dir, false)
@@ -196,8 +204,12 @@ func TestComposeMigrateConfig_ObservableDryRun(t *testing.T) {
 	dir := setupTestInstall(t, "CANASTA_ENABLE_OBSERVABILITY=true\n", "wikis:\n  - id: main\n    url: example.com\n")
 
 	// Create Caddyfiles so caddy migration doesn't trigger
-	os.WriteFile(filepath.Join(dir, "config", "Caddyfile.site"), []byte("# site"), 0644)
-	os.WriteFile(filepath.Join(dir, "config", "Caddyfile.global"), []byte("# global"), 0644)
+	if err := os.WriteFile(filepath.Join(dir, "config", "Caddyfile.site"), []byte("# site"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config", "Caddyfile.global"), []byte("# global"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	c := &ComposeOrchestrator{}
 	changed, err := c.MigrateConfig(dir, true)
@@ -220,8 +232,12 @@ func TestComposeMigrateConfig_ObservableAlreadyConfigured(t *testing.T) {
 	dir := setupTestInstall(t, env, "wikis:\n  - id: main\n    url: example.com\n")
 
 	// Create Caddyfiles so caddy migration doesn't trigger
-	os.WriteFile(filepath.Join(dir, "config", "Caddyfile.site"), []byte("# site"), 0644)
-	os.WriteFile(filepath.Join(dir, "config", "Caddyfile.global"), []byte("# global"), 0644)
+	if err := os.WriteFile(filepath.Join(dir, "config", "Caddyfile.site"), []byte("# site"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config", "Caddyfile.global"), []byte("# global"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	c := &ComposeOrchestrator{}
 	changed, err := c.MigrateConfig(dir, false)
@@ -280,8 +296,12 @@ func TestComposeMigrateConfig_OldProfileMigration(t *testing.T) {
 	dir := setupTestInstall(t, "COMPOSE_PROFILES=web,observable\n", "wikis:\n  - id: main\n    url: example.com\n")
 
 	// Create Caddyfiles so caddy migration doesn't trigger
-	os.WriteFile(filepath.Join(dir, "config", "Caddyfile.site"), []byte("# site"), 0644)
-	os.WriteFile(filepath.Join(dir, "config", "Caddyfile.global"), []byte("# global"), 0644)
+	if err := os.WriteFile(filepath.Join(dir, "config", "Caddyfile.site"), []byte("# site"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config", "Caddyfile.global"), []byte("# global"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	c := &ComposeOrchestrator{}
 	changed, err := c.MigrateConfig(dir, false)

--- a/internal/orchestrators/kubernetes_test.go
+++ b/internal/orchestrators/kubernetes_test.go
@@ -584,7 +584,9 @@ func TestGenerateKustomizationObservabilityEnabled(t *testing.T) {
 	dir := setupTestInstallation(t, "test-wiki")
 	// Enable observability
 	envPath := filepath.Join(dir, ".env")
-	os.WriteFile(envPath, []byte("MW_SITE_SERVER=https://example.com\nCANASTA_ENABLE_OBSERVABILITY=true\n"), 0644)
+	if err := os.WriteFile(envPath, []byte("MW_SITE_SERVER=https://example.com\nCANASTA_ENABLE_OBSERVABILITY=true\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	k := &KubernetesOrchestrator{}
 	if err := k.generateKustomization(dir, false); err != nil {
@@ -650,7 +652,9 @@ func TestKubernetesMigrateConfigObservability(t *testing.T) {
 	dir := setupTestInstallation(t, "test-wiki")
 	// Enable observability but don't provide credentials
 	envPath := filepath.Join(dir, ".env")
-	os.WriteFile(envPath, []byte("CANASTA_ENABLE_OBSERVABILITY=true\n"), 0644)
+	if err := os.WriteFile(envPath, []byte("CANASTA_ENABLE_OBSERVABILITY=true\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	k := &KubernetesOrchestrator{}
 	changed, err := k.MigrateConfig(dir, false)
@@ -692,7 +696,9 @@ func TestGenerateKustomizationElasticsearchEnabled(t *testing.T) {
 	dir := setupTestInstallation(t, "test-wiki")
 	// Enable Elasticsearch
 	envPath := filepath.Join(dir, ".env")
-	os.WriteFile(envPath, []byte("MW_SITE_SERVER=https://example.com\nCANASTA_ENABLE_ELASTICSEARCH=true\n"), 0644)
+	if err := os.WriteFile(envPath, []byte("MW_SITE_SERVER=https://example.com\nCANASTA_ENABLE_ELASTICSEARCH=true\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	k := &KubernetesOrchestrator{}
 	if err := k.generateKustomization(dir, false); err != nil {


### PR DESCRIPTION
Fix all `errcheck` violations reported by golangci-lint.

**Test files** (5 files): Wrap unchecked `os.WriteFile` and `os.MkdirAll` calls with `if err := ...; err != nil { t.Fatal(err) }`. In `devmode_test.go`, the setup function signatures were updated to accept `*testing.T` to enable error checking.

**Production code** (1 file): Mark one intentionally ignored `execute.Run` return (best-effort Docker container cleanup) with blank identifiers `_, _ =`.

Fixes #556
Part of #542