### PR TITLE
Lint cleanup: fix all gocritic violations

### DIFF
--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -197,19 +197,19 @@ func AddWiki(opts AddWikiOptions) error {
 		return err
 	}
 
-	//Migrate to the new version Canasta
+	// Migrate to the new version Canasta
 	err = canasta.MigrateToNewVersion(opts.Instance.Path)
 	if err != nil {
 		return err
 	}
 
-	//Checking Running status
+	// Checking Running status
 	err = orch.CheckRunningStatus(opts.Instance)
 	if err != nil {
 		return err
 	}
 
-	//Checking Wiki existence
+	// Checking Wiki existence
 	wikiIDExists, err := farmsettings.WikiIDExists(opts.Instance.Path, opts.WikiID)
 	if err != nil {
 		return err
@@ -260,13 +260,13 @@ func AddWiki(opts AddWikiOptions) error {
 		}
 	}
 
-	//Add the wiki in farmsettings (only after successful installation)
+	// Add the wiki in farmsettings (only after successful installation)
 	err = farmsettings.AddWiki(opts.WikiID, opts.Instance.Path, opts.Domain, opts.WikiPath, opts.SiteName)
 	if err != nil {
 		return err
 	}
 
-	//Rewrite the Caddyfile (only after adding to wikis.yaml)
+	// Rewrite the Caddyfile (only after adding to wikis.yaml)
 	err = orch.UpdateConfig(opts.Instance.Path)
 	if err != nil {
 		return err

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -240,7 +240,8 @@ func createCanasta(opts createOptions) error {
 	// Determine the base image to use
 	var baseImage string
 	var localImageBuilt bool
-	if opts.BuildFromPath != "" {
+	switch {
+	case opts.BuildFromPath != "":
 		// Build Canasta (and optionally CanastaBase) from source
 		logging.Print("Building from local source...\n")
 		builtImage, err := imagebuild.BuildFromSource(opts.BuildFromPath)
@@ -249,10 +250,10 @@ func createCanasta(opts createOptions) error {
 		}
 		baseImage = builtImage
 		localImageBuilt = true
-	} else if opts.CanastaImage != "" {
+	case opts.CanastaImage != "":
 		// Use the user-specified image
 		baseImage = opts.CanastaImage
-	} else {
+	default:
 		// Use the default Canasta image
 		baseImage = canasta.GetDefaultImage()
 	}

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -101,7 +101,7 @@ func Delete(instance config.Installation) error {
 		return err
 	}
 
-	//Delete config files
+	// Delete config files
 	if _, err := orchestrators.DeleteConfig(instance.Path); err != nil {
 		return err
 	}
@@ -113,7 +113,7 @@ func Delete(instance config.Installation) error {
 		logging.Print("Removed backup schedule.\n")
 	}
 
-	//Deleting installation details from conf.json
+	// Deleting installation details from conf.json
 	if err = config.Delete(instance.Id); err != nil {
 		return err
 	}

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -90,7 +90,7 @@ func RemoveWiki(instance config.Installation, wikiID string, yes bool) error {
 		fmt.Println("These may require manual removal.")
 	}
 
-	//Checking Wiki existence
+	// Checking Wiki existence
 	exists, err := farmsettings.WikiIDExists(instance.Path, wikiID)
 	if err != nil {
 		return err
@@ -111,7 +111,7 @@ func RemoveWiki(instance config.Installation, wikiID string, yes bool) error {
 		}
 	}
 
-	//Remove the wiki
+	// Remove the wiki
 	err = farmsettings.RemoveWiki(wikiID, instance.Path)
 	if err != nil {
 		return err
@@ -125,7 +125,7 @@ func RemoveWiki(instance config.Installation, wikiID string, yes bool) error {
 		}
 	}
 
-	//Remove the Localsettings
+	// Remove the Localsettings
 	err = canasta.RemoveSettings(instance.Path, wikiID)
 	if err != nil {
 		return err
@@ -147,13 +147,13 @@ func RemoveWiki(instance config.Installation, wikiID string, yes bool) error {
 		return err
 	}
 
-	//Rewrite the Caddyfile
+	// Rewrite the Caddyfile
 	err = orch.UpdateConfig(instance.Path)
 	if err != nil {
 		return err
 	}
 
-	//Restart the Canasta Instance
+	// Restart the Canasta Instance
 	err = restart.Restart(instance)
 	if err != nil {
 		return err

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -141,7 +141,8 @@ func Upgrade(instance config.Installation, dryRun bool) error {
 	envPath := filepath.Join(instance.Path, ".env")
 
 	if !dryRun {
-		if instance.BuildFrom != "" {
+		switch {
+		case instance.BuildFrom != "":
 			// Rebuild Canasta image from stored source path
 			fmt.Printf("Rebuilding Canasta image from %s...\n", instance.BuildFrom)
 			imageTag, err := imagebuild.BuildFromSource(instance.BuildFrom)
@@ -174,13 +175,13 @@ func Upgrade(instance config.Installation, dryRun bool) error {
 			}
 
 			imagesUpdated = true
-		} else if !orch.SupportsImagePull() {
+		case !orch.SupportsImagePull():
 			fmt.Println("Regenerating configuration and re-applying manifests...")
 			if err := orch.UpdateConfig(instance.Path); err != nil {
 				return err
 			}
 			imagesUpdated = true
-		} else {
+		default:
 			fmt.Println("Pulling Canasta container images...")
 			report, err := orch.Update(instance.Path)
 			if err != nil {
@@ -382,11 +383,12 @@ func runMigration(installPath string, orch orchestrators.Orchestrator, dryRun bo
 		changed = true
 	}
 
-	if !changed {
+	switch {
+	case !changed:
 		fmt.Println("No config migrations needed.")
-	} else if dryRun {
+	case dryRun:
 		fmt.Println("Config migrations would be applied.")
-	} else {
+	default:
 		fmt.Println("Migrations applied.")
 	}
 

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -669,14 +669,12 @@ func GenerateDBPasswords(canastaInfo CanastaVariables) (CanastaVariables, error)
 	// Wiki DB password: flag → auto-generate (per-farm, saved to .env only)
 	if canastaInfo.WikiDBUsername == "root" {
 		canastaInfo.WikiDBPassword = canastaInfo.RootDBPassword
-	} else {
-		if canastaInfo.WikiDBPassword == "" {
-			canastaInfo.WikiDBPassword, err = gen.Generate(30, 4, 6, false, true)
-			if err != nil {
-				return canastaInfo, err
-			}
-			fmt.Printf("Generated wiki database password (will be saved to .env)\n")
+	} else if canastaInfo.WikiDBPassword == "" {
+		canastaInfo.WikiDBPassword, err = gen.Generate(30, 4, 6, false, true)
+		if err != nil {
+			return canastaInfo, err
 		}
+		fmt.Printf("Generated wiki database password (will be saved to .env)\n")
 	}
 
 	return canastaInfo, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -367,14 +367,15 @@ func GetConfigDir() (string, error) {
 	}
 
 	fi, err := os.Stat(dir)
-	if os.IsNotExist(err) {
+	switch {
+	case os.IsNotExist(err):
 		err = os.MkdirAll(dir, 0o755)
 		if err != nil {
 			return "", err
 		}
-	} else if err != nil {
+	case err != nil:
 		return "", fmt.Errorf("error statting %s (%w)", dir, err)
-	} else {
+	default:
 		mode := fi.Mode()
 		if !mode.IsDir() {
 			return "", fmt.Errorf("%s exists but is not a directory", dir)

--- a/internal/orchestrators/compose.go
+++ b/internal/orchestrators/compose.go
@@ -289,11 +289,12 @@ func (c *ComposeOrchestrator) Update(installPath string) (*UpdateReport, error) 
 	// Compare before and after
 	for service, after := range afterImages {
 		before, existed := beforeImages[service]
-		if !existed {
+		switch {
+		case !existed:
 			report.UpdatedImages = append(report.UpdatedImages, after)
-		} else if before.ID != after.ID {
+		case before.ID != after.ID:
 			report.UpdatedImages = append(report.UpdatedImages, after)
-		} else {
+		default:
 			report.UnchangedImages = append(report.UnchangedImages, after)
 		}
 	}
@@ -604,17 +605,19 @@ func getComposeImages(installPath string, compose config.Orchestrator) (map[stri
 			containerName := fields[0]
 			parts := strings.Split(containerName, "-")
 			var service string
-			if len(parts) >= 3 {
+			switch {
+			case len(parts) >= 3:
 				service = strings.Join(parts[1:len(parts)-1], "-")
-			} else if len(parts) == 2 {
+			case len(parts) == 2:
 				service = parts[0]
-			} else {
+			default:
 				parts = strings.Split(containerName, "_")
-				if len(parts) >= 3 {
+				switch {
+				case len(parts) >= 3:
 					service = strings.Join(parts[1:len(parts)-1], "_")
-				} else if len(parts) == 2 {
+				case len(parts) == 2:
 					service = parts[0]
-				} else {
+				default:
 					service = containerName
 				}
 			}


### PR DESCRIPTION
Fix all `gocritic` violations reported by golangci-lint across 8 files.

- **commentFormatting** (9): Add space between `//` and comment text
- **ifElseChain** (5): Rewrite if-else chains as switch statements in `create.go`, `upgrade.go`, `config.go`, and `compose.go`
- **elseif** (1): Collapse `else { if }` to `else if` in `canasta.go`

Fixes #558
Part of #542