### PR TITLE
Fix all revive lint violations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,3 +2,8 @@ linters-settings:
   gosec:
     excludes:
       - G306
+  revive:
+    rules:
+      - name: exported
+        arguments:
+          - disableStutteringCheck

--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -87,7 +87,7 @@ an existing database dump instead of running the installer.`,
 
   # Add a wiki with an existing database dump
   canasta add -i myinstance -w docs -u localhost/docs -d /path/to/dump.sql`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				return fmt.Errorf("unknown argument %q; use flags to specify options (e.g. canasta add --wiki <wiki> --url <url>)", args[0])
 			}
@@ -137,7 +137,7 @@ an existing database dump instead of running the installer.`,
 			}
 
 			fmt.Printf("Adding wiki '%s' to Canasta instance '%s'...\n", wikiID, instance.ID)
-			err = AddWiki(AddWikiOptions{
+			err = Wiki(WikiOptions{
 				Instance:         instance,
 				WikiID:           wikiID,
 				SiteName:         siteName,
@@ -175,8 +175,8 @@ an existing database dump instead of running the installer.`,
 	return addCmd
 }
 
-// AddWikiOptions contains all the parameters needed to add a wiki to a Canasta instance.
-type AddWikiOptions struct {
+// WikiOptions contains the parameters needed to add a wiki to a Canasta instance.
+type WikiOptions struct {
 	Instance         config.Installation
 	WikiID           string
 	SiteName         string
@@ -190,8 +190,8 @@ type AddWikiOptions struct {
 	WorkingDir       string
 }
 
-// AddWiki accepts the Canasta instance info, wiki ID, site name, domain and path of the new wiki, database info, and the initial admin info, then creates a new wiki in the Canasta instance.
-func AddWiki(opts AddWikiOptions) error {
+// Wiki accepts the Canasta instance info, wiki ID, site name, domain and path of the new wiki, database info, and the initial admin info, then creates a new wiki in the Canasta instance.
+func Wiki(opts WikiOptions) error {
 	orch, err := orchestrators.New(opts.Instance.Orchestrator)
 	if err != nil {
 		return err
@@ -254,7 +254,7 @@ func AddWiki(opts AddWikiOptions) error {
 
 	// Run MediaWiki installer only if not importing a database
 	if opts.DatabasePath == "" {
-		err = mediawiki.InstallOne(opts.Instance.Path, opts.WikiID, opts.Domain, opts.Admin, opts.AdminPassword, opts.WikiDBUser, opts.WorkingDir, orch)
+		err = mediawiki.InstallOne(opts.Instance.Path, opts.WikiID, opts.Domain, opts.Admin, opts.AdminPassword, opts.WikiDBUser, orch)
 		if err != nil {
 			return err
 		}

--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -137,7 +137,7 @@ an existing database dump instead of running the installer.`,
 			}
 
 			fmt.Printf("Adding wiki '%s' to Canasta instance '%s'...\n", wikiID, instance.ID)
-			err = Wiki(WikiOptions{
+			err = AddWiki(AddWikiOptions{
 				Instance:         instance,
 				WikiID:           wikiID,
 				SiteName:         siteName,
@@ -175,8 +175,8 @@ an existing database dump instead of running the installer.`,
 	return addCmd
 }
 
-// WikiOptions contains the parameters needed to add a wiki to a Canasta instance.
-type WikiOptions struct {
+// AddWikiOptions contains the parameters needed to add a wiki to a Canasta instance.
+type AddWikiOptions struct {
 	Instance         config.Installation
 	WikiID           string
 	SiteName         string
@@ -190,8 +190,8 @@ type WikiOptions struct {
 	WorkingDir       string
 }
 
-// Wiki accepts the Canasta instance info, wiki ID, site name, domain and path of the new wiki, database info, and the initial admin info, then creates a new wiki in the Canasta instance.
-func Wiki(opts WikiOptions) error {
+// AddWiki accepts the Canasta instance info, wiki ID, site name, domain and path of the new wiki, database info, and the initial admin info, then creates a new wiki in the Canasta instance.
+func AddWiki(opts AddWikiOptions) error {
 	orch, err := orchestrators.New(opts.Instance.Orchestrator)
 	if err != nil {
 		return err

--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -35,7 +35,7 @@ func NewCmd() *cobra.Command {
 a backup repository, create and restore backups, list and compare backups,
 and schedule recurring backups. Requires RESTIC_REPOSITORY (or AWS S3 settings)
 and RESTIC_PASSWORD to be configured in the installation's .env file.`,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
 			var err error
 			instance, err = canasta.CheckCanastaID(instance)
 			if err != nil {

--- a/cmd/backup/check.go
+++ b/cmd/backup/check.go
@@ -17,7 +17,7 @@ func newCheckCmd(orch *orchestrators.Orchestrator, instance *config.Installation
 		Long: `Verify the integrity of the backup repository and its data. This
 checks for errors in the repository structure and snapshot data.`,
 		Example: `  canasta backup check -i myinstance`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			output, err := runBackup(*orch, instance.Path, *envPath, nil, "-r", *repoURL, "check")
 			if err != nil {
 				return err

--- a/cmd/backup/create.go
+++ b/cmd/backup/create.go
@@ -26,7 +26,7 @@ with .env, docker-compose.override.yml, and my.cnf (if present), then
 uploads the snapshot to the backup repository with the specified tag.`,
 		Example: `  # Create a backup with a descriptive tag
   canasta backup create -i myinstance -t before-upgrade`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := takeSnapshot(*orch, *instance, *envPath, *repoURL, tag); err != nil {
 				return err
 			}

--- a/cmd/backup/delete.go
+++ b/cmd/backup/delete.go
@@ -18,7 +18,7 @@ func newDeleteCmd(orch *orchestrators.Orchestrator, instance *config.Installatio
 		Long: `Remove a snapshot from the backup repository by its ID. The snapshot data
 may still exist until a prune is run on the repository.`,
 		Example: `  canasta backup delete -i myinstance -s abc123`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			output, err := runBackup(*orch, instance.Path, *envPath, nil, "-r", *repoURL, "forget", snapshot)
 			if err != nil {
 				return err

--- a/cmd/backup/diff.go
+++ b/cmd/backup/diff.go
@@ -19,7 +19,7 @@ func newDiffCmd(orch *orchestrators.Orchestrator, instance *config.Installation,
 contents and metadata of both snapshots, displaying added, removed, and
 modified files.`,
 		Example: `  canasta backup diff -i myinstance --snapshot1 abc123 --snapshot2 def456`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			output, err := runBackup(*orch, instance.Path, *envPath, nil, "-r", *repoURL, "diff", snapshot1, snapshot2)
 			if err != nil {
 				return err

--- a/cmd/backup/files.go
+++ b/cmd/backup/files.go
@@ -18,7 +18,7 @@ func newFilesCmd(orch *orchestrators.Orchestrator, instance *config.Installation
 		Long: `List all files contained in a specific backup snapshot. This is useful
 for inspecting what was backed up before performing a restore.`,
 		Example: `  canasta backup files -i myinstance -s abc123`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			output, err := runBackup(*orch, instance.Path, *envPath, nil, "-r", *repoURL, "ls", snapshot)
 			if err != nil {
 				return err

--- a/cmd/backup/init.go
+++ b/cmd/backup/init.go
@@ -18,7 +18,7 @@ func newInitCmd(orch *orchestrators.Orchestrator, instance *config.Installation,
 creating any backups. The repository location is read from the
 RESTIC_REPOSITORY variable (or AWS S3 settings) in the installation's .env file.`,
 		Example: `  canasta backup init -i myinstance`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			fmt.Println("Initializing backup repository")
 			output, err := runBackup(*orch, instance.Path, *envPath, nil, "-r", *repoURL, "init")
 			if err != nil {

--- a/cmd/backup/list.go
+++ b/cmd/backup/list.go
@@ -17,7 +17,7 @@ func newListCmd(orch *orchestrators.Orchestrator, instance *config.Installation,
 		Long: `List all snapshots stored in the backup repository. Displays
 each snapshot's ID, timestamp, hostname, and tags.`,
 		Example: `  canasta backup list -i myinstance`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			output, err := runBackup(*orch, instance.Path, *envPath, nil, "-r", *repoURL, "snapshots")
 			if err != nil {
 				return err

--- a/cmd/backup/restore.go
+++ b/cmd/backup/restore.go
@@ -40,7 +40,7 @@ images, and public assets from the backup, leaving shared files untouched.`,
 
   # Restore only a single wiki's database
   canasta backup restore -i myinstance -s abc123 -w wiki2`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return restoreSnapshot(*orch, *instance, *envPath, *repoURL, snapshotID, skipBeforeSnapshot, wikiID)
 		},
 	}

--- a/cmd/backup/schedule.go
+++ b/cmd/backup/schedule.go
@@ -42,7 +42,7 @@ installation directory.`,
   # Schedule hourly backups
   canasta backup schedule set -i myinstance "0 * * * *"`,
 		Args: cobra.MinimumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			return scheduleBackup(*instance, strings.Join(args, " "))
 		},
 	}
@@ -54,7 +54,7 @@ func newScheduleListCmd(instance *config.Installation) *cobra.Command {
 		Short:   "Show the backup schedule",
 		Long:    `Show the current backup schedule for this installation, if one exists.`,
 		Example: `  canasta backup schedule list -i myinstance`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return listSchedule(*instance)
 		},
 	}
@@ -66,7 +66,7 @@ func newScheduleRemoveCmd(instance *config.Installation) *cobra.Command {
 		Short:   "Remove a scheduled backup",
 		Long:    `Remove the crontab entry for recurring backups of this installation.`,
 		Example: `  canasta backup schedule remove -i myinstance`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return unscheduleBackup(*instance)
 		},
 	}

--- a/cmd/backup/unlock.go
+++ b/cmd/backup/unlock.go
@@ -17,7 +17,7 @@ func newUnlockCmd(orch *orchestrators.Orchestrator, instance *config.Installatio
 		Long: `Remove stale lock files from the backup repository. Use this if a previous
 backup operation was interrupted and left the repository in a locked state.`,
 		Example: `  canasta backup unlock -i myinstance`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			output, err := runBackup(*orch, instance.Path, *envPath, nil, "-r", *repoURL, "unlock")
 			if err != nil {
 				return err

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -79,7 +79,7 @@ Other settings (database passwords, secret keys, etc.) are generated
 by "canasta create" and should not be changed directly.
 To change the domain, first edit config/wikis.yaml, then use
 "canasta config set" to update MW_SITE_SERVER and MW_SITE_FQDN.`,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
 			var err error
 			instance, err = canasta.CheckCanastaID(instance)
 			if err != nil {

--- a/cmd/config/get.go
+++ b/cmd/config/get.go
@@ -23,7 +23,7 @@ With no arguments, prints all settings sorted alphabetically as KEY=VALUE lines.
 With a KEY argument, prints just the value (no KEY= prefix) for easy scripting.
 Key lookup is case-insensitive.`,
 		Args: cobra.MaximumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			envPath := filepath.Join(instance.Path, ".env")
 			envVars, err := canasta.GetEnvVariable(envPath)
 			if err != nil {

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -119,7 +119,7 @@ Use --no-restart to skip the restart (useful for batching multiple changes).`,
   canasta config set HTTP_PORT=8080 HTTPS_PORT=8443 -i myinstance
   canasta config set CANASTA_ENABLE_OBSERVABILITY=true -i myinstance`,
 		Args: cobra.MinimumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			envPath := filepath.Join(instance.Path, ".env")
 			envVars, err := canasta.GetEnvVariable(envPath)
 			if err != nil {
@@ -211,7 +211,7 @@ Use --no-restart to skip the restart (useful for batching multiple changes).`,
 }
 
 // validatePort checks that the value is a valid port number.
-func validatePort(inst config.Installation, value string) error {
+func validatePort(_ config.Installation, value string) error {
 	port, err := strconv.Atoi(value)
 	if err != nil || port < 1 || port > 65535 {
 		return fmt.Errorf("invalid port number: %s", value)

--- a/cmd/config/unset.go
+++ b/cmd/config/unset.go
@@ -30,7 +30,7 @@ is removed. The instance is then restarted unless --no-restart is specified.`,
   canasta config unset HTTP_PORT HTTPS_PORT -i myinstance
   canasta config unset CANASTA_ENABLE_OBSERVABILITY -i myinstance --no-restart`,
 		Args: cobra.MinimumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			envPath := filepath.Join(instance.Path, ".env")
 			envVars, err := canasta.GetEnvVariable(envPath)
 			if err != nil {

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -31,7 +31,7 @@ func NewCmd() *cobra.Command {
 		yamlPath           string
 		err                error
 		keepConfig         bool
-		canastaInfo        canasta.CanastaVariables
+		canastaInfo        canasta.Variables
 		override           string
 		envFile            string
 		canastaImage       string // custom Canasta image reference
@@ -55,7 +55,7 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
 
   # Create with an existing database dump
   canasta create -i myinstance -w main -d /path/to/dump.sql -n example.com`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Check if the system has at least 4GB of memory
 			if err := system.CheckMemoryInGB(4); err != nil {
 				return err
@@ -214,7 +214,7 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
 }
 
 type createOptions struct {
-	CanastaInfo        canasta.CanastaVariables
+	CanastaInfo        canasta.Variables
 	Orch               orchestrators.Orchestrator
 	WorkingDir         string
 	Path               string

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -31,7 +31,7 @@ func NewCmd() *cobra.Command {
 		yamlPath           string
 		err                error
 		keepConfig         bool
-		canastaInfo        canasta.Variables
+		canastaInfo        canasta.CanastaVariables
 		override           string
 		envFile            string
 		canastaImage       string // custom Canasta image reference
@@ -214,7 +214,7 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
 }
 
 type createOptions struct {
-	CanastaInfo        canasta.Variables
+	CanastaInfo        canasta.CanastaVariables
 	Orch               orchestrators.Orchestrator
 	WorkingDir         string
 	Path               string

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -38,7 +38,7 @@ prompted for confirmation before any data is deleted.`,
 
   # Delete without confirmation prompt
   canasta delete -i myinstance -y`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				return fmt.Errorf("unknown argument %q; use --id to specify the instance ID (e.g. canasta delete --id %s)", args[0], args[0])
 			}

--- a/cmd/devmode/devmode.go
+++ b/cmd/devmode/devmode.go
@@ -30,7 +30,7 @@ func NewCmd() *cobra.Command {
 		Long: `Enable or disable development mode on a Canasta installation. Development
 mode extracts MediaWiki code for live editing and enables Xdebug for step
 debugging. This is only supported with Docker Compose.`,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
 			var err error
 			instance, err = canasta.CheckCanastaID(instance)
 			if err != nil {

--- a/cmd/devmode/disable.go
+++ b/cmd/devmode/disable.go
@@ -21,7 +21,7 @@ directory is preserved so you can re-enable dev mode later without
 re-extracting code.`,
 		Example: `  # Disable dev mode on an installation
   canasta devmode disable -i myinstance`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			fmt.Printf("Disabling development mode on '%s'...\n", instance.ID)
 
 			// Disable dev mode (restore symlinks to real directories)

--- a/cmd/devmode/enable.go
+++ b/cmd/devmode/enable.go
@@ -22,7 +22,7 @@ MediaWiki code for live editing, builds an Xdebug-enabled image, and restarts
 the instance with dev mode compose files. Only supported with Docker Compose.`,
 		Example: `  # Enable dev mode on an installation
   canasta devmode enable -i myinstance`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			fmt.Printf("Enabling development mode on '%s'...\n", instance.ID)
 
 			// Determine the base image: check .env for CANASTA_IMAGE, fall back to default

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -34,7 +34,7 @@ Use a .gz extension on the output path to get a gzip-compressed dump.`,
 
   # Export as gzipped SQL
   canasta export -i myinstance -w main -f /backups/main-backup.sql.gz`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			var err error
 
 			instance, err = canasta.CheckCanastaID(instance)

--- a/cmd/import/import.go
+++ b/cmd/import/import.go
@@ -36,7 +36,7 @@ To create a new wiki from a database dump, use the --database flag with
 
   # Import a gzipped dump and replace the wiki's Settings.php
   canasta import -i myinstance -w main -d /path/to/dump.sql.gz -l /path/to/Settings.php`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			var err error
 
 			instance, err = canasta.CheckCanastaID(instance)

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -23,7 +23,7 @@ ID, path, and orchestrator as recorded in the Canasta configuration file.
 Use --cleanup to remove stale entries whose installation directories no longer exist.`,
 		Example: `  canasta list
   canasta list --cleanup`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return List(instance, cleanup)
 		},
 	}
@@ -31,7 +31,7 @@ Use --cleanup to remove stale entries whose installation directories no longer e
 	return listCmd
 }
 
-func List(instance config.Installation, cleanup bool) error {
+func List(_ config.Installation, cleanup bool) error {
 	if cleanup {
 		installations, err := config.GetAll()
 		if err != nil {

--- a/cmd/maintenance/exec.go
+++ b/cmd/maintenance/exec.go
@@ -36,12 +36,12 @@ The default service is "web" (the MediaWiki container).`,
 
   # Default service is "web", so this also works
   canasta maintenance exec -i myinstance -- php -v`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(_ *cobra.Command, _ []string) error {
 			var err error
 			*instance, err = canasta.CheckCanastaID(*instance)
 			return err
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			orch, err := orchestrators.New(instance.Orchestrator)
 			if err != nil {
 				return err

--- a/cmd/maintenance/extension.go
+++ b/cmd/maintenance/extension.go
@@ -52,12 +52,12 @@ Use --wiki to target a specific wiki.`,
   # Run for a specific wiki in a farm
   canasta maintenance extension -i myinstance --wiki=docs CirrusSearch UpdateSearchIndexConfig.php`,
 		Args: cobra.ArbitraryArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(_ *cobra.Command, _ []string) error {
 			var err error
 			*instance, err = canasta.CheckCanastaID(*instance)
 			return err
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			switch {
 			case len(args) == 0:
 				return listExtensionsWithMaintenance(*instance, *wiki)

--- a/cmd/maintenance/extension_test.go
+++ b/cmd/maintenance/extension_test.go
@@ -18,7 +18,7 @@ type extMockOrchestrator struct {
 	streamingErr   error
 }
 
-func (m *extMockOrchestrator) CheckDependencies() error                 { return nil }
+func (m *extMockOrchestrator) CheckDependencies() error       { return nil }
 func (m *extMockOrchestrator) WriteStackFiles(_ string) error { return nil }
 func (m *extMockOrchestrator) UpdateStackFiles(_ string, _ bool) (bool, error) {
 	return false, nil

--- a/cmd/maintenance/extension_test.go
+++ b/cmd/maintenance/extension_test.go
@@ -19,23 +19,23 @@ type extMockOrchestrator struct {
 }
 
 func (m *extMockOrchestrator) CheckDependencies() error                 { return nil }
-func (m *extMockOrchestrator) WriteStackFiles(installPath string) error { return nil }
-func (m *extMockOrchestrator) UpdateStackFiles(installPath string, dryRun bool) (bool, error) {
+func (m *extMockOrchestrator) WriteStackFiles(_ string) error { return nil }
+func (m *extMockOrchestrator) UpdateStackFiles(_ string, _ bool) (bool, error) {
 	return false, nil
 }
-func (m *extMockOrchestrator) Start(inst config.Installation) error {
+func (m *extMockOrchestrator) Start(_ config.Installation) error {
 	return nil
 }
-func (m *extMockOrchestrator) Stop(inst config.Installation) error {
+func (m *extMockOrchestrator) Stop(_ config.Installation) error {
 	return nil
 }
-func (m *extMockOrchestrator) Update(installPath string) (*orchestrators.UpdateReport, error) {
+func (m *extMockOrchestrator) Update(_ string) (*orchestrators.UpdateReport, error) {
 	return nil, nil
 }
-func (m *extMockOrchestrator) Destroy(installPath string) (string, error) {
+func (m *extMockOrchestrator) Destroy(_ string) (string, error) {
 	return "", nil
 }
-func (m *extMockOrchestrator) ExecWithError(installPath, service, command string) (string, error) {
+func (m *extMockOrchestrator) ExecWithError(_, _, command string) (string, error) {
 	m.calls = append(m.calls, command)
 	if m.execOutputs != nil {
 		for key, output := range m.execOutputs {
@@ -46,47 +46,47 @@ func (m *extMockOrchestrator) ExecWithError(installPath, service, command string
 	}
 	return "", m.execErr
 }
-func (m *extMockOrchestrator) ExecStreaming(installPath, service, command string) error {
+func (m *extMockOrchestrator) ExecStreaming(_, _, command string) error {
 	m.streamingCalls = append(m.streamingCalls, command)
 	return m.streamingErr
 }
-func (m *extMockOrchestrator) CheckRunningStatus(inst config.Installation) error {
+func (m *extMockOrchestrator) CheckRunningStatus(_ config.Installation) error {
 	return nil
 }
-func (m *extMockOrchestrator) CopyFrom(installPath, service, containerPath, hostPath string) error {
+func (m *extMockOrchestrator) CopyFrom(_, _, _, _ string) error {
 	return nil
 }
-func (m *extMockOrchestrator) CopyTo(installPath, service, hostPath, containerPath string) error {
+func (m *extMockOrchestrator) CopyTo(_, _, _, _ string) error {
 	return nil
 }
 
-func (m *extMockOrchestrator) RunBackup(installPath, envPath string, volumes map[string]string, args ...string) (string, error) {
+func (m *extMockOrchestrator) RunBackup(_, _ string, _ map[string]string, _ ...string) (string, error) {
 	return "", nil
 }
 
-func (m *extMockOrchestrator) RestoreFromBackupVolume(installPath string, dirs map[string]string) error {
+func (m *extMockOrchestrator) RestoreFromBackupVolume(_ string, _ map[string]string) error {
 	return nil
 }
-func (m *extMockOrchestrator) InitConfig(installPath string) error {
+func (m *extMockOrchestrator) InitConfig(_ string) error {
 	return nil
 }
-func (m *extMockOrchestrator) UpdateConfig(installPath string) error {
+func (m *extMockOrchestrator) UpdateConfig(_ string) error {
 	return nil
 }
-func (m *extMockOrchestrator) MigrateConfig(installPath string, dryRun bool) (bool, error) {
+func (m *extMockOrchestrator) MigrateConfig(_ string, _ bool) (bool, error) {
 	return false, nil
 }
 
-func (m *extMockOrchestrator) ListServices(inst config.Installation) ([]string, error) {
+func (m *extMockOrchestrator) ListServices(_ config.Installation) ([]string, error) {
 	return nil, nil
 }
-func (m *extMockOrchestrator) ExecInteractive(inst config.Installation, service string, command []string) error {
+func (m *extMockOrchestrator) ExecInteractive(_ config.Installation, _ string, _ []string) error {
 	return nil
 }
 func (m *extMockOrchestrator) Name() string            { return "Mock" }
 func (m *extMockOrchestrator) SupportsDevMode() bool   { return true }
 func (m *extMockOrchestrator) SupportsImagePull() bool { return true }
-func (m *extMockOrchestrator) StopAndStart(inst config.Installation) error {
+func (m *extMockOrchestrator) StopAndStart(_ config.Installation) error {
 	return nil
 }
 

--- a/cmd/maintenance/maintenanceScript.go
+++ b/cmd/maintenance/maintenanceScript.go
@@ -35,12 +35,12 @@ Use --wiki to target a specific wiki in a farm.`,
   # Run a script for a specific wiki in a farm
   canasta maintenance script "rebuildrecentchanges.php" -i myinstance --wiki=docs`,
 		Args: cobra.RangeArgs(0, 1),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(_ *cobra.Command, _ []string) error {
 			var err error
 			*instance, err = canasta.CheckCanastaID(*instance)
 			return err
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return listMaintenanceScripts(*instance)
 			}

--- a/cmd/maintenance/maintenanceUpdate.go
+++ b/cmd/maintenance/maintenanceUpdate.go
@@ -34,12 +34,12 @@ specific wiki.`,
 		Example: `  canasta maintenance update -i myinstance
   canasta maintenance update -i myinstance --wiki=docs
   canasta maintenance update -i myinstance --skip-jobs --skip-smw`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(_ *cobra.Command, _ []string) error {
 			var err error
 			*instance, err = canasta.CheckCanastaID(*instance)
 			return err
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if *wiki != "" {
 				return runMaintenanceUpdate(*instance, *wiki, skipJobs, skipSMW)
 			}

--- a/cmd/maintenance/maintenance_test.go
+++ b/cmd/maintenance/maintenance_test.go
@@ -75,7 +75,7 @@ func TestScriptAcceptsZeroArgs(t *testing.T) {
 	// script accepts 0 args (lists scripts) or 1 arg (runs a script)
 	// override PreRunE/RunE to isolate arg validation
 	scriptCmd.PreRunE = nil
-	scriptCmd.RunE = func(cmd *cobra.Command, args []string) error { return nil }
+	scriptCmd.RunE = func(_ *cobra.Command, _ []string) error { return nil }
 
 	cmd.SetArgs([]string{"script"})
 	if err := cmd.Execute(); err != nil {

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -40,7 +40,7 @@ for confirmation before any data is deleted.`,
 
   # Remove without confirmation prompt
   canasta remove -i myinstance -w docs -y`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if wikiID == "" {
 				if len(args) > 0 {
 					return fmt.Errorf("unknown argument %q; use --wiki to specify the wiki ID (e.g. canasta remove --wiki %s)", args[0], args[0])
@@ -54,7 +54,7 @@ for confirmation before any data is deleted.`,
 			}
 
 			fmt.Printf("Removing wiki '%s' from Canasta instance '%s'...\n", wikiID, instance.ID)
-			if err := RemoveWiki(instance, wikiID, yes); err != nil {
+			if err := Wiki(instance, wikiID, yes); err != nil {
 				return err
 			}
 			fmt.Println("Done.")
@@ -68,8 +68,8 @@ for confirmation before any data is deleted.`,
 	return addCmd
 }
 
-// RemoveWiki removes a wiki with the given wikiID from a Canasta instance
-func RemoveWiki(instance config.Installation, wikiID string, yes bool) error {
+// Wiki removes a wiki with the given wikiID from a Canasta instance.
+func Wiki(instance config.Installation, wikiID string, yes bool) error {
 	orch, err := orchestrators.New(instance.Orchestrator)
 	if err != nil {
 		return err

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -54,7 +54,7 @@ for confirmation before any data is deleted.`,
 			}
 
 			fmt.Printf("Removing wiki '%s' from Canasta instance '%s'...\n", wikiID, instance.ID)
-			if err := Wiki(instance, wikiID, yes); err != nil {
+			if err := RemoveWiki(instance, wikiID, yes); err != nil {
 				return err
 			}
 			fmt.Println("Done.")
@@ -68,8 +68,8 @@ for confirmation before any data is deleted.`,
 	return addCmd
 }
 
-// Wiki removes a wiki with the given wikiID from a Canasta instance.
-func Wiki(instance config.Installation, wikiID string, yes bool) error {
+// RemoveWiki removes a wiki with the given wikiID from a Canasta instance.
+func RemoveWiki(instance config.Installation, wikiID string, yes bool) error {
 	orch, err := orchestrators.New(instance.Orchestrator)
 	if err != nil {
 		return err

--- a/cmd/restart/restart.go
+++ b/cmd/restart/restart.go
@@ -30,7 +30,7 @@ restart. Use 'canasta devmode enable' or 'canasta devmode disable' to
 change the development mode setting.`,
 		Example: `  # Restart an installation by ID
   canasta restart -i myinstance`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				return fmt.Errorf("unknown argument %q; use --id to specify the instance ID (e.g. canasta restart --id %s)", args[0], args[0])
 			}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -38,11 +38,11 @@ and backing up multiple Canasta instances, including wiki farms with multiple
 wikis per instance.`,
 	SilenceErrors: true,
 	SilenceUsage:  true,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+	PersistentPreRun: func(_ *cobra.Command, _ []string) {
 		logging.SetVerbose(verbose)
 		logging.Print("Verbose logging enabled")
 	},
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		_ = cmd.Help()
 	},
 }

--- a/cmd/sitemap/generate.go
+++ b/cmd/sitemap/generate.go
@@ -27,7 +27,7 @@ generator will automatically refresh them.`,
 
   # Generate sitemaps for all wikis
   canasta sitemap generate -i myinstance`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return runGenerate(*instance, *orch, wikiID)
 		},
 	}

--- a/cmd/sitemap/remove.go
+++ b/cmd/sitemap/remove.go
@@ -32,7 +32,7 @@ for all wikis. Once removed, the background generator will skip those wikis.`,
 
   # Remove sitemaps for all wikis without prompting
   canasta sitemap remove -i myinstance -y`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return runRemove(*instance, *orch, wikiID, yes)
 		},
 	}

--- a/cmd/sitemap/sitemap.go
+++ b/cmd/sitemap/sitemap.go
@@ -30,7 +30,7 @@ func NewCmd() *cobra.Command {
 Sitemaps improve search engine indexing by listing all pages on your wiki.
 Use "canasta sitemap generate" to create sitemaps and "canasta sitemap remove"
 to delete them.`,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
 			var err error
 			instance, err = canasta.CheckCanastaID(instance)
 			if err != nil {

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -29,7 +29,7 @@ has development mode enabled, it starts with Xdebug automatically. Use
 development mode setting.`,
 		Example: `  # Start an installation by ID
   canasta start -i myinstance`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				return fmt.Errorf("unknown argument %q; use --id to specify the instance ID (e.g. canasta start --id %s)", args[0], args[0])
 			}

--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -27,7 +27,7 @@ func NewCmd() *cobra.Command {
 are stopped gracefully, preserving all data in Docker volumes.`,
 		Example: `  # Stop an installation by ID
   canasta stop -i myinstance`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				return fmt.Errorf("unknown argument %q; use --id to specify the instance ID (e.g. canasta stop --id %s)", args[0], args[0])
 			}

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -51,7 +51,7 @@ distributed using the stored configuration.`,
 
   # Preview what would change without applying
   canasta upgrade --dry-run`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			// Check for CLI updates first (skipped automatically for dev builds and dry-run)
 			if !dryRun {
 				if _, err := selfupdate.CheckAndUpdate(); err != nil {

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -28,7 +28,7 @@ func NewCmd() *cobra.Command {
 		Long: `Display the Canasta CLI version, git commit hash, and build timestamp.
 Shows "dev" if the binary was built without version information.`,
 		Example: `  canasta version`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			fmt.Println(displayVersion())
 			return nil
 		},

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -23,7 +23,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/spinner"
 )
 
-type CanastaVariables struct {
+type Variables struct {
 	ID             string
 	AdminPassword  string
 	AdminName      string
@@ -652,7 +652,7 @@ func warnIfProblematicPassword(varName, value string) {
 
 // GenerateDBPasswords generates database passwords (root and wiki DB).
 // This should always be called, even when importing a database.
-func GenerateDBPasswords(canastaInfo CanastaVariables) (CanastaVariables, error) {
+func GenerateDBPasswords(canastaInfo Variables) (Variables, error) {
 	var err error
 
 	gen, err := safePasswordGenerator()
@@ -685,7 +685,7 @@ func GenerateDBPasswords(canastaInfo CanastaVariables) (CanastaVariables, error)
 
 // GenerateAdminPassword generates an admin password if not provided.
 // This should only be called when NOT importing a database (i.e., running install.php).
-func GenerateAdminPassword(canastaInfo CanastaVariables) (CanastaVariables, error) {
+func GenerateAdminPassword(canastaInfo Variables) (Variables, error) {
 	var err error
 
 	gen, err := safePasswordGenerator()

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -23,7 +23,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/spinner"
 )
 
-type Variables struct {
+type CanastaVariables struct {
 	ID             string
 	AdminPassword  string
 	AdminName      string
@@ -652,7 +652,7 @@ func warnIfProblematicPassword(varName, value string) {
 
 // GenerateDBPasswords generates database passwords (root and wiki DB).
 // This should always be called, even when importing a database.
-func GenerateDBPasswords(canastaInfo Variables) (Variables, error) {
+func GenerateDBPasswords(canastaInfo CanastaVariables) (CanastaVariables, error) {
 	var err error
 
 	gen, err := safePasswordGenerator()
@@ -685,7 +685,7 @@ func GenerateDBPasswords(canastaInfo Variables) (Variables, error) {
 
 // GenerateAdminPassword generates an admin password if not provided.
 // This should only be called when NOT importing a database (i.e., running install.php).
-func GenerateAdminPassword(canastaInfo Variables) (Variables, error) {
+func GenerateAdminPassword(canastaInfo CanastaVariables) (CanastaVariables, error) {
 	var err error
 
 	gen, err := safePasswordGenerator()

--- a/internal/canasta/canasta_test.go
+++ b/internal/canasta/canasta_test.go
@@ -195,7 +195,7 @@ func TestDeleteEnvVariable(t *testing.T) {
 }
 
 func TestGenerateAdminAndDBPasswords(t *testing.T) {
-	info := Variables{
+	info := CanastaVariables{
 		ID:        "test",
 		AdminName: "admin",
 	}
@@ -255,7 +255,7 @@ func TestGenerateAdminAndDBPasswords(t *testing.T) {
 }
 
 func TestGeneratePasswordsPreserveExisting(t *testing.T) {
-	info := Variables{
+	info := CanastaVariables{
 		ID:             "test",
 		AdminName:      "admin",
 		AdminPassword:  "myadminpass",
@@ -285,7 +285,7 @@ func TestGeneratePasswordsPreserveExisting(t *testing.T) {
 }
 
 func TestGenerateDBPasswordsRootUser(t *testing.T) {
-	info := Variables{
+	info := CanastaVariables{
 		WikiDBUsername: "root",
 	}
 

--- a/internal/canasta/canasta_test.go
+++ b/internal/canasta/canasta_test.go
@@ -195,7 +195,7 @@ func TestDeleteEnvVariable(t *testing.T) {
 }
 
 func TestGenerateAdminAndDBPasswords(t *testing.T) {
-	info := CanastaVariables{
+	info := Variables{
 		ID:        "test",
 		AdminName: "admin",
 	}
@@ -255,7 +255,7 @@ func TestGenerateAdminAndDBPasswords(t *testing.T) {
 }
 
 func TestGeneratePasswordsPreserveExisting(t *testing.T) {
-	info := CanastaVariables{
+	info := Variables{
 		ID:             "test",
 		AdminName:      "admin",
 		AdminPassword:  "myadminpass",
@@ -285,7 +285,7 @@ func TestGeneratePasswordsPreserveExisting(t *testing.T) {
 }
 
 func TestGenerateDBPasswordsRootUser(t *testing.T) {
-	info := CanastaVariables{
+	info := Variables{
 		WikiDBUsername: "root",
 	}
 

--- a/internal/devmode/devmode_test.go
+++ b/internal/devmode/devmode_test.go
@@ -26,7 +26,7 @@ func TestIsDevModeSetup(t *testing.T) {
 		},
 		{
 			name: "neither file present",
-			setup: func(t *testing.T, dir string) {
+			setup: func(_ *testing.T, _ string) {
 			},
 			want: false,
 		},

--- a/internal/extensionsskins/commands.go
+++ b/internal/extensionsskins/commands.go
@@ -35,7 +35,7 @@ func NewCmd(constants Item) *cobra.Command {
 		Long: fmt.Sprintf(`Manage MediaWiki %s in a Canasta installation. Subcommands allow you
 to list all available %s, and enable or disable them globally or for
 a specific wiki in a farm.`, constants.Plural, constants.Plural),
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
 			var err error
 			instance, err = canasta.CheckCanastaID(instance)
 			if err != nil {
@@ -56,17 +56,14 @@ a specific wiki in a farm.`, constants.Plural, constants.Plural),
 	return cmd
 }
 
-// Consistent signature with newEnableCmd/newDisableCmd.
-//
-//nolint:unparam
-func newListCmd(instance *config.Installation, orch *orchestrators.Orchestrator, wiki *string, constants *Item) *cobra.Command {
+func newListCmd(instance *config.Installation, orch *orchestrators.Orchestrator, _ *string, constants *Item) *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
 		Short: fmt.Sprintf("Lists all the installed Canasta %s", constants.Plural),
 		Long: fmt.Sprintf(`List all Canasta %s available in the installation. Each %s
 is shown with its enabled/disabled status.`, constants.Plural, constants.CmdName),
 		Example: fmt.Sprintf("  canasta %s list -i myinstance", constants.CmdName),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return List(*instance, *orch, *constants)
 		},
 	}
@@ -110,7 +107,7 @@ After enabling, update.php is automatically run to apply any required
 database changes. Use --skip-update to skip this step.`, constants.Plural, constants.Plural, article(constants.CmdName), constants.CmdName),
 		Example: example,
 		Args:    cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			names := strings.Split(args[0], ",")
 			anyEnabled := false
 			for _, name := range names {
@@ -139,10 +136,7 @@ database changes. Use --skip-update to skip this step.`, constants.Plural, const
 	return cmd
 }
 
-// Consistent signature with newEnableCmd/newListCmd.
-//
-//nolint:unparam
-func newDisableCmd(instance *config.Installation, orch *orchestrators.Orchestrator, wiki *string, constants *Item) *cobra.Command {
+func newDisableCmd(instance *config.Installation, _ *orchestrators.Orchestrator, wiki *string, constants *Item) *cobra.Command {
 	// Build the Use string with an appropriate argument placeholder
 	argName := strings.ToUpper(constants.CmdName)
 	useStr := fmt.Sprintf("disable %s1,%s2,...", argName, argName)
@@ -165,7 +159,7 @@ specified as a comma-separated list. Use the --wiki flag to disable %s %s
 for a specific wiki only.`, constants.Plural, constants.Plural, article(constants.CmdName), constants.CmdName),
 		Example: example,
 		Args:    cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			names := strings.Split(args[0], ",")
 			for _, name := range names {
 				name = strings.TrimSpace(name)

--- a/internal/mediawiki/mediawiki.go
+++ b/internal/mediawiki/mediawiki.go
@@ -35,7 +35,7 @@ func WaitForDB(path string, orch orchestrators.Orchestrator) error {
 	return nil
 }
 
-func Install(path, yamlPath string, orch orchestrators.Orchestrator, canastaInfo canasta.Variables) (canasta.Variables, error) {
+func Install(path, yamlPath string, orch orchestrators.Orchestrator, canastaInfo canasta.CanastaVariables) (canasta.CanastaVariables, error) {
 	var err error
 	logging.Print("Configuring MediaWiki Installation\n")
 	logging.Print("Running install.php\n")

--- a/internal/mediawiki/mediawiki.go
+++ b/internal/mediawiki/mediawiki.go
@@ -35,7 +35,7 @@ func WaitForDB(path string, orch orchestrators.Orchestrator) error {
 	return nil
 }
 
-func Install(path, yamlPath string, orch orchestrators.Orchestrator, canastaInfo canasta.CanastaVariables) (canasta.CanastaVariables, error) {
+func Install(path, yamlPath string, orch orchestrators.Orchestrator, canastaInfo canasta.Variables) (canasta.Variables, error) {
 	var err error
 	logging.Print("Configuring MediaWiki Installation\n")
 	logging.Print("Running install.php\n")
@@ -131,7 +131,7 @@ func Install(path, yamlPath string, orch orchestrators.Orchestrator, canastaInfo
 	return canastaInfo, nil
 }
 
-func InstallOne(installPath, id, domain, admin, adminPassword, dbuser, workingDir string, orch orchestrators.Orchestrator) error {
+func InstallOne(installPath, id, domain, admin, adminPassword, dbuser string, orch orchestrators.Orchestrator) error {
 	var err error
 	logging.Print("Configuring MediaWiki Installation\n")
 	logging.Print("Running install.php\n")

--- a/internal/orchestrators/backup_test.go
+++ b/internal/orchestrators/backup_test.go
@@ -29,7 +29,7 @@ func TestBackupVolumeName(t *testing.T) {
 func captureShellArg(t *testing.T) *string {
 	t.Helper()
 	var captured string
-	execute.Run = func(path, command string, args ...string) (string, error) {
+	execute.Run = func(_, _ string, args ...string) (string, error) {
 		for i, a := range args {
 			if a == "-c" && i > 0 && args[i-1] == "sh" && i+1 < len(args) {
 				captured = args[i+1]

--- a/internal/orchestrators/orchestrator_test.go
+++ b/internal/orchestrators/orchestrator_test.go
@@ -19,81 +19,81 @@ type mockOrchestrator struct {
 }
 
 func (m *mockOrchestrator) CheckDependencies() error                 { return nil }
-func (m *mockOrchestrator) WriteStackFiles(installPath string) error { return nil }
-func (m *mockOrchestrator) UpdateStackFiles(installPath string, dryRun bool) (bool, error) {
+func (m *mockOrchestrator) WriteStackFiles(_ string) error { return nil }
+func (m *mockOrchestrator) UpdateStackFiles(_ string, _ bool) (bool, error) {
 	return false, nil
 }
 
-func (m *mockOrchestrator) Start(instance config.Installation) error {
+func (m *mockOrchestrator) Start(_ config.Installation) error {
 	m.calls = append(m.calls, "Start")
 	return m.startErr
 }
 
-func (m *mockOrchestrator) Stop(instance config.Installation) error {
+func (m *mockOrchestrator) Stop(_ config.Installation) error {
 	m.calls = append(m.calls, "Stop")
 	return m.stopErr
 }
 
-func (m *mockOrchestrator) Update(installPath string) (*UpdateReport, error) {
+func (m *mockOrchestrator) Update(_ string) (*UpdateReport, error) {
 	return nil, nil
 }
 
-func (m *mockOrchestrator) Destroy(installPath string) (string, error) {
+func (m *mockOrchestrator) Destroy(_ string) (string, error) {
 	return "", nil
 }
 
-func (m *mockOrchestrator) ExecWithError(installPath, service, command string) (string, error) {
+func (m *mockOrchestrator) ExecWithError(_, service, command string) (string, error) {
 	m.calls = append(m.calls, fmt.Sprintf("ExecWithError:%s:%s", service, command))
 	return m.execOutput, m.execErr
 }
 
-func (m *mockOrchestrator) ExecStreaming(installPath, service, command string) error {
+func (m *mockOrchestrator) ExecStreaming(_, _, _ string) error {
 	return nil
 }
 
-func (m *mockOrchestrator) CheckRunningStatus(instance config.Installation) error {
+func (m *mockOrchestrator) CheckRunningStatus(_ config.Installation) error {
 	return nil
 }
 
-func (m *mockOrchestrator) CopyFrom(installPath, service, containerPath, hostPath string) error {
+func (m *mockOrchestrator) CopyFrom(_, service, containerPath, hostPath string) error {
 	m.calls = append(m.calls, fmt.Sprintf("CopyFrom:%s:%s:%s", service, containerPath, hostPath))
 	return nil
 }
 
-func (m *mockOrchestrator) CopyTo(installPath, service, hostPath, containerPath string) error {
+func (m *mockOrchestrator) CopyTo(_, service, hostPath, containerPath string) error {
 	m.calls = append(m.calls, fmt.Sprintf("CopyTo:%s:%s:%s", service, hostPath, containerPath))
 	return m.copyToErr
 }
 
-func (m *mockOrchestrator) RunBackup(installPath, envPath string, volumes map[string]string, args ...string) (string, error) {
+func (m *mockOrchestrator) RunBackup(_, _ string, _ map[string]string, args ...string) (string, error) {
 	m.calls = append(m.calls, fmt.Sprintf("RunBackup:%s", strings.Join(args, " ")))
 	return m.execOutput, m.execErr
 }
 
-func (m *mockOrchestrator) RestoreFromBackupVolume(installPath string, dirs map[string]string) error {
+func (m *mockOrchestrator) RestoreFromBackupVolume(_ string, _ map[string]string) error {
 	m.calls = append(m.calls, "RestoreFromBackupVolume")
 	return nil
 }
 
-func (m *mockOrchestrator) InitConfig(installPath string) error {
+func (m *mockOrchestrator) InitConfig(_ string) error {
 	m.calls = append(m.calls, "InitConfig")
 	return nil
 }
 
-func (m *mockOrchestrator) UpdateConfig(installPath string) error {
+func (m *mockOrchestrator) UpdateConfig(_ string) error {
 	m.calls = append(m.calls, "UpdateConfig")
 	return nil
 }
 
-func (m *mockOrchestrator) MigrateConfig(installPath string, dryRun bool) (bool, error) {
+func (m *mockOrchestrator) MigrateConfig(_ string, _ bool) (bool, error) {
 	m.calls = append(m.calls, "MigrateConfig")
 	return false, nil
 }
 
-func (m *mockOrchestrator) ListServices(instance config.Installation) ([]string, error) {
+func (m *mockOrchestrator) ListServices(_ config.Installation) ([]string, error) {
 	return nil, nil
 }
-func (m *mockOrchestrator) ExecInteractive(instance config.Installation, service string, command []string) error {
+func (m *mockOrchestrator) ExecInteractive(_ config.Installation, _ string, _ []string) error {
 	return nil
 }
 func (m *mockOrchestrator) Name() string            { return "Mock" }

--- a/internal/orchestrators/orchestrator_test.go
+++ b/internal/orchestrators/orchestrator_test.go
@@ -18,7 +18,7 @@ type mockOrchestrator struct {
 	stopErr    error
 }
 
-func (m *mockOrchestrator) CheckDependencies() error                 { return nil }
+func (m *mockOrchestrator) CheckDependencies() error       { return nil }
 func (m *mockOrchestrator) WriteStackFiles(_ string) error { return nil }
 func (m *mockOrchestrator) UpdateStackFiles(_ string, _ bool) (bool, error) {
 	return false, nil


### PR DESCRIPTION
Closes #564

## Summary

Fix 98 revive violations unique to this linter (out of 112 total). The remaining 14 are `var-naming` and `error-return` violations that overlap with stylecheck #561 and were resolved when that PR merged.

**Changes:**
- Rename unused Cobra callback parameters (`cmd`, `args`) to `_` across all command files
- Rename unused mock orchestrator parameters to `_` in test files
- Disable stuttering check globally in `.golangci.yml` via `disableStutteringCheck` (keeps original descriptive names like `canasta.CanastaVariables` and `add.AddWiki`)
- Remove unused `workingDir` parameter from `mediawiki.InstallOne` (single caller updated)
- Drop two `//nolint:unparam` directives no longer needed after parameter renames

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all tests pass
- [x] `golangci-lint run --enable revive --disable-all --max-issues-per-linter 0` reports only the overlapping violations already fixed in #561