### PR TITLE
Lint cleanup: fix all stylecheck violations

### DIFF
--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -103,12 +103,12 @@ an existing database dump instead of running the installer.`,
 			if !strings.HasPrefix(urlString, "http://") && !strings.HasPrefix(urlString, "https://") {
 				urlString = "https://" + urlString
 			}
-			parsedUrl, err := urlpkg.Parse(urlString)
+			parsedURL, err := urlpkg.Parse(urlString)
 			if err != nil {
 				return fmt.Errorf("failed to parse URL: %w", err)
 			}
-			domainName = parsedUrl.Host
-			wikiPath = strings.Trim(parsedUrl.Path, "/")
+			domainName = parsedURL.Host
+			wikiPath = strings.Trim(parsedURL.Path, "/")
 
 			// Validate wiki URL path
 			if err := farmsettings.ValidateWikiPath(wikiPath); err != nil {
@@ -131,12 +131,12 @@ an existing database dump instead of running the installer.`,
 				fmt.Printf("Generated admin password for wiki '%s'\n", wikiID)
 			}
 
-			instance, err = canasta.CheckCanastaId(instance)
+			instance, err = canasta.CheckCanastaID(instance)
 			if err != nil {
 				return err
 			}
 
-			fmt.Printf("Adding wiki '%s' to Canasta instance '%s'...\n", wikiID, instance.Id)
+			fmt.Printf("Adding wiki '%s' to Canasta instance '%s'...\n", wikiID, instance.ID)
 			err = AddWiki(AddWikiOptions{
 				Instance:         instance,
 				WikiID:           wikiID,
@@ -161,7 +161,7 @@ an existing database dump instead of running the installer.`,
 	addCmd.Flags().StringVarP(&wikiID, "wiki", "w", "", "ID of the new wiki")
 	addCmd.Flags().StringVarP(&url, "url", "u", "", "URL of the new wiki (domain/path format, e.g., 'localhost/wiki2' or 'example.com/mywiki'; do not include protocol/scheme)")
 	addCmd.Flags().StringVarP(&siteName, "site-name", "t", "", "Display name of the wiki (optional, defaults to wiki ID)")
-	addCmd.Flags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
+	addCmd.Flags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
 	addCmd.Flags().StringVarP(&databasePath, "database", "d", "", "Path to existing database dump (.sql or .sql.gz) to import instead of running install.php")
 	addCmd.Flags().StringVarP(&wikiSettingsPath, "wiki-settings", "l", "", "Path to per-wiki settings file to copy to config/settings/wikis/<wiki_id>/ (filename preserved)")
 	addCmd.Flags().StringVarP(&admin, "admin", "a", "WikiSysop", "Admin name of the new wiki (default: \"WikiSysop\")")
@@ -215,15 +215,15 @@ func AddWiki(opts AddWikiOptions) error {
 		return err
 	}
 	if wikiIDExists {
-		return fmt.Errorf("A wiki with the ID '%s' exists", opts.WikiID)
+		return fmt.Errorf("a wiki with the ID '%s' exists", opts.WikiID)
 	}
 
-	urlExists, err := farmsettings.WikiUrlExists(opts.Instance.Path, opts.Domain, opts.WikiPath)
+	urlExists, err := farmsettings.WikiURLExists(opts.Instance.Path, opts.Domain, opts.WikiPath)
 	if err != nil {
 		return err
 	}
 	if urlExists {
-		return fmt.Errorf("A wiki with the same installation path '%s' in the Canasta instance '%s' exists", opts.WikiID+": "+opts.Domain+"/"+opts.WikiPath, opts.Instance.Id)
+		return fmt.Errorf("a wiki with the same installation path '%s' in the Canasta instance '%s' exists", opts.WikiID+": "+opts.Domain+"/"+opts.WikiPath, opts.Instance.ID)
 	}
 
 	// Import the database if databasePath is specified
@@ -277,7 +277,7 @@ func AddWiki(opts AddWikiOptions) error {
 		return err
 	}
 
-	fmt.Println("Successfully added wiki '" + opts.WikiID + "' in Canasta instance '" + opts.Instance.Id + "'...")
+	fmt.Println("Successfully added wiki '" + opts.WikiID + "' in Canasta instance '" + opts.Instance.ID + "'...")
 
 	return nil
 }

--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -37,7 +37,7 @@ and schedule recurring backups. Requires RESTIC_REPOSITORY (or AWS S3 settings)
 and RESTIC_PASSWORD to be configured in the installation's .env file.`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			instance, err = canasta.CheckCanastaId(instance)
+			instance, err = canasta.CheckCanastaID(instance)
 			if err != nil {
 				return err
 			}
@@ -67,7 +67,7 @@ and RESTIC_PASSWORD to be configured in the installation's .env file.`,
 	backupCmd.AddCommand(newDiffCmd(&orch, &instance, &envPath, &repoURL))
 	backupCmd.AddCommand(newScheduleCmd(&instance))
 
-	backupCmd.PersistentFlags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
+	backupCmd.PersistentFlags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
 	return backupCmd
 
 }
@@ -92,7 +92,7 @@ func getWikiIDs(installPath string) ([]string, error) {
 	yamlPath := filepath.Join(installPath, "config", "wikis.yaml")
 	ids, _, _, err := farmsettings.ReadWikisYaml(yamlPath)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to read wikis.yaml: %w", err)
+		return nil, fmt.Errorf("failed to read wikis.yaml: %w", err)
 	}
 	return ids, nil
 }

--- a/cmd/backup/restore.go
+++ b/cmd/backup/restore.go
@@ -17,7 +17,7 @@ import (
 func newRestoreCmd(orch *orchestrators.Orchestrator, instance *config.Installation, envPath, repoURL *string) *cobra.Command {
 
 	var (
-		snapshotId         string
+		snapshotID         string
 		skipBeforeSnapshot bool
 		wikiID             string
 	)
@@ -41,18 +41,18 @@ images, and public assets from the backup, leaving shared files untouched.`,
   # Restore only a single wiki's database
   canasta backup restore -i myinstance -s abc123 -w wiki2`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return restoreSnapshot(*orch, *instance, *envPath, *repoURL, snapshotId, skipBeforeSnapshot, wikiID)
+			return restoreSnapshot(*orch, *instance, *envPath, *repoURL, snapshotID, skipBeforeSnapshot, wikiID)
 		},
 	}
 
-	restoreCmd.Flags().StringVarP(&snapshotId, "snapshot", "s", "", "Snapshot ID (required)")
+	restoreCmd.Flags().StringVarP(&snapshotID, "snapshot", "s", "", "Snapshot ID (required)")
 	restoreCmd.Flags().BoolVar(&skipBeforeSnapshot, "skip-safety-backup", false, "Skip taking a safety backup before restore")
 	restoreCmd.Flags().StringVarP(&wikiID, "wiki", "w", "", "Restore only this wiki's database and per-wiki files")
 	_ = restoreCmd.MarkFlagRequired("snapshot")
 	return restoreCmd
 }
 
