### PR TITLE
Style: put nolint explanations on separate lines

### DIFF
--- a/cmd/upgrade/upgrade_test.go
+++ b/cmd/upgrade/upgrade_test.go
@@ -349,7 +349,8 @@ func TestRemoveEmptyComposerLocalPreservesPopulated(t *testing.T) {
 }
 
 func TestAddVclSpecialRandomBypass(t *testing.T) {
-	//nolint:gosec // G101: not credentials, VCL config for tests
+	// Not credentials, VCL config for tests.
+	//nolint:gosec
 	vclWithoutBypass := `vcl 4.0;
 
 backend default {
@@ -366,7 +367,8 @@ sub vcl_recv {
     call mobile_detect;
 }`
 
-	//nolint:gosec // G101: not credentials, VCL config for tests
+	// Not credentials, VCL config for tests.
+	//nolint:gosec
 	vclWithBypass := `vcl 4.0;
 
 backend default {

--- a/internal/orchestrators/compose.go
+++ b/internal/orchestrators/compose.go
@@ -41,7 +41,8 @@ func (c *ComposeOrchestrator) CheckDependencies() error {
 		return err
 	}
 	if compose.Path != "" {
-		//nolint:gosec // compose.Path from system lookup
+		// compose.Path is from system lookup.
+		//nolint:gosec
 		cmd := exec.Command(compose.Path, "version")
 		if err := cmd.Run(); err != nil {
 			return fmt.Errorf("unable to execute compose (%s)", err)
@@ -359,7 +360,8 @@ func (c *ComposeOrchestrator) ListServices(instance config.Installation) ([]stri
 	}
 	var cmd *exec.Cmd
 	if compose.Path != "" {
-		//nolint:gosec // compose.Path from system lookup
+		// compose.Path is from system lookup.
+		//nolint:gosec
 		cmd = exec.Command(compose.Path, "ps", "--services")
 	} else {
 		cmd = exec.Command("docker", "compose", "ps", "--services")
@@ -388,7 +390,8 @@ func (c *ComposeOrchestrator) ExecInteractive(instance config.Installation, serv
 	if compose.Path != "" {
 		args = append(args, "exec", service)
 		args = append(args, command...)
-		//nolint:gosec // compose.Path from system lookup
+		// compose.Path is from system lookup.
+		//nolint:gosec
 		cmd := exec.Command(compose.Path, args...)
 		cmd.Dir = instance.Path
 		cmd.Stdin = os.Stdin
@@ -412,7 +415,8 @@ func (c *ComposeOrchestrator) ExecWithError(installPath, service, command string
 	}
 	var cmd *exec.Cmd
 	if compose.Path != "" {
-		//nolint:gosec // compose.Path from system lookup
+		// compose.Path is from system lookup.
+		//nolint:gosec
 		cmd = exec.Command(compose.Path, "exec", "-T", service, "/bin/bash", "-c", command)
 	} else {
 		cmd = exec.Command("docker", "compose", "exec", "-T", service, "/bin/bash", "-c", command)
@@ -433,7 +437,8 @@ func (c *ComposeOrchestrator) ExecStreaming(installPath, service, command string
 	}
 	var cmd *exec.Cmd
 	if compose.Path != "" {
-		//nolint:gosec // compose.Path from system lookup
+		// compose.Path is from system lookup.
+		//nolint:gosec
 		cmd = exec.Command(compose.Path, "exec", "-T", service, "/bin/bash", "-c", command)
 	} else {
 		cmd = exec.Command("docker", "compose", "exec", "-T", service, "/bin/bash", "-c", command)
@@ -474,10 +479,12 @@ func (c *ComposeOrchestrator) CopyFrom(installPath, service, containerPath, host
 	}
 	var cmd *exec.Cmd
 	if compose.Path != "" {
-		//nolint:gosec // compose.Path from system lookup
+		// compose.Path is from system lookup.
+		//nolint:gosec
 		cmd = exec.Command(compose.Path, "cp", service+":"+containerPath, hostPath)
 	} else {
-		//nolint:gosec // args from trusted caller
+		// Args from trusted caller.
+		//nolint:gosec
 		cmd = exec.Command("docker", "compose", "cp", service+":"+containerPath, hostPath)
 	}
 	if installPath != "" {
@@ -497,10 +504,12 @@ func (c *ComposeOrchestrator) CopyTo(installPath, service, hostPath, containerPa
 	}
 	var cmd *exec.Cmd
 	if compose.Path != "" {
-		//nolint:gosec // compose.Path from system lookup
+		// compose.Path is from system lookup.
+		//nolint:gosec
 		cmd = exec.Command(compose.Path, "cp", hostPath, service+":"+containerPath)
 	} else {
-		//nolint:gosec // args from trusted caller
+		// Args from trusted caller.
+		//nolint:gosec
 		cmd = exec.Command("docker", "compose", "cp", hostPath, service+":"+containerPath)
 	}
 	if installPath != "" {

--- a/internal/system/memory.go
+++ b/internal/system/memory.go
@@ -118,7 +118,8 @@ func gbToByte(gb int) uint64 {
 	if gb < 0 {
 		return 0
 	}
-	//nolint:gosec // gb is validated non-negative above
+	// gb is validated non-negative above.
+	//nolint:gosec
 	return uint64(gb) * 1024 * 1024 * 1024
 }
 


### PR DESCRIPTION
## Summary

Split inline `//nolint:gosec // explanation` comments into separate lines for consistency:

```go
// compose.Path is from system lookup.
//nolint:gosec
```

Affects 12 occurrences across 3 files.

Fixes #566
Part of #542