-func restoreSnapshot(orch orchestrators.Orchestrator, instance config.Installation, envPath, repoURL, snapshotId string, skipBeforeSnapshot bool, wikiID string) error {
+func restoreSnapshot(orch orchestrators.Orchestrator, instance config.Installation, envPath, repoURL, snapshotID string, skipBeforeSnapshot bool, wikiID string) error {
 	envVariables, envErr := canasta.GetEnvVariable(envPath)
 	if envErr != nil {
 		return envErr
@@ -60,14 +60,14 @@ func restoreSnapshot(orch orchestrators.Orchestrator, instance config.Installati
 
 	if !skipBeforeSnapshot {
 		logging.Print("Taking snapshot...")
-		if err := takeSnapshot(orch, instance, envPath, repoURL, "BeforeRestoring-"+snapshotId); err != nil {
+		if err := takeSnapshot(orch, instance, envPath, repoURL, "BeforeRestoring-"+snapshotID); err != nil {
 			return err
 		}
 		logging.Print("Snapshot taken...")
 	}
 
 	logging.Print("Restoring snapshot to backup volume...")
-	_, err := runBackup(orch, instance.Path, envPath, nil, "-r", repoURL, "restore", snapshotId, "--target", "/")
+	_, err := runBackup(orch, instance.Path, envPath, nil, "-r", repoURL, "restore", snapshotID, "--target", "/")
 	if err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func restoreWiki(orch orchestrators.Orchestrator, instance config.Installation, 
 	_, restoreErr := orch.ExecWithError(instance.Path, orchestrators.ServiceWeb, command)
 	if restoreErr != nil {
 		cleanupBackupDir(instance.Path)
-		return fmt.Errorf("Database restore failed for wiki '%s': %w", wikiID, restoreErr)
+		return fmt.Errorf("database restore failed for wiki '%s': %w", wikiID, restoreErr)
 	}
 
 	// Clean up the database dump directory
@@ -173,7 +173,7 @@ func restoreFull(orch orchestrators.Orchestrator, instance config.Installation, 
 			orchestrators.ShellQuote(env["MYSQL_PASSWORD"]), dumpPath(id))
 		_, restoreErr := orch.ExecWithError(instance.Path, orchestrators.ServiceWeb, command)
 		if restoreErr != nil {
-			return fmt.Errorf("Database restore failed for wiki '%s': %w", id, restoreErr)
+			return fmt.Errorf("database restore failed for wiki '%s': %w", id, restoreErr)
 		}
 	}
 
@@ -198,7 +198,7 @@ func getWikiIDsForRestore(installPath string) ([]string, error) {
 	yamlPath := filepath.Join(installPath, "config", "wikis.yaml")
 	ids, _, _, err := farmsettings.ReadWikisYaml(yamlPath)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to read wikis.yaml: %w", err)
+		return nil, fmt.Errorf("failed to read wikis.yaml: %w", err)
 	}
 
 	var result []string
@@ -210,7 +210,7 @@ func getWikiIDsForRestore(installPath string) ([]string, error) {
 	}
 
 	if len(result) == 0 {
-		return nil, fmt.Errorf("No database dump files found in backup")
+		return nil, fmt.Errorf("no database dump files found in backup")
 	}
 	return result, nil
 }

--- a/cmd/backup/schedule.go
+++ b/cmd/backup/schedule.go
@@ -122,7 +122,7 @@ func scheduleBackup(instance config.Installation, cronExpression string) error {
 	logPath := filepath.Join(instance.Path, "backup.log")
 	quotedLogPath := orchestrators.ShellQuote(logPath)
 	rotateCmd := fmt.Sprintf("find %s -size +10M -exec mv {} %s \\;", quotedLogPath, orchestrators.ShellQuote(logPath+".1"))
-	cmdStr := fmt.Sprintf("%s %s && %s backup create -i %s --tag scheduled-$(date +\\%%Y\\%%m\\%%d\\%%H\\%%M\\%%S) >> %s 2>&1", cronExpression, rotateCmd, executable, instance.Id, quotedLogPath)
+	cmdStr := fmt.Sprintf("%s %s && %s backup create -i %s --tag scheduled-$(date +\\%%Y\\%%m\\%%d\\%%H\\%%M\\%%S) >> %s 2>&1", cronExpression, rotateCmd, executable, instance.ID, quotedLogPath)
 
 	logging.Print(fmt.Sprintf("Scheduling backup with cron: %s", cronExpression))
 
@@ -133,12 +133,12 @@ func scheduleBackup(instance config.Installation, cronExpression string) error {
 
 	var newLines []string
 	updated := false
-	identifier := jobIdentifierForInstance(instance.Id)
+	identifier := jobIdentifierForInstance(instance.ID)
 
 	for _, line := range lines {
 		if strings.Contains(line, identifier) {
 			oldCron := cronFromLine(line)
-			fmt.Printf("Replacing existing schedule '%s' with '%s' for instance '%s'.\n", oldCron, cronExpression, instance.Id)
+			fmt.Printf("Replacing existing schedule '%s' with '%s' for instance '%s'.\n", oldCron, cronExpression, instance.ID)
 			fmt.Println("Tip: to schedule multiple times, combine them in one expression (e.g., \"0 0 * * 2,5\" for Tuesdays and Fridays).")
 			newLines = append(newLines, cmdStr)
 			updated = true
@@ -165,24 +165,24 @@ func listSchedule(instance config.Installation) error {
 		return err
 	}
 
-	identifier := jobIdentifierForInstance(instance.Id)
+	identifier := jobIdentifierForInstance(instance.ID)
 	for _, line := range lines {
 		if strings.Contains(line, identifier) {
-			fmt.Printf("Instance '%s' is scheduled for backup at: %s\n", instance.Id, cronFromLine(line))
+			fmt.Printf("Instance '%s' is scheduled for backup at: %s\n", instance.ID, cronFromLine(line))
 			return nil
 		}
 	}
 
-	return fmt.Errorf("no backup schedule found for instance '%s'", instance.Id)
+	return fmt.Errorf("no backup schedule found for instance '%s'", instance.ID)
 }
 
 func unscheduleBackup(instance config.Installation) error {
-	removed, err := RemoveSchedule(instance.Id)
+	removed, err := RemoveSchedule(instance.ID)
 	if err != nil {
 		return err
 	}
 	if !removed {
-		return fmt.Errorf("no backup schedule found for instance '%s'", instance.Id)
+		return fmt.Errorf("no backup schedule found for instance '%s'", instance.ID)
 	}
 	fmt.Println("Backup schedule removed.")
 	return nil

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -81,7 +81,7 @@ To change the domain, first edit config/wikis.yaml, then use
 "canasta config set" to update MW_SITE_SERVER and MW_SITE_FQDN.`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			instance, err = canasta.CheckCanastaId(instance)
+			instance, err = canasta.CheckCanastaID(instance)
 			if err != nil {
 				return err
 			}
@@ -90,7 +90,7 @@ To change the domain, first edit config/wikis.yaml, then use
 		},
 	}
 
-	configCmd.PersistentFlags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
+	configCmd.PersistentFlags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
 
 	configCmd.AddCommand(newGetCmd(&instance))
 	configCmd.AddCommand(newSetCmd(&instance, &orch))

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -72,13 +72,13 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
 
 			// Validate Canasta instance ID format
 			validString := regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-_]*[a-zA-Z0-9])?$`)
-			if !validString.MatchString(canastaInfo.Id) {
-				return fmt.Errorf("Canasta instance ID should not contain spaces or non-ASCII characters, only alphanumeric characters are allowed")
+			if !validString.MatchString(canastaInfo.ID) {
+				return fmt.Errorf("canasta instance ID should not contain spaces or non-ASCII characters, only alphanumeric characters are allowed")
 			}
 
 			// Check for duplicate ID before doing any work
-			if _, err := config.GetDetails(canastaInfo.Id); err == nil {
-				return fmt.Errorf("Canasta installation with ID '%s' already exists", canastaInfo.Id)
+			if _, err := config.GetDetails(canastaInfo.ID); err == nil {
+				return fmt.Errorf("canasta installation with ID '%s' already exists", canastaInfo.ID)
 			}
 
 			// Validate --canasta-image and --build-from are mutually exclusive
@@ -127,7 +127,7 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
 				}
 			}
 
-			stopSpinner := spinner.New("Creating Canasta installation '" + canastaInfo.Id + "'...")
+			stopSpinner := spinner.New("Creating Canasta installation '" + canastaInfo.ID + "'...")
 
 			orch, err := orchestrators.New(orchestrator)
 			if err != nil {
@@ -167,10 +167,10 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
 				stopSpinner()
 				fmt.Print(err.Error(), "\n")
 				if !keepConfig {
-					deleteConfigAndContainers(filepath.Join(path, canastaInfo.Id), orch)
-					return fmt.Errorf("Installation failed and files were cleaned up")
+					deleteConfigAndContainers(filepath.Join(path, canastaInfo.ID), orch)
+					return fmt.Errorf("installation failed and files were cleaned up")
 				}
-				return fmt.Errorf("Installation failed. Keeping all the containers and config files")
+				return fmt.Errorf("installation failed. Keeping all the containers and config files")
 			}
 			stopSpinner()
 			fmt.Println("\033[32mPlease note that mailing does not currently work on this wiki, because Canasta requires $wgSMTP to be set in order to send emails (see https://www.mediawiki.org/wiki/Manual:$wgSMTP).\033[0m")
@@ -185,7 +185,7 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
 
 	createCmd.Flags().StringVarP(&path, "path", "p", workingDir, "Canasta directory")
 	createCmd.Flags().StringVarP(&orchestrator, "orchestrator", "o", "compose", "Orchestrator to use (compose or kubernetes)")
-	createCmd.Flags().StringVarP(&canastaInfo.Id, "id", "i", "", "Canasta instance ID")
+	createCmd.Flags().StringVarP(&canastaInfo.ID, "id", "i", "", "Canasta instance ID")
 	createCmd.Flags().StringVarP(&wikiID, "wiki", "w", "", "ID of the wiki")
 	createCmd.Flags().StringVarP(&siteName, "site-name", "t", "", "Display name of the wiki (optional, defaults to wiki ID)")
 	createCmd.Flags().StringVarP(&domain, "domain-name", "n", "localhost", "Domain name")
@@ -258,7 +258,7 @@ func createCanasta(opts createOptions) error {
 	}
 
 	// Create the installation directory and write orchestrator stack files
-	path := filepath.Join(opts.Path, opts.CanastaInfo.Id)
+	path := filepath.Join(opts.Path, opts.CanastaInfo.ID)
 	if err := os.MkdirAll(path, permissions.DirectoryPermission); err != nil {
 		return fmt.Errorf("failed to create installation directory: %w", err)
 	}
@@ -320,7 +320,7 @@ func createCanasta(opts createOptions) error {
 	var kindClusterName string
 	if opts.CreateCluster && isK8s {
 		httpPort, httpsPort := orchestrators.GetPortsFromEnv(path)
-		kindClusterName = orchestrators.KindClusterName(opts.CanastaInfo.Id)
+		kindClusterName = orchestrators.KindClusterName(opts.CanastaInfo.ID)
 		if err := orchestrators.CreateKindCluster(kindClusterName, httpPort, httpsPort); err != nil {
 			return fmt.Errorf("failed to create kind cluster: %w", err)
 		}
@@ -401,7 +401,7 @@ func createCanasta(opts createOptions) error {
 	if isK8s {
 		reg = opts.Registry
 	}
-	instance := config.Installation{Id: opts.CanastaInfo.Id, Path: path, Orchestrator: opts.Orchestrator, DevMode: false, ManagedCluster: opts.CreateCluster, Registry: reg, KindCluster: kindClusterName, BuildFrom: opts.BuildFromPath}
+	instance := config.Installation{ID: opts.CanastaInfo.ID, Path: path, Orchestrator: opts.Orchestrator, DevMode: false, ManagedCluster: opts.CreateCluster, Registry: reg, KindCluster: kindClusterName, BuildFrom: opts.BuildFromPath}
 	if err := config.Add(instance); err != nil {
 		return err
 	}

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -43,13 +43,13 @@ prompted for confirmation before any data is deleted.`,
 				return fmt.Errorf("unknown argument %q; use --id to specify the instance ID (e.g. canasta delete --id %s)", args[0], args[0])
 			}
 			var err error
-			instance, err = canasta.CheckCanastaId(instance)
+			instance, err = canasta.CheckCanastaID(instance)
 			if err != nil {
 				return err
 			}
 			if !yes {
 				reader := bufio.NewReader(os.Stdin)
-				fmt.Printf("This will permanently delete the Canasta installation '%s' and all its data. Continue? [y/N] ", instance.Id)
+				fmt.Printf("This will permanently delete the Canasta installation '%s' and all its data. Continue? [y/N] ", instance.ID)
 				text, _ := reader.ReadString('\n')
 				text = strings.ToLower(strings.TrimSpace(text))
 				if text != "y" {
@@ -63,13 +63,13 @@ prompted for confirmation before any data is deleted.`,
 			return nil
 		},
 	}
-	deleteCmd.Flags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
+	deleteCmd.Flags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
 	deleteCmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompt")
 	return deleteCmd
 }
 
 func Delete(instance config.Installation) error {
-	description := "Deleting Canasta installation '" + instance.Id + "'..."
+	description := "Deleting Canasta installation '" + instance.ID + "'..."
 	stopSpinner := spinner.New(description)
 	defer stopSpinner() // ensure cleanup on error paths
 
@@ -107,14 +107,14 @@ func Delete(instance config.Installation) error {
 	}
 
 	// Remove any scheduled backup crontab entry
-	if removed, err := backupCmd.RemoveSchedule(instance.Id); err != nil {
+	if removed, err := backupCmd.RemoveSchedule(instance.ID); err != nil {
 		logging.Print(fmt.Sprintf("Warning: could not clean up backup schedule: %v\n", err))
 	} else if removed {
 		logging.Print("Removed backup schedule.\n")
 	}
 
 	//Deleting installation details from conf.json
-	if err = config.Delete(instance.Id); err != nil {
+	if err = config.Delete(instance.ID); err != nil {
 		return err
 	}
 

--- a/cmd/devmode/devmode.go
+++ b/cmd/devmode/devmode.go
@@ -32,7 +32,7 @@ mode extracts MediaWiki code for live editing and enables Xdebug for step
 debugging. This is only supported with Docker Compose.`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			instance, err = canasta.CheckCanastaId(instance)
+			instance, err = canasta.CheckCanastaID(instance)
 			if err != nil {
 				return err
 			}
@@ -47,7 +47,7 @@ debugging. This is only supported with Docker Compose.`,
 		},
 	}
 
-	devmodeCmd.PersistentFlags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
+	devmodeCmd.PersistentFlags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
 
 	devmodeCmd.AddCommand(newEnableCmd(&instance, &orch))
 	devmodeCmd.AddCommand(newDisableCmd(&instance, &orch))

--- a/cmd/devmode/disable.go
+++ b/cmd/devmode/disable.go
@@ -22,7 +22,7 @@ re-extracting code.`,
 		Example: `  # Disable dev mode on an installation
   canasta devmode disable -i myinstance`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Printf("Disabling development mode on '%s'...\n", instance.Id)
+			fmt.Printf("Disabling development mode on '%s'...\n", instance.ID)
 
 			// Disable dev mode (restore symlinks to real directories)
 			if err := devmodePkg.DisableDevMode(instance.Path); err != nil {
@@ -31,7 +31,7 @@ re-extracting code.`,
 
 			// Update config registry
 			instance.DevMode = false
-			if instance.Id != "" {
+			if instance.ID != "" {
 				if err := config.Update(*instance); err != nil {
 					logging.Print(fmt.Sprintf("Warning: could not update config: %v\n", err))
 				}

--- a/cmd/devmode/enable.go
+++ b/cmd/devmode/enable.go
@@ -23,7 +23,7 @@ the instance with dev mode compose files. Only supported with Docker Compose.`,
 		Example: `  # Enable dev mode on an installation
   canasta devmode enable -i myinstance`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Printf("Enabling development mode on '%s'...\n", instance.Id)
+			fmt.Printf("Enabling development mode on '%s'...\n", instance.ID)
 
 			// Determine the base image: check .env for CANASTA_IMAGE, fall back to default
 			baseImage := canasta.GetDefaultImage()
@@ -41,7 +41,7 @@ the instance with dev mode compose files. Only supported with Docker Compose.`,
 
 			// Update config registry
 			instance.DevMode = true
-			if instance.Id != "" {
+			if instance.ID != "" {
 				if err := config.Update(*instance); err != nil {
 					logging.Print(fmt.Sprintf("Warning: could not update config: %v\n", err))
 				}

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -37,7 +37,7 @@ Use a .gz extension on the output path to get a gzip-compressed dump.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 
-			instance, err = canasta.CheckCanastaId(instance)
+			instance, err = canasta.CheckCanastaID(instance)
 			if err != nil {
 				return err
 			}
@@ -58,7 +58,7 @@ Use a .gz extension on the output path to get a gzip-compressed dump.`,
 				return err
 			}
 			if !exists {
-				return fmt.Errorf("wiki '%s' does not exist in Canasta instance '%s'", wikiID, instance.Id)
+				return fmt.Errorf("wiki '%s' does not exist in Canasta instance '%s'", wikiID, instance.ID)
 			}
 
 			// Default output path
@@ -81,7 +81,7 @@ Use a .gz extension on the output path to get a gzip-compressed dump.`,
 	}
 	instance.Path = workingDir
 
-	exportCmd.Flags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
+	exportCmd.Flags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
 	exportCmd.Flags().StringVarP(&wikiID, "wiki", "w", "", "ID of the wiki to export")
 	exportCmd.Flags().StringVarP(&outputPath, "file", "f", "", "Output file path (default: <wikiID>.sql)")
 

--- a/cmd/import/import.go
+++ b/cmd/import/import.go
@@ -39,7 +39,7 @@ To create a new wiki from a database dump, use the --database flag with
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 
-			instance, err = canasta.CheckCanastaId(instance)
+			instance, err = canasta.CheckCanastaID(instance)
 			if err != nil {
 				return err
 			}
@@ -60,7 +60,7 @@ To create a new wiki from a database dump, use the --database flag with
 				return err
 			}
 			if !exists {
-				return fmt.Errorf("wiki '%s' does not exist in Canasta instance '%s'", wikiID, instance.Id)
+				return fmt.Errorf("wiki '%s' does not exist in Canasta instance '%s'", wikiID, instance.ID)
 			}
 
 			// Validate database path
@@ -73,7 +73,7 @@ To create a new wiki from a database dump, use the --database flag with
 				return err
 			}
 
-			fmt.Printf("Importing database into wiki '%s' in Canasta instance '%s'...\n", wikiID, instance.Id)
+			fmt.Printf("Importing database into wiki '%s' in Canasta instance '%s'...\n", wikiID, instance.ID)
 			if err := importDatabase(orch, instance, wikiID, databasePath, settingsPath, workingDir); err != nil {
 				return err
 			}
@@ -88,7 +88,7 @@ To create a new wiki from a database dump, use the --database flag with
 	}
 	instance.Path = workingDir
 
-	importCmd.Flags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
+	importCmd.Flags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
 	importCmd.Flags().StringVarP(&wikiID, "wiki", "w", "", "ID of the wiki to import into")
 	importCmd.Flags().StringVarP(&databasePath, "database", "d", "", "Path to SQL dump file (.sql or .sql.gz)")
 	importCmd.Flags().StringVarP(&settingsPath, "wiki-settings", "l", "", "Path to per-wiki Settings.php to replace the existing one")

--- a/cmd/list/list_test.go
+++ b/cmd/list/list_test.go
@@ -34,7 +34,7 @@ func TestList(t *testing.T) {
 	}
 
 	installation := config.Installation{
-		Id:           "test-instance",
+		ID:           "test-instance",
 		Path:         installPath,
 		Orchestrator: "compose",
 	}
@@ -91,7 +91,7 @@ func TestListCleanup(t *testing.T) {
 	installPath := filepath.Join(tmpDir, "stale-installation")
 
 	installation := config.Installation{
-		Id:           "stale-instance",
+		ID:           "stale-instance",
 		Path:         installPath,
 		Orchestrator: "compose",
 	}
@@ -147,7 +147,7 @@ func TestListNotFound(t *testing.T) {
 	installPath := filepath.Join(tmpDir, "missing-installation")
 
 	installation := config.Installation{
-		Id:           "missing-instance",
+		ID:           "missing-instance",
 		Path:         installPath,
 		Orchestrator: "compose",
 	}

--- a/cmd/maintenance/exec.go
+++ b/cmd/maintenance/exec.go
@@ -38,7 +38,7 @@ The default service is "web" (the MediaWiki container).`,
   canasta maintenance exec -i myinstance -- php -v`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			*instance, err = canasta.CheckCanastaId(*instance)
+			*instance, err = canasta.CheckCanastaID(*instance)
 			return err
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/maintenance/extension.go
+++ b/cmd/maintenance/extension.go
@@ -54,7 +54,7 @@ Use --wiki to target a specific wiki.`,
 		Args: cobra.ArbitraryArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			*instance, err = canasta.CheckCanastaId(*instance)
+			*instance, err = canasta.CheckCanastaID(*instance)
 			return err
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -181,7 +181,7 @@ func listExtensionScriptsWith(orch orchestrators.Orchestrator, inst config.Insta
 		}
 	}
 	if !loaded {
-		return fmt.Errorf("Extension %q is not loaded for the target wiki(s)", extName)
+		return fmt.Errorf("extension %q is not loaded for the target wiki(s)", extName)
 	}
 
 	// Check that the extension has a maintenance directory
@@ -245,7 +245,7 @@ func runExtensionScriptWith(orch orchestrators.Orchestrator, inst config.Install
 		}
 	}
 	if !loaded {
-		return fmt.Errorf("Extension %q is not loaded for wiki %q", extName, checkWiki)
+		return fmt.Errorf("extension %q is not loaded for wiki %q", extName, checkWiki)
 	}
 
 	// Determine which path the extension is at

--- a/cmd/maintenance/maintenance.go
+++ b/cmd/maintenance/maintenance.go
@@ -34,7 +34,7 @@ arbitrary core maintenance scripts, or run extension-specific maintenance script
 	maintenanceCmd.AddCommand(newExtensionCmd(&instance, &wiki))
 	maintenanceCmd.AddCommand(newExecCmd(&instance))
 
-	maintenanceCmd.PersistentFlags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
+	maintenanceCmd.PersistentFlags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
 	maintenanceCmd.PersistentFlags().StringVarP(&wiki, "wiki", "w", "", "Wiki ID to run maintenance on (default: all wikis)")
 	return maintenanceCmd
 }

--- a/cmd/maintenance/maintenanceScript.go
+++ b/cmd/maintenance/maintenanceScript.go
@@ -37,7 +37,7 @@ Use --wiki to target a specific wiki in a farm.`,
 		Args: cobra.RangeArgs(0, 1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			*instance, err = canasta.CheckCanastaId(*instance)
+			*instance, err = canasta.CheckCanastaID(*instance)
 			return err
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/maintenance/maintenanceUpdate.go
+++ b/cmd/maintenance/maintenanceUpdate.go
@@ -36,7 +36,7 @@ specific wiki.`,
   canasta maintenance update -i myinstance --skip-jobs --skip-smw`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			*instance, err = canasta.CheckCanastaId(*instance)
+			*instance, err = canasta.CheckCanastaID(*instance)
 			return err
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -48,12 +48,12 @@ for confirmation before any data is deleted.`,
 				return fmt.Errorf("--wiki flag is required")
 			}
 
-			instance, err = canasta.CheckCanastaId(instance)
+			instance, err = canasta.CheckCanastaID(instance)
 			if err != nil {
 				return err
 			}
 
-			fmt.Printf("Removing wiki '%s' from Canasta instance '%s'...\n", wikiID, instance.Id)
+			fmt.Printf("Removing wiki '%s' from Canasta instance '%s'...\n", wikiID, instance.ID)
 			if err := RemoveWiki(instance, wikiID, yes); err != nil {
 				return err
 			}
@@ -63,7 +63,7 @@ for confirmation before any data is deleted.`,
 	}
 
 	addCmd.Flags().StringVarP(&wikiID, "wiki", "w", "", "ID of the wiki")
-	addCmd.Flags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
+	addCmd.Flags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
 	addCmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompt")
 	return addCmd
 }
@@ -96,12 +96,12 @@ func RemoveWiki(instance config.Installation, wikiID string, yes bool) error {
 		return err
 	}
 	if !exists {
-		return fmt.Errorf("A wiki with the ID '%s' does not exist", wikiID)
+		return fmt.Errorf("a wiki with the ID '%s' does not exist", wikiID)
 	}
 
 	if !yes {
 		reader := bufio.NewReader(os.Stdin)
-		fmt.Print("This will delete the wiki " + wikiID + " in the Canasta instance " + instance.Id + " and the corresponding database. Continue? [y/N] ")
+		fmt.Print("This will delete the wiki " + wikiID + " in the Canasta instance " + instance.ID + " and the corresponding database. Continue? [y/N] ")
 		text, _ := reader.ReadString('\n')
 		text = strings.ToLower(strings.TrimSpace(text))
 
@@ -159,7 +159,7 @@ func RemoveWiki(instance config.Installation, wikiID string, yes bool) error {
 		return err
 	}
 
-	fmt.Println("Successfully removed wiki " + wikiID + " from Canasta instance " + instance.Id + ".")
+	fmt.Println("Successfully removed wiki " + wikiID + " from Canasta instance " + instance.ID + ".")
 
 	return nil
 }

--- a/cmd/restart/restart.go
+++ b/cmd/restart/restart.go
@@ -34,11 +34,11 @@ change the development mode setting.`,
 			if len(args) > 0 {
 				return fmt.Errorf("unknown argument %q; use --id to specify the instance ID (e.g. canasta restart --id %s)", args[0], args[0])
 			}
-			resolvedInstance, err := canasta.CheckCanastaId(instance)
+			resolvedInstance, err := canasta.CheckCanastaID(instance)
 			if err != nil {
 				return err
 			}
-			fmt.Println("Restarting Canasta installation '" + resolvedInstance.Id + "'...")
+			fmt.Println("Restarting Canasta installation '" + resolvedInstance.ID + "'...")
 			if err = Restart(resolvedInstance); err != nil {
 				return err
 			}
@@ -46,7 +46,7 @@ change the development mode setting.`,
 			return nil
 		},
 	}
-	restartCmd.Flags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
+	restartCmd.Flags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
 	return restartCmd
 }
 

--- a/cmd/sitemap/sitemap.go
+++ b/cmd/sitemap/sitemap.go
@@ -32,7 +32,7 @@ Use "canasta sitemap generate" to create sitemaps and "canasta sitemap remove"
 to delete them.`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			instance, err = canasta.CheckCanastaId(instance)
+			instance, err = canasta.CheckCanastaID(instance)
 			if err != nil {
 				return err
 			}
@@ -47,7 +47,7 @@ to delete them.`,
 	sitemapCmd.AddCommand(newGenerateCmd(&instance, &orch))
 	sitemapCmd.AddCommand(newRemoveCmd(&instance, &orch))
 
-	sitemapCmd.PersistentFlags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
+	sitemapCmd.PersistentFlags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
 
 	return sitemapCmd
 }

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -33,11 +33,11 @@ development mode setting.`,
 			if len(args) > 0 {
 				return fmt.Errorf("unknown argument %q; use --id to specify the instance ID (e.g. canasta start --id %s)", args[0], args[0])
 			}
-			resolvedInstance, err := canasta.CheckCanastaId(instance)
+			resolvedInstance, err := canasta.CheckCanastaID(instance)
 			if err != nil {
 				return err
 			}
-			fmt.Println("Starting Canasta installation '" + resolvedInstance.Id + "'...")
+			fmt.Println("Starting Canasta installation '" + resolvedInstance.ID + "'...")
 			if err := Start(resolvedInstance); err != nil {
 				return err
 			}
@@ -45,7 +45,7 @@ development mode setting.`,
 			return nil
 		},
 	}
-	startCmd.Flags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
+	startCmd.Flags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
 	return startCmd
 }
 

--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -31,11 +31,11 @@ are stopped gracefully, preserving all data in Docker volumes.`,
 			if len(args) > 0 {
 				return fmt.Errorf("unknown argument %q; use --id to specify the instance ID (e.g. canasta stop --id %s)", args[0], args[0])
 			}
-			resolvedInstance, err := canasta.CheckCanastaId(instance)
+			resolvedInstance, err := canasta.CheckCanastaID(instance)
 			if err != nil {
 				return err
 			}
-			fmt.Println("Stopping Canasta installation '" + resolvedInstance.Id + "'...")
+			fmt.Println("Stopping Canasta installation '" + resolvedInstance.ID + "'...")
 			if err = Stop(resolvedInstance); err != nil {
 				return err
 			}
@@ -43,7 +43,7 @@ are stopped gracefully, preserving all data in Docker volumes.`,
 			return nil
 		},
 	}
-	stopCmd.Flags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
+	stopCmd.Flags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
 	return stopCmd
 }
 

--- a/cmd/upgrade/mysql_to_mariadb.go
+++ b/cmd/upgrade/mysql_to_mariadb.go
@@ -30,7 +30,7 @@ func composeVolumeName(installPath, volume string) string {
 //nolint:unparam
 func detectMySQL8Data(installPath string) (bool, error) {
 	volName := composeVolumeName(installPath, "mysql-data-volume")
-	err, _ := execute.Run("", "docker", "run", "--rm",
+	_, err := execute.Run("", "docker", "run", "--rm",
 		"-v", volName+":/data",
 		"alpine", "test", "-f", "/data/mysql.ibd")
 	return err == nil, nil
@@ -58,7 +58,7 @@ func dumpMySQL8Data(installPath string) (string, error) {
 
 	// Start a temporary MySQL 8.0 container with the existing data volume
 	fmt.Println("  Starting temporary MySQL 8.0 container for dump...")
-	err, output := execute.Run("", "docker", "run", "-d",
+	output, err := execute.Run("", "docker", "run", "-d",
 		"--name", containerName,
 		"-v", volName+":/var/lib/mysql",
 		"-e", "MYSQL_ROOT_PASSWORD="+password,
@@ -74,7 +74,7 @@ func dumpMySQL8Data(installPath string) (string, error) {
 
 	// Wait for MySQL to be ready
 	fmt.Println("  Waiting for MySQL 8.0 to be ready...")
-	err, output = execute.Run("", "docker", "exec", containerName,
+	output, err = execute.Run("", "docker", "exec", containerName,
 		"mysqladmin", "ping", "-h", "localhost",
 		"--user=root", "--password="+password,
 		"--wait=60")
@@ -84,7 +84,7 @@ func dumpMySQL8Data(installPath string) (string, error) {
 
 	// List user databases (exclude system databases)
 	fmt.Println("  Listing user databases...")
-	err, output = execute.Run("", "docker", "exec", containerName,
+	output, err = execute.Run("", "docker", "exec", containerName,
 		"mysql", "--user=root", "--password="+password,
 		"--skip-column-names", "--batch",
 		"-e", "SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT IN ('mysql','information_schema','performance_schema','sys')")
@@ -113,7 +113,7 @@ func dumpMySQL8Data(installPath string) (string, error) {
 	// Dump all user databases into a single file inside the container
 	dumpCmd := fmt.Sprintf("mysqldump --user=root --password=%s --databases %s --single-transaction --routines --triggers --events > /tmp/dump.sql",
 		shellEscape(password), strings.Join(databases, " "))
-	err, output = execute.Run("", "docker", "exec", containerName,
+	output, err = execute.Run("", "docker", "exec", containerName,
 		"bash", "-c", dumpCmd)
 	if err != nil {
 		return "", fmt.Errorf("mysqldump failed: %s", output)
@@ -126,7 +126,7 @@ func dumpMySQL8Data(installPath string) (string, error) {
 	}
 	tmpFile.Close()
 
-	err, output = execute.Run("", "docker", "cp",
+	output, err = execute.Run("", "docker", "cp",
 		containerName+":/tmp/dump.sql", tmpFile.Name())
 	if err != nil {
 		os.Remove(tmpFile.Name())
@@ -142,7 +142,7 @@ func dumpMySQL8Data(installPath string) (string, error) {
 func clearMySQLDataVolume(installPath string) error {
 	volName := composeVolumeName(installPath, "mysql-data-volume")
 	fmt.Println("  Clearing MySQL data volume for fresh MariaDB initialization...")
-	err, output := execute.Run("", "docker", "run", "--rm",
+	output, err := execute.Run("", "docker", "run", "--rm",
 		"-v", volName+":/data",
 		"alpine", "sh", "-c", "rm -rf /data/*")
 	if err != nil {

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -108,7 +108,7 @@ func Upgrade(instance config.Installation, dryRun bool) error {
 	var err error
 
 	// Check installation existence
-	instance, err = canasta.CheckCanastaId(instance)
+	instance, err = canasta.CheckCanastaID(instance)
 	if err != nil {
 		return err
 	}

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -24,7 +24,7 @@ import (
 )
 
 type CanastaVariables struct {
-	Id             string
+	ID             string
 	AdminPassword  string
 	AdminName      string
 	RootDBPassword string
@@ -207,7 +207,7 @@ func UpdateEnvFile(customEnvPath, installPath, workingDir, rootDBpass, wikiDBpas
 
 func CopyYaml(yamlPath, installPath string) error {
 	logging.Print(fmt.Sprintf("Copying %s to %s/config/wikis.yaml\n", yamlPath, installPath))
-	err, output := execute.Run("", "cp", yamlPath, filepath.Join(installPath, "config", "wikis.yaml"))
+	output, err := execute.Run("", "cp", yamlPath, filepath.Join(installPath, "config", "wikis.yaml"))
 	if err != nil {
 		return fmt.Errorf("failed to copy wikis.yaml from %s: %s", yamlPath, output)
 	}
@@ -259,9 +259,9 @@ func CopySettings(installPath string) error {
 }
 
 func CopySetting(installPath, id string) error {
-	normalizedId := NormalizeWikiID(id)
+	normalizedID := NormalizeWikiID(id)
 
-	dirPath := filepath.Join(installPath, "config", "settings", "wikis", normalizedId)
+	dirPath := filepath.Join(installPath, "config", "settings", "wikis", normalizedID)
 
 	// Create the directory if it doesn't exist
 	if err := os.MkdirAll(dirPath, permissions.DirectoryPermission); err != nil {
@@ -300,7 +300,7 @@ func CopyWikiSettingFile(installPath, wikiID, settingsFilePath, workingDir strin
 	// Copy the provided file as Settings.php
 	destPath := filepath.Join(dirPath, "Settings.php")
 	logging.Print(fmt.Sprintf("Copying %s to %s\n", settingsFilePath, destPath))
-	err, output := execute.Run("", "cp", settingsFilePath, destPath)
+	output, err := execute.Run("", "cp", settingsFilePath, destPath)
 	if err != nil {
 		return fmt.Errorf("failed to copy wiki settings file to %s: %s", destPath, output)
 	}
@@ -328,7 +328,7 @@ func CopyGlobalSettingFile(installPath, settingsFilePath, workingDir string) err
 	// Copy the provided file preserving its name
 	destPath := filepath.Join(dirPath, filename)
 	logging.Print(fmt.Sprintf("Copying %s to %s\n", settingsFilePath, destPath))
-	err, output := execute.Run("", "cp", settingsFilePath, destPath)
+	output, err := execute.Run("", "cp", settingsFilePath, destPath)
 	if err != nil {
 		return fmt.Errorf("failed to copy global settings file to %s: %s", destPath, output)
 	}
@@ -614,7 +614,7 @@ func CopyComposerFile(installPath, sourceFilename, workingDir string) error {
 	}
 	destPath := filepath.Join(installPath, "config", "composer.local.json")
 	logging.Print(fmt.Sprintf("Copying %s to %s\n", sourceFilename, destPath))
-	err, output := execute.Run("", "cp", sourceFilename, destPath)
+	output, err := execute.Run("", "cp", sourceFilename, destPath)
 	if err != nil {
 		return fmt.Errorf("failed to copy composer file from %s: %s", sourceFilename, output)
 	}
@@ -805,17 +805,17 @@ func GetEnvVariable(envPath string) (map[string]string, error) {
 }
 
 // Checking Installation existence
-func CheckCanastaId(instance config.Installation) (config.Installation, error) {
+func CheckCanastaID(instance config.Installation) (config.Installation, error) {
 	var err error
-	if instance.Id != "" {
-		if instance, err = config.GetDetails(instance.Id); err != nil {
+	if instance.ID != "" {
+		if instance, err = config.GetDetails(instance.ID); err != nil {
 			return instance, err
 		}
 	} else {
-		if instance.Id, err = config.GetCanastaID(instance.Path); err != nil {
+		if instance.ID, err = config.GetCanastaID(instance.Path); err != nil {
 			return instance, err
 		}
-		if instance, err = config.GetDetails(instance.Id); err != nil {
+		if instance, err = config.GetDetails(instance.ID); err != nil {
 			return instance, err
 		}
 	}
@@ -826,7 +826,7 @@ func CheckCanastaId(instance config.Installation) (config.Installation, error) {
 func removeWikiDir(installPath, subdir, id string) error {
 	dirPath := filepath.Join(installPath, subdir, id)
 	if _, err := os.Stat(dirPath); err == nil {
-		err, output := execute.Run("", "rm", "-rf", dirPath)
+		output, err := execute.Run("", "rm", "-rf", dirPath)
 		if err != nil {
 			return fmt.Errorf("failed to remove %s for wiki %q: %s", subdir, id, output)
 		}

--- a/internal/canasta/canasta_test.go
+++ b/internal/canasta/canasta_test.go
@@ -196,7 +196,7 @@ func TestDeleteEnvVariable(t *testing.T) {
 
 func TestGenerateAdminAndDBPasswords(t *testing.T) {
 	info := CanastaVariables{
-		Id:        "test",
+		ID:        "test",
 		AdminName: "admin",
 	}
 
@@ -256,7 +256,7 @@ func TestGenerateAdminAndDBPasswords(t *testing.T) {
 
 func TestGeneratePasswordsPreserveExisting(t *testing.T) {
 	info := CanastaVariables{
-		Id:             "test",
+		ID:             "test",
 		AdminName:      "admin",
 		AdminPassword:  "myadminpass",
 		RootDBPassword: "myrootpass",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,7 +14,7 @@ import (
 )
 
 type Installation struct {
-	Id             string `json:"id"`
+	ID             string `json:"id"`
 	Path           string `json:"path"`
 	Orchestrator   string `json:"orchestrator"`
 	DevMode        bool   `json:"devMode,omitempty"`
@@ -25,7 +25,7 @@ type Installation struct {
 }
 
 type Orchestrator struct {
-	Id, Path string
+	ID, Path string
 }
 
 type Canasta struct {
@@ -108,7 +108,7 @@ func Exists(canastaID string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return existingInstallations.Installations[canastaID].Id != "", nil
+	return existingInstallations.Installations[canastaID].ID != "", nil
 }
 
 func OrchestratorExists(orchestrator string) (bool, error) {
@@ -149,7 +149,7 @@ func ListAll() error {
 
 		if pathMissing {
 			fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\n",
-				installation.Id,
+				installation.ID,
 				"N/A",
 				"N/A",
 				"N/A",
@@ -161,7 +161,7 @@ func ListAll() error {
 		if _, err := os.Stat(filepath.Join(installation.Path, "config", "wikis.yaml")); os.IsNotExist(err) {
 			// File does not exist, print only installation info
 			fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\n",
-				installation.Id,
+				installation.ID,
 				"N/A", // Placeholder
 				"N/A", // Placeholder
 				"N/A", // Placeholder
@@ -172,14 +172,14 @@ func ListAll() error {
 
 		ids, serverNames, paths, err := farmsettings.ReadWikisYaml(filepath.Join(installation.Path, "config", "wikis.yaml"))
 		if err != nil {
-			fmt.Printf("Error reading wikis.yaml for installation ID '%s': %s\n", installation.Id, err)
+			fmt.Printf("Error reading wikis.yaml for installation ID '%s': %s\n", installation.ID, err)
 			continue
 		}
 
 		for i := range ids {
 			if i == 0 {
 				fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\n",
-					installation.Id,
+					installation.ID,
 					ids[i],
 					serverNames[i],
 					paths[i],
@@ -223,7 +223,7 @@ func GetDetails(canastaID string) (Installation, error) {
 	if exists {
 		return existingInstallations.Installations[canastaID], nil
 	}
-	return Installation{}, fmt.Errorf("Canasta installation with the ID doesn't exist")
+	return Installation{}, fmt.Errorf("canasta installation with the ID doesn't exist")
 }
 
 func GetCanastaID(installPath string) (string, error) {
@@ -235,7 +235,7 @@ func GetCanastaID(installPath string) (string, error) {
 	for {
 		for _, inst := range existingInstallations.Installations {
 			if inst.Path == dir {
-				return inst.Id, nil
+				return inst.ID, nil
 			}
 		}
 		parent := filepath.Dir(dir)
@@ -244,21 +244,21 @@ func GetCanastaID(installPath string) (string, error) {
 		}
 		dir = parent
 	}
-	return "", fmt.Errorf("No Canasta installations exist at %s", installPath)
+	return "", fmt.Errorf("no Canasta installations exist at %s", installPath)
 }
 
 func Add(details Installation) error {
 	if err := ensureInitialized(); err != nil {
 		return err
 	}
-	exists, err := Exists(details.Id)
+	exists, err := Exists(details.ID)
 	if err != nil {
 		return err
 	}
 	if exists {
-		return fmt.Errorf("Canasta ID is already used for another installation")
+		return fmt.Errorf("canasta ID is already used for another installation")
 	}
-	existingInstallations.Installations[details.Id] = details
+	existingInstallations.Installations[details.ID] = details
 	return write(existingInstallations)
 }
 
@@ -274,10 +274,10 @@ func AddOrchestrator(details Orchestrator) error {
 		"kubernetes": true,
 		"k8s":        true,
 	}
-	if !supportedOrchestrators[details.Id] {
-		return fmt.Errorf("orchestrator %s is not supported", details.Id)
+	if !supportedOrchestrators[details.ID] {
+		return fmt.Errorf("orchestrator %s is not supported", details.ID)
 	}
-	existingInstallations.Orchestrators[details.Id] = details
+	existingInstallations.Orchestrators[details.ID] = details
 	err := write(existingInstallations)
 	return err
 }
@@ -305,7 +305,7 @@ func Delete(canastaID string) error {
 		return err
 	}
 	if !exists {
-		return fmt.Errorf("Canasta installation with the ID doesn't exist")
+		return fmt.Errorf("canasta installation with the ID doesn't exist")
 	}
 	delete(existingInstallations.Installations, canastaID)
 	return write(existingInstallations)
@@ -316,14 +316,14 @@ func Update(details Installation) error {
 	if err := ensureInitialized(); err != nil {
 		return err
 	}
-	exists, err := Exists(details.Id)
+	exists, err := Exists(details.ID)
 	if err != nil {
 		return err
 	}
 	if !exists {
-		return fmt.Errorf("Canasta installation with ID '%s' doesn't exist", details.Id)
+		return fmt.Errorf("canasta installation with ID '%s' doesn't exist", details.ID)
 	}
-	existingInstallations.Installations[details.Id] = details
+	existingInstallations.Installations[details.ID] = details
 	return write(existingInstallations)
 }
 
@@ -358,7 +358,7 @@ func GetConfigDir() (string, error) {
 		// Checks if this is running as root
 		currentUser, err := user.Current()
 		if err != nil {
-			return "", fmt.Errorf("Unable to get the current user: %s", err)
+			return "", fmt.Errorf("unable to get the current user: %s", err)
 		}
 
 		if currentUser.Username == "root" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,7 +18,7 @@ func TestAddAndGetDetails(t *testing.T) {
 	setupTestDir(t)
 
 	inst := Installation{
-		Id:           "test1",
+		ID:           "test1",
 		Path:         "/tmp/test1",
 		Orchestrator: "compose",
 	}
@@ -31,7 +31,7 @@ func TestAddAndGetDetails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetDetails() error = %v", err)
 	}
-	if got.Id != "test1" || got.Path != "/tmp/test1" || got.Orchestrator != "compose" {
+	if got.ID != "test1" || got.Path != "/tmp/test1" || got.Orchestrator != "compose" {
 		t.Errorf("GetDetails() = %+v, want %+v", got, inst)
 	}
 }
@@ -39,7 +39,7 @@ func TestAddAndGetDetails(t *testing.T) {
 func TestExists(t *testing.T) {
 	setupTestDir(t)
 
-	inst := Installation{Id: "exists1", Path: "/tmp/exists1", Orchestrator: "compose"}
+	inst := Installation{ID: "exists1", Path: "/tmp/exists1", Orchestrator: "compose"}
 	if err := Add(inst); err != nil {
 		t.Fatalf("Add() error = %v", err)
 	}
@@ -64,7 +64,7 @@ func TestExists(t *testing.T) {
 func TestDelete(t *testing.T) {
 	setupTestDir(t)
 
-	inst := Installation{Id: "del1", Path: "/tmp/del1", Orchestrator: "compose"}
+	inst := Installation{ID: "del1", Path: "/tmp/del1", Orchestrator: "compose"}
 	if err := Add(inst); err != nil {
 		t.Fatalf("Add() error = %v", err)
 	}
@@ -85,7 +85,7 @@ func TestDelete(t *testing.T) {
 func TestUpdate(t *testing.T) {
 	setupTestDir(t)
 
-	inst := Installation{Id: "upd1", Path: "/tmp/upd1", Orchestrator: "compose"}
+	inst := Installation{ID: "upd1", Path: "/tmp/upd1", Orchestrator: "compose"}
 	if err := Add(inst); err != nil {
 		t.Fatalf("Add() error = %v", err)
 	}
@@ -107,7 +107,7 @@ func TestUpdate(t *testing.T) {
 func TestDuplicateAdd(t *testing.T) {
 	setupTestDir(t)
 
-	inst := Installation{Id: "dup1", Path: "/tmp/dup1", Orchestrator: "compose"}
+	inst := Installation{ID: "dup1", Path: "/tmp/dup1", Orchestrator: "compose"}
 	if err := Add(inst); err != nil {
 		t.Fatalf("Add() error = %v", err)
 	}
@@ -130,8 +130,8 @@ func TestDeleteNonexistent(t *testing.T) {
 func TestGetAll(t *testing.T) {
 	setupTestDir(t)
 
-	inst1 := Installation{Id: "all1", Path: "/tmp/all1", Orchestrator: "compose"}
-	inst2 := Installation{Id: "all2", Path: "/tmp/all2", Orchestrator: "compose"}
+	inst1 := Installation{ID: "all1", Path: "/tmp/all1", Orchestrator: "compose"}
+	inst2 := Installation{ID: "all2", Path: "/tmp/all2", Orchestrator: "compose"}
 	if err := Add(inst1); err != nil {
 		t.Fatalf("Add() error = %v", err)
 	}
@@ -151,7 +151,7 @@ func TestGetAll(t *testing.T) {
 func TestGetCanastaID(t *testing.T) {
 	setupTestDir(t)
 
-	inst := Installation{Id: "pathtest", Path: "/tmp/pathtest", Orchestrator: "compose"}
+	inst := Installation{ID: "pathtest", Path: "/tmp/pathtest", Orchestrator: "compose"}
 	if err := Add(inst); err != nil {
 		t.Fatalf("Add() error = %v", err)
 	}
@@ -173,7 +173,7 @@ func TestGetCanastaID(t *testing.T) {
 func TestGetCanastaIDFromSubdirectory(t *testing.T) {
 	setupTestDir(t)
 
-	inst := Installation{Id: "subdir-test", Path: "/srv/canasta/my-wiki", Orchestrator: "compose"}
+	inst := Installation{ID: "subdir-test", Path: "/srv/canasta/my-wiki", Orchestrator: "compose"}
 	if err := Add(inst); err != nil {
 		t.Fatalf("Add() error = %v", err)
 	}
@@ -220,7 +220,7 @@ func TestAddOrchestratorSupported(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			setupTestDir(t)
-			err := AddOrchestrator(Orchestrator{Id: tt.id, Path: "/usr/bin/test"})
+			err := AddOrchestrator(Orchestrator{ID: tt.id, Path: "/usr/bin/test"})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("AddOrchestrator(%q) error = %v, wantErr %v", tt.id, err, tt.wantErr)
 			}
@@ -235,7 +235,7 @@ func TestBuildFromRoundTrip(t *testing.T) {
 	dir := setupTestDir(t)
 
 	inst := Installation{
-		Id:           "bf1",
+		ID:           "bf1",
 		Path:         "/tmp/bf1",
 		Orchestrator: "compose",
 		BuildFrom:    "/home/user/workspace",
@@ -266,7 +266,7 @@ func TestBuildFromOmittedWhenEmpty(t *testing.T) {
 	dir := setupTestDir(t)
 
 	inst := Installation{
-		Id:           "nobf1",
+		ID:           "nobf1",
 		Path:         "/tmp/nobf1",
 		Orchestrator: "compose",
 	}

--- a/internal/devmode/devmode.go
+++ b/internal/devmode/devmode.go
@@ -91,7 +91,7 @@ func ExtractMediaWikiCode(installPath, baseImage string) error {
 	// Local images (e.g., "canasta:local") don't need pulling
 	if strings.Contains(baseImage, "/") {
 		logging.Print(fmt.Sprintf("Pulling image %s...\n", baseImage))
-		if err, output := execute.Run("", "docker", "pull", baseImage); err != nil {
+		if output, err := execute.Run("", "docker", "pull", baseImage); err != nil {
 			return fmt.Errorf("failed to pull image: %s", output)
 		}
 	} else {
@@ -111,13 +111,13 @@ func ExtractMediaWikiCode(installPath, baseImage string) error {
 	_, _ = execute.Run("", "docker", "rm", "-f", containerName)
 
 	logging.Print("Starting temporary container for code extraction...\n")
-	if err, output := execute.Run("", "docker", "run", "-d", "--name", containerName, baseImage, "sleep", "infinity"); err != nil {
+	if output, err := execute.Run("", "docker", "run", "-d", "--name", containerName, baseImage, "sleep", "infinity"); err != nil {
 		return fmt.Errorf("failed to start temporary container: %s", output)
 	}
 
 	// Run the symlinks script to create extensions/ and skins/ symlinks
 	logging.Print("Creating extension and skin symlinks...\n")
-	if err, output := execute.Run("", "docker", "exec", containerName, "/create-symlinks.sh"); err != nil {
+	if output, err := execute.Run("", "docker", "exec", containerName, "/create-symlinks.sh"); err != nil {
 		_, _ = execute.Run("", "docker", "rm", "-f", containerName)
 		return fmt.Errorf("failed to create symlinks: %s", output)
 	}
@@ -136,7 +136,7 @@ func ExtractMediaWikiCode(installPath, baseImage string) error {
 
 	// Remove the temporary container
 	logging.Print("Removing temporary container...\n")
-	if err, output := execute.Run("", "docker", "rm", "-f", containerName); err != nil {
+	if output, err := execute.Run("", "docker", "rm", "-f", containerName); err != nil {
 		return fmt.Errorf("failed to remove temporary container: %s", output)
 	}
 
@@ -200,7 +200,7 @@ func consolidateUserDir(installPath, codeDir, dirName, userDirName string) error
 			}
 
 			// Copy directory recursively using cp -r
-			if err, output := execute.Run("", "cp", "-r", srcPath, dstPath); err != nil {
+			if output, err := execute.Run("", "cp", "-r", srcPath, dstPath); err != nil {
 				return fmt.Errorf("failed to copy %s: %s", entry.Name(), output)
 			}
 		}
@@ -326,8 +326,8 @@ func WriteIDEConfigs(installPath string) error {
 	if err := os.MkdirAll(vscodeDir, permissions.DirectoryPermission); err != nil {
 		return fmt.Errorf("failed to create .vscode directory: %w", err)
 	}
-	launchJsonPath := filepath.Join(vscodeDir, "launch.json")
-	if err := os.WriteFile(launchJsonPath, []byte(vscodeLaunchContent), permissions.FilePermission); err != nil {
+	launchJSONPath := filepath.Join(vscodeDir, "launch.json")
+	if err := os.WriteFile(launchJSONPath, []byte(vscodeLaunchContent), permissions.FilePermission); err != nil {
 		return fmt.Errorf("failed to create VSCode launch.json: %w", err)
 	}
 
@@ -340,10 +340,10 @@ func WriteIDEConfigs(installPath string) error {
 	if err := os.MkdirAll(runConfDir, permissions.DirectoryPermission); err != nil {
 		return fmt.Errorf("failed to create .idea/runConfigurations directory: %w", err)
 	}
-	phpXmlContent := strings.Replace(phpstormServerConfig, `host="localhost"`, fmt.Sprintf(`host="%s"`, host), 1)
-	phpXmlContent = strings.Replace(phpXmlContent, `port="80"`, fmt.Sprintf(`port="%s"`, port), 1)
-	phpXmlPath := filepath.Join(ideaDir, "php.xml")
-	if err := os.WriteFile(phpXmlPath, []byte(phpXmlContent), permissions.FilePermission); err != nil {
+	phpXMLContent := strings.Replace(phpstormServerConfig, `host="localhost"`, fmt.Sprintf(`host="%s"`, host), 1)
+	phpXMLContent = strings.Replace(phpXMLContent, `port="80"`, fmt.Sprintf(`port="%s"`, port), 1)
+	phpXMLPath := filepath.Join(ideaDir, "php.xml")
+	if err := os.WriteFile(phpXMLPath, []byte(phpXMLContent), permissions.FilePermission); err != nil {
 		return fmt.Errorf("failed to create PHPStorm php.xml: %w", err)
 	}
 
@@ -471,7 +471,7 @@ func restoreUserDir(installPath, dirName, userDirName string) error {
 			dstPath := filepath.Join(symlinkPath, entry.Name())
 
 			logging.Print(fmt.Sprintf("  Copying %s to %s/...\n", entry.Name(), dirName))
-			if err, output := execute.Run("", "cp", "-r", srcPath, dstPath); err != nil {
+			if output, err := execute.Run("", "cp", "-r", srcPath, dstPath); err != nil {
 				return fmt.Errorf("failed to copy %s: %s", entry.Name(), output)
 			}
 		}

--- a/internal/execute/execute.go
+++ b/internal/execute/execute.go
@@ -24,7 +24,7 @@ func (w *writerWithPrint) String() string {
 }
 
 // RunFunc is the signature for the command execution function.
-type RunFunc func(path, command string, cmdArgs ...string) (error, string)
+type RunFunc func(path, command string, cmdArgs ...string) (string, error)
 
 // Run is the package-level function variable for executing commands.
 // Tests can replace this with a mock implementation.
@@ -33,7 +33,7 @@ var Run RunFunc = defaultRun
 // ResetForTesting restores Run to the default implementation.
 func ResetForTesting() { Run = defaultRun }
 
-func defaultRun(path, command string, cmdArgs ...string) (error, string) {
+func defaultRun(path, command string, cmdArgs ...string) (string, error) {
 	outWriter := &writerWithPrint{}
 	errWriter := &writerWithPrint{}
 
@@ -54,11 +54,11 @@ func defaultRun(path, command string, cmdArgs ...string) (error, string) {
 	}
 
 	if err := cmd.Start(); err != nil {
-		return err, ""
+		return "", err
 	}
 
 	err := cmd.Wait()
 	output := outWriter.String() + errWriter.String()
 
-	return err, output
+	return output, err
 }

--- a/internal/execute/execute_test.go
+++ b/internal/execute/execute_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestRunExecutesDirect(t *testing.T) {
 	// Run a simple command and check output
-	err, output := Run("", "echo", "hello", "world")
+	output, err := Run("", "echo", "hello", "world")
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
@@ -19,7 +19,7 @@ func TestRunExecutesDirect(t *testing.T) {
 func TestRunNoShellInterpretation(t *testing.T) {
 	// Verify that shell metacharacters are NOT interpreted.
 	// If Run still used bash -c, $HOME would be expanded by the shell.
-	err, output := Run("", "echo", "$HOME")
+	output, err := Run("", "echo", "$HOME")
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
@@ -30,7 +30,7 @@ func TestRunNoShellInterpretation(t *testing.T) {
 
 func TestRunWithPath(t *testing.T) {
 	dir := t.TempDir()
-	err, output := Run(dir, "pwd")
+	output, err := Run(dir, "pwd")
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
@@ -40,7 +40,7 @@ func TestRunWithPath(t *testing.T) {
 }
 
 func TestRunCommandNotFound(t *testing.T) {
-	err, _ := Run("", "nonexistent-command-12345")
+	_, err := Run("", "nonexistent-command-12345")
 	if err == nil {
 		t.Error("Run() expected error for nonexistent command, got nil")
 	}

--- a/internal/extensionsskins/commands.go
+++ b/internal/extensionsskins/commands.go
@@ -37,7 +37,7 @@ to list all available %s, and enable or disable them globally or for
 a specific wiki in a farm.`, constants.Plural, constants.Plural),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			instance, err = canasta.CheckCanastaId(instance)
+			instance, err = canasta.CheckCanastaID(instance)
 			if err != nil {
 				return err
 			}
@@ -46,7 +46,7 @@ a specific wiki in a farm.`, constants.Plural, constants.Plural),
 		},
 	}
 
-	cmd.PersistentFlags().StringVarP(&instance.Id, "id", "i", "", "Canasta instance ID")
+	cmd.PersistentFlags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
 	cmd.PersistentFlags().StringVarP(&wiki, "wiki", "w", "", "ID of the specific wiki within the Canasta farm")
 
 	cmd.AddCommand(newListCmd(&instance, &orch, &wiki, &constants))

--- a/internal/farmsettings/farmsettings.go
+++ b/internal/farmsettings/farmsettings.go
@@ -33,7 +33,7 @@ func ValidateWikiID(wikiID string) error {
 
 	// Check if wikiID contains a hyphen (-)
 	if strings.Contains(wikiID, "-") {
-		return fmt.Errorf("The character '-' is not allowed in wikiID")
+		return fmt.Errorf("the character '-' is not allowed in wikiID")
 	}
 
 	// Check if wikiID is one of the reserved names
@@ -165,8 +165,8 @@ func WikiIDExists(installPath, wikiID string) (bool, error) {
 	return false, nil
 }
 
-// WikiUrlExists checks if a wiki with the given URL (domain/path combo) exists in the installation
-func WikiUrlExists(installPath, domain, wikiPath string) (bool, error) {
+// WikiURLExists checks if a wiki with the given URL (domain/path combo) exists in the installation
+func WikiURLExists(installPath, domain, wikiPath string) (bool, error) {
 	// Get the absolute path to the wikis.yaml file
 	filePath := filepath.Join(installPath, "config", "wikis.yaml")
 
@@ -183,9 +183,9 @@ func WikiUrlExists(installPath, domain, wikiPath string) (bool, error) {
 	}
 
 	// Check if a wiki with the given URL exists
-	targetUrl := domain + "/" + wikiPath
+	targetURL := domain + "/" + wikiPath
 	for i := range serverNames {
-		if serverNames[i]+paths[i] == targetUrl {
+		if serverNames[i]+paths[i] == targetURL {
 			return true, nil
 		}
 	}

--- a/internal/farmsettings/farmsettings_test.go
+++ b/internal/farmsettings/farmsettings_test.go
@@ -313,7 +313,7 @@ func TestWikiIDExistsNoFile(t *testing.T) {
 	}
 }
 
-func TestWikiUrlExists(t *testing.T) {
+func TestWikiURLExists(t *testing.T) {
 	dir := t.TempDir()
 	configDir := filepath.Join(dir, "config")
 	if err := os.MkdirAll(configDir, 0755); err != nil {
@@ -326,17 +326,17 @@ func TestWikiUrlExists(t *testing.T) {
 		t.Fatalf("GenerateWikisYaml() error = %v", err)
 	}
 
-	exists, err := WikiUrlExists(dir, "example.com", "wiki")
+	exists, err := WikiURLExists(dir, "example.com", "wiki")
 	if err != nil {
-		t.Fatalf("WikiUrlExists() error = %v", err)
+		t.Fatalf("WikiURLExists() error = %v", err)
 	}
 	if !exists {
 		t.Error("expected URL to exist")
 	}
 
-	exists, err = WikiUrlExists(dir, "other.com", "wiki")
+	exists, err = WikiURLExists(dir, "other.com", "wiki")
 	if err != nil {
-		t.Fatalf("WikiUrlExists() error = %v", err)
+		t.Fatalf("WikiURLExists() error = %v", err)
 	}
 	if exists {
 		t.Error("expected other.com URL to not exist")

--- a/internal/imagebuild/imagebuild.go
+++ b/internal/imagebuild/imagebuild.go
@@ -33,7 +33,8 @@ func BuildFromSource(workspacePath string) (string, error) {
 	// Check if Canasta has a Dockerfile
 	canastaDockerfile := filepath.Join(canastaPath, "Dockerfile")
 	if _, err := os.Stat(canastaDockerfile); os.IsNotExist(err) {
-		return "", fmt.Errorf("dockerfile not found in Canasta repo at %s", canastaDockerfile)
+		//nolint:stylecheck // Dockerfile is a proper noun (filename)
+		return "", fmt.Errorf("Dockerfile not found in Canasta repo at %s", canastaDockerfile)
 	}
 
 	baseImage := "ghcr.io/canastawiki/canasta-base:latest"

--- a/internal/imagebuild/imagebuild.go
+++ b/internal/imagebuild/imagebuild.go
@@ -27,13 +27,13 @@ func BuildFromSource(workspacePath string) (string, error) {
 
 	// Verify Canasta repo exists (required)
 	if _, err := os.Stat(canastaPath); os.IsNotExist(err) {
-		return "", fmt.Errorf("Canasta/ directory not found in %s", workspacePath)
+		return "", fmt.Errorf("canasta/ directory not found in %s", workspacePath)
 	}
 
 	// Check if Canasta has a Dockerfile
 	canastaDockerfile := filepath.Join(canastaPath, "Dockerfile")
 	if _, err := os.Stat(canastaDockerfile); os.IsNotExist(err) {
-		return "", fmt.Errorf("Dockerfile not found in Canasta repo at %s", canastaDockerfile)
+		return "", fmt.Errorf("dockerfile not found in Canasta repo at %s", canastaDockerfile)
 	}
 
 	baseImage := "ghcr.io/canastawiki/canasta-base:latest"
@@ -68,13 +68,13 @@ func BuildFromSource(workspacePath string) (string, error) {
 func PushImage(localTag, registry string) (string, error) {
 	remoteTag := registry + "/" + localTag
 	logging.Print(fmt.Sprintf("Tagging %s as %s\n", localTag, remoteTag))
-	err, output := execute.Run("", "docker", "tag", localTag, remoteTag)
+	output, err := execute.Run("", "docker", "tag", localTag, remoteTag)
 	if err != nil {
 		return "", fmt.Errorf("failed to tag image: %s", output)
 	}
 
 	logging.Print(fmt.Sprintf("Pushing %s\n", remoteTag))
-	err, output = execute.Run("", "docker", "push", remoteTag)
+	output, err = execute.Run("", "docker", "push", remoteTag)
 	if err != nil {
 		return "", fmt.Errorf("failed to push image: %s", output)
 	}
@@ -84,7 +84,7 @@ func PushImage(localTag, registry string) (string, error) {
 
 // buildImage builds a Docker image from a Dockerfile in the given path
 func buildImage(path, tag string) error {
-	err, output := execute.Run(path, "docker", "build", "-t", tag, ".")
+	output, err := execute.Run(path, "docker", "build", "-t", tag, ".")
 	if err != nil {
 		return fmt.Errorf("failed to build Docker image %q: %s", tag, output)
 	}
@@ -94,7 +94,7 @@ func buildImage(path, tag string) error {
 // buildCanastaImage builds the Canasta image with a specified base image
 // The Canasta Dockerfile must support a BASE_IMAGE build arg
 func buildCanastaImage(path, baseImage, tag string) error {
-	err, output := execute.Run(path, "docker", "build",
+	output, err := execute.Run(path, "docker", "build",
 		"--build-arg", fmt.Sprintf("BASE_IMAGE=%s", baseImage),
 		"-t", tag, ".")
 	if err != nil {

--- a/internal/imagebuild/imagebuild.go
+++ b/internal/imagebuild/imagebuild.go
@@ -33,7 +33,8 @@ func BuildFromSource(workspacePath string) (string, error) {
 	// Check if Canasta has a Dockerfile
 	canastaDockerfile := filepath.Join(canastaPath, "Dockerfile")
 	if _, err := os.Stat(canastaDockerfile); os.IsNotExist(err) {
-		//nolint:stylecheck // Dockerfile is a proper noun (filename)
+		// Dockerfile is a proper noun (filename).
+		//nolint:stylecheck
 		return "", fmt.Errorf("Dockerfile not found in Canasta repo at %s", canastaDockerfile)
 	}
 

--- a/internal/mediawiki/mediawiki.go
+++ b/internal/mediawiki/mediawiki.go
@@ -213,7 +213,7 @@ func backupLegacySettings(installPath string) (useNewArchitecture bool, original
 	wikisYamlExists, _ := fileExists(filepath.Join(installPath, "config", "wikis.yaml"))
 
 	if !localExists && !commonExists && !wikisYamlExists {
-		return false, "", fmt.Errorf("No valid configuration found (wikis.yaml, LocalSettings.php, or CommonSettings.php)")
+		return false, "", fmt.Errorf("no valid configuration found (wikis.yaml, LocalSettings.php, or CommonSettings.php)")
 	}
 
 	useNewArchitecture = wikisYamlExists && !localExists && !commonExists
@@ -235,11 +235,11 @@ func backupLegacySettings(installPath string) (useNewArchitecture bool, original
 		backupFile = localSettingsBackup
 	}
 
-	err, _ = execute.Run(installPath, "cp", filepath.Join(configDir, originalSettingsFile), filepath.Join(configDir, backupFile))
+	_, err = execute.Run(installPath, "cp", filepath.Join(configDir, originalSettingsFile), filepath.Join(configDir, backupFile))
 	if err != nil {
 		return false, "", err
 	}
-	err, _ = execute.Run(installPath, "rm", filepath.Join(configDir, originalSettingsFile))
+	_, err = execute.Run(installPath, "rm", filepath.Join(configDir, originalSettingsFile))
 	if err != nil {
 		return false, "", err
 	}
@@ -263,7 +263,7 @@ func restoreLegacySettings(installPath string, useNewArchitecture bool, original
 	}
 
 	// Restore as CommonSettings.php (both cases: existing farm or single→farm conversion)
-	err, _ := execute.Run(installPath, "mv", filepath.Join(configDir, backupFile), filepath.Join(configDir, commonSettingsFile))
+	_, err := execute.Run(installPath, "mv", filepath.Join(configDir, backupFile), filepath.Join(configDir, commonSettingsFile))
 	return err
 }
 
@@ -275,7 +275,7 @@ func RemoveDatabase(installPath, id string, orch orchestrators.Orchestrator) err
 	command := fmt.Sprintf("echo 'DROP DATABASE IF EXISTS %s;' | mariadb -h db -u root -p%s", orchestrators.ShellQuote(id), orchestrators.ShellQuote(envVariables["MYSQL_PASSWORD"]))
 	output, err := orch.ExecWithError(installPath, orchestrators.ServiceDB, command)
 	if err != nil {
-		return fmt.Errorf("Error while dropping database '%s': %v. Output: %s", id, err, output)
+		return fmt.Errorf("error while dropping database '%s': %v. Output: %s", id, err, output)
 	}
 
 	return nil

--- a/internal/orchestrators/backup.go
+++ b/internal/orchestrators/backup.go
@@ -47,7 +47,7 @@ func stageToVolume(volName string, volumes map[string]string) error {
 	shellCmd := "rm -rf /currentsnapshot/* && " + strings.Join(copyParts, " && ")
 	cmdArgs = append(cmdArgs, "alpine", "sh", "-c", shellCmd)
 
-	err, output := execute.Run("", cmdArgs[0], cmdArgs[1:]...)
+	output, err := execute.Run("", cmdArgs[0], cmdArgs[1:]...)
 	if err != nil {
 		return fmt.Errorf("failed to stage files to backup volume: %s", output)
 	}
@@ -65,7 +65,7 @@ func runResticDocker(installPath, envPath, volName string, args ...string) (stri
 	cmdArgs = append(cmdArgs, "restic/restic")
 	cmdArgs = append(cmdArgs, args...)
 
-	err, output := execute.Run(installPath, cmdArgs[0], cmdArgs[1:]...)
+	output, err := execute.Run(installPath, cmdArgs[0], cmdArgs[1:]...)
 	if err != nil {
 		if strings.Contains(output, "repository does not exist") {
 			return output, fmt.Errorf("backup repository not found. Run 'canasta backup init' to create it")
@@ -102,7 +102,7 @@ func restoreFromVolume(volName, installPath string, dirs map[string]string) erro
 	shellCmd := strings.Join(copyParts, " && ")
 	cmdArgs = append(cmdArgs, "alpine", "sh", "-c", shellCmd)
 
-	err, output := execute.Run("", cmdArgs[0], cmdArgs[1:]...)
+	output, err := execute.Run("", cmdArgs[0], cmdArgs[1:]...)
 	if err != nil {
 		return fmt.Errorf("failed to restore files from backup volume: %s", output)
 	}

--- a/internal/orchestrators/backup_test.go
+++ b/internal/orchestrators/backup_test.go
@@ -29,13 +29,13 @@ func TestBackupVolumeName(t *testing.T) {
 func captureShellArg(t *testing.T) *string {
 	t.Helper()
 	var captured string
-	execute.Run = func(path, command string, args ...string) (error, string) {
+	execute.Run = func(path, command string, args ...string) (string, error) {
 		for i, a := range args {
 			if a == "-c" && i > 0 && args[i-1] == "sh" && i+1 < len(args) {
 				captured = args[i+1]
 			}
 		}
-		return nil, ""
+		return "", nil
 	}
 	t.Cleanup(execute.ResetForTesting)
 	return &captured

--- a/internal/orchestrators/compose.go
+++ b/internal/orchestrators/compose.go
@@ -187,13 +187,13 @@ func (c *ComposeOrchestrator) Start(instance config.Installation) error {
 	}
 	args = append(args, "up", "-d")
 	if compose.Path != "" {
-		err, output := execute.Run(instance.Path, compose.Path, args...)
+		output, err := execute.Run(instance.Path, compose.Path, args...)
 		if err != nil {
 			return fmt.Errorf("failed to start containers at %s: %s", instance.Path, output)
 		}
 	} else {
 		allArgs := append([]string{"compose"}, args...)
-		err, output := execute.Run(instance.Path, "docker", allArgs...)
+		output, err := execute.Run(instance.Path, "docker", allArgs...)
 		if err != nil {
 			return fmt.Errorf("failed to start containers at %s: %s", instance.Path, output)
 		}
@@ -220,13 +220,13 @@ func (c *ComposeOrchestrator) Stop(instance config.Installation) error {
 	}
 	args = append(args, "down")
 	if compose.Path != "" {
-		err, output := execute.Run(instance.Path, compose.Path, args...)
+		output, err := execute.Run(instance.Path, compose.Path, args...)
 		if err != nil {
 			return fmt.Errorf("failed to stop containers at %s: %s", instance.Path, output)
 		}
 	} else {
 		allArgs := append([]string{"compose"}, args...)
-		err, output := execute.Run(instance.Path, "docker", allArgs...)
+		output, err := execute.Run(instance.Path, "docker", allArgs...)
 		if err != nil {
 			return fmt.Errorf("failed to stop containers at %s: %s", instance.Path, output)
 		}
@@ -241,12 +241,12 @@ func (c *ComposeOrchestrator) Pull(installPath string) error {
 		return err
 	}
 	if compose.Path != "" {
-		err, output := execute.Run(installPath, compose.Path, "pull", "--ignore-buildable", "--ignore-pull-failures")
+		output, err := execute.Run(installPath, compose.Path, "pull", "--ignore-buildable", "--ignore-pull-failures")
 		if err != nil {
 			return fmt.Errorf("failed to pull images at %s: %s", installPath, output)
 		}
 	} else {
-		err, output := execute.Run(installPath, "docker", "compose", "pull", "--ignore-buildable", "--ignore-pull-failures")
+		output, err := execute.Run(installPath, "docker", "compose", "pull", "--ignore-buildable", "--ignore-pull-failures")
 		if err != nil {
 			return fmt.Errorf("failed to pull images at %s: %s", installPath, output)
 		}
@@ -269,12 +269,12 @@ func (c *ComposeOrchestrator) Update(installPath string) (*UpdateReport, error) 
 
 	// Run pull
 	if compose.Path != "" {
-		err, output := execute.Run(installPath, compose.Path, "pull", "--ignore-buildable", "--ignore-pull-failures")
+		output, err := execute.Run(installPath, compose.Path, "pull", "--ignore-buildable", "--ignore-pull-failures")
 		if err != nil {
 			return nil, fmt.Errorf("failed to pull images for update at %s: %s", installPath, output)
 		}
 	} else {
-		err, output := execute.Run(installPath, "docker", "compose", "pull", "--ignore-buildable", "--ignore-pull-failures")
+		output, err := execute.Run(installPath, "docker", "compose", "pull", "--ignore-buildable", "--ignore-pull-failures")
 		if err != nil {
 			return nil, fmt.Errorf("failed to pull images for update at %s: %s", installPath, output)
 		}
@@ -313,13 +313,13 @@ func (c *ComposeOrchestrator) Build(installPath string, files ...string) error {
 	}
 	args = append(args, "build")
 	if compose.Path != "" {
-		err, output := execute.Run(installPath, compose.Path, args...)
+		output, err := execute.Run(installPath, compose.Path, args...)
 		if err != nil {
 			return fmt.Errorf("failed to build images at %s: %s", installPath, output)
 		}
 	} else {
 		allArgs := append([]string{"compose"}, args...)
-		err, output := execute.Run(installPath, "docker", allArgs...)
+		output, err := execute.Run(installPath, "docker", allArgs...)
 		if err != nil {
 			return fmt.Errorf("failed to build images at %s: %s", installPath, output)
 		}
@@ -334,16 +334,16 @@ func (c *ComposeOrchestrator) Destroy(installPath string) (string, error) {
 	}
 	var output string
 	if compose.Path != "" {
-		err, output = execute.Run(installPath, compose.Path, "down", "-v")
+		output, err = execute.Run(installPath, compose.Path, "down", "-v")
 	} else {
-		err, output = execute.Run(installPath, "docker", "compose", "down", "-v")
+		output, err = execute.Run(installPath, "docker", "compose", "down", "-v")
 	}
 	if err != nil {
 		return output, err
 	}
 
 	// Remove the backup staging volume (not part of docker-compose.yml)
-	if rmErr, rmOutput := execute.Run("", "docker", "volume", "rm", backupVolumeName(installPath)); rmErr != nil {
+	if rmOutput, rmErr := execute.Run("", "docker", "volume", "rm", backupVolumeName(installPath)); rmErr != nil {
 		logging.Print(fmt.Sprintf("Warning: failed to remove backup volume: %s\n", rmOutput))
 	}
 
@@ -451,12 +451,12 @@ func (c *ComposeOrchestrator) CheckRunningStatus(instance config.Installation) e
 	}
 	var output string
 	if compose.Path != "" {
-		err, output = execute.Run(instance.Path, compose.Path, "ps", "-q", containerName)
+		output, err = execute.Run(instance.Path, compose.Path, "ps", "-q", containerName)
 	} else {
-		err, output = execute.Run(instance.Path, "docker", "compose", "ps", "-q", containerName)
+		output, err = execute.Run(instance.Path, "docker", "compose", "ps", "-q", containerName)
 	}
 	if err != nil || output == "" {
-		return fmt.Errorf("Container %s is not running", containerName)
+		return fmt.Errorf("container %s is not running", containerName)
 	}
 	return nil
 }
@@ -507,7 +507,7 @@ func (c *ComposeOrchestrator) RunBackup(installPath, envPath string, volumes map
 	volName := backupVolumeName(installPath)
 
 	// Ensure the persistent backup volume exists (idempotent)
-	err, output := execute.Run("", "docker", "volume", "create", volName)
+	output, err := execute.Run("", "docker", "volume", "create", volName)
 	if err != nil {
 		return "", fmt.Errorf("failed to create backup volume: %s", output)
 	}
@@ -538,7 +538,7 @@ func runResticDockerWithBindMount(installPath, envPath, volName, repoPath string
 	cmdArgs = append(cmdArgs, "restic/restic")
 	cmdArgs = append(cmdArgs, args...)
 
-	err, output := execute.Run(installPath, cmdArgs[0], cmdArgs[1:]...)
+	output, err := execute.Run(installPath, cmdArgs[0], cmdArgs[1:]...)
 	if err != nil {
 		if strings.Contains(output, "repository does not exist") {
 			return output, fmt.Errorf("backup repository not found. Run 'canasta backup init' to create it")
@@ -560,7 +560,7 @@ func (c *ComposeOrchestrator) CopyOverrideFile(installPath, sourceFilename, work
 		}
 		var overrideFilename = filepath.Join(installPath, "docker-compose.override.yml")
 		logging.Print(fmt.Sprintf("Copying %s to %s\n", sourceFilename, overrideFilename))
-		err, output := execute.Run("", "cp", sourceFilename, overrideFilename)
+		output, err := execute.Run("", "cp", sourceFilename, overrideFilename)
 		if err != nil {
 			return fmt.Errorf("failed to copy override file from %s: %s", sourceFilename, output)
 		}
@@ -575,9 +575,9 @@ func getComposeImages(installPath string, compose config.Orchestrator) (map[stri
 	var output string
 	var err error
 	if compose.Path != "" {
-		err, output = execute.Run(installPath, compose.Path, "images")
+		output, err = execute.Run(installPath, compose.Path, "images")
 	} else {
-		err, output = execute.Run(installPath, "docker", "compose", "images")
+		output, err = execute.Run(installPath, "docker", "compose", "images")
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to run docker compose images: %s", output)

--- a/internal/orchestrators/kubernetes.go
+++ b/internal/orchestrators/kubernetes.go
@@ -422,7 +422,7 @@ func (k *KubernetesOrchestrator) RunBackup(installPath, envPath string, volumes 
 	volName := backupVolumeName(installPath)
 
 	// Docker is available (required by kind), so create the staging volume
-	err, output := execute.Run("", "docker", "volume", "create", volName)
+	output, err := execute.Run("", "docker", "volume", "create", volName)
 	if err != nil {
 		return "", fmt.Errorf("failed to create backup volume: %s", output)
 	}

--- a/internal/orchestrators/orchestrator.go
+++ b/internal/orchestrators/orchestrator.go
@@ -80,7 +80,7 @@ type UpdateReport struct {
 // DeleteConfig removes the installation directory from disk.
 // This is a pure filesystem operation, not orchestrator-specific.
 func DeleteConfig(installPath string) (string, error) {
-	err, output := execute.Run("", "rm", "-rf", installPath)
+	output, err := execute.Run("", "rm", "-rf", installPath)
 	return output, err
 }
 

--- a/internal/orchestrators/orchestrator_test.go
+++ b/internal/orchestrators/orchestrator_test.go
@@ -154,7 +154,7 @@ func TestExecError(t *testing.T) {
 
 func TestStopAndStart(t *testing.T) {
 	mock := &mockOrchestrator{}
-	instance := config.Installation{Id: "test", Path: "/tmp/test"}
+	instance := config.Installation{ID: "test", Path: "/tmp/test"}
 
 	err := StopAndStart(mock, instance)
 	if err != nil {
@@ -168,7 +168,7 @@ func TestStopAndStart(t *testing.T) {
 
 func TestStopAndStartStopError(t *testing.T) {
 	mock := &mockOrchestrator{stopErr: fmt.Errorf("stop failed")}
-	instance := config.Installation{Id: "test", Path: "/tmp/test"}
+	instance := config.Installation{ID: "test", Path: "/tmp/test"}
 
 	err := StopAndStart(mock, instance)
 	if err == nil {
@@ -185,7 +185,7 @@ func TestStopAndStartStopError(t *testing.T) {
 
 func TestImportDatabase(t *testing.T) {
 	mock := &mockOrchestrator{}
-	instance := config.Installation{Id: "test", Path: "/tmp/test"}
+	instance := config.Installation{ID: "test", Path: "/tmp/test"}
 
 	err := ImportDatabase(mock, "mywiki", "/path/to/dump.sql", "secret", instance)
 	if err != nil {
@@ -221,7 +221,7 @@ func TestImportDatabase(t *testing.T) {
 
 func TestImportDatabaseCompressed(t *testing.T) {
 	mock := &mockOrchestrator{}
-	instance := config.Installation{Id: "test", Path: "/tmp/test"}
+	instance := config.Installation{ID: "test", Path: "/tmp/test"}
 
 	err := ImportDatabase(mock, "mywiki", "/path/to/dump.sql.gz", "secret", instance)
 	if err != nil {
@@ -242,7 +242,7 @@ func TestImportDatabaseCompressed(t *testing.T) {
 
 func TestImportDatabaseCopyError(t *testing.T) {
 	mock := &mockOrchestrator{copyToErr: fmt.Errorf("copy failed")}
-	instance := config.Installation{Id: "test", Path: "/tmp/test"}
+	instance := config.Installation{ID: "test", Path: "/tmp/test"}
 
 	err := ImportDatabase(mock, "mywiki", "/path/to/dump.sql", "secret", instance)
 	if err == nil {
@@ -252,7 +252,7 @@ func TestImportDatabaseCopyError(t *testing.T) {
 
 func TestImportDatabaseDefaultPassword(t *testing.T) {
 	mock := &mockOrchestrator{}
-	instance := config.Installation{Id: "test", Path: "/tmp/test"}
+	instance := config.Installation{ID: "test", Path: "/tmp/test"}
 
 	err := ImportDatabase(mock, "mywiki", "/path/to/dump.sql", "", instance)
 	if err != nil {


### PR DESCRIPTION
Fix all `stylecheck` violations reported by golangci-lint across 43 files.

**ST1003 — naming conventions (12 unique violations):**
- Rename struct fields `Id` → `ID` in `Installation`, `Orchestrator`, `CanastaVariables` and all usage (70 occurrences, 21 files)
- Rename `CheckCanastaId` → `CheckCanastaID` (19 files)
- Rename `WikiUrlExists` → `WikiURLExists` (3 files)
- Rename local variables: `snapshotId` → `snapshotID`, `parsedUrl` → `parsedURL`, `normalizedId` → `normalizedID`, `launchJsonPath` → `launchJSONPath`, `phpXmlContent` → `phpXMLContent`, `phpXmlPath` → `phpXMLPath`

**ST1005 — error string capitalization (6 unique violations):**
- Lowercase all capitalized error strings per Go convention

**ST1008 — error return order (2 unique violations):**
- Change `execute.Run` return type from `(error, string)` to `(string, error)` and update all 57 call sites plus 1 test mock

Note: The `json:"id"` struct tag is preserved, so serialization/deserialization of `conf.json` is unaffected.

Fixes #560
Part of #542