### PR TITLE
Fix dead code, duplication, and bugs from code quality audit

### DIFF
--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
-	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
 	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
@@ -46,7 +45,10 @@ and RESTIC_PASSWORD to be configured in the installation's .env file.`,
 			if envErr != nil {
 				return envErr
 			}
-			repoURL = getRepoURL(envVariables)
+			repoURL, err = getRepoURL(envVariables)
+			if err != nil {
+				return err
+			}
 
 			orch, err = orchestrators.New(instance.Orchestrator)
 			if err != nil {
@@ -72,29 +74,24 @@ and RESTIC_PASSWORD to be configured in the installation's .env file.`,
 
 }
 
-func getRepoURL(env map[string]string) string {
+func getRepoURL(env map[string]string) (string, error) {
 	if val, ok := env["RESTIC_REPOSITORY"]; ok && val != "" {
-		return val
+		return val, nil
 	}
 	if val, ok := env["RESTIC_REPO"]; ok && val != "" {
-		return val
+		return val, nil
 	}
-	return "s3:" + env["AWS_S3_API"] + "/" + env["AWS_S3_BUCKET"]
+	api := env["AWS_S3_API"]
+	bucket := env["AWS_S3_BUCKET"]
+	if api == "" && bucket == "" {
+		return "", fmt.Errorf("no backup repository configured: set RESTIC_REPOSITORY or AWS_S3_API/AWS_S3_BUCKET in .env")
+	}
+	return "s3:" + api + "/" + bucket, nil
 }
 
 // runBackup is a convenience wrapper for orch.RunBackup.
 func runBackup(orch orchestrators.Orchestrator, installPath, envPath string, volumes map[string]string, args ...string) (string, error) {
 	return orch.RunBackup(installPath, envPath, volumes, args...)
-}
-
-// getWikiIDs reads wikis.yaml and returns all wiki IDs.
-func getWikiIDs(installPath string) ([]string, error) {
-	yamlPath := filepath.Join(installPath, "config", "wikis.yaml")
-	ids, _, _, err := farmsettings.ReadWikisYaml(yamlPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read wikis.yaml: %w", err)
-	}
-	return ids, nil
 }
 
 // dumpPath returns the container path for a wiki's database dump file.

--- a/cmd/backup/backup_test.go
+++ b/cmd/backup/backup_test.go
@@ -41,33 +41,6 @@ func TestDumpPath(t *testing.T) {
 	}
 }
 
-func TestGetWikiIDs(t *testing.T) {
-	dir := t.TempDir()
-	wikis := []farmsettings.Wiki{
-		{ID: "main", URL: "localhost", NAME: "main"},
-		{ID: "wiki2", URL: "localhost/wiki2", NAME: "wiki2"},
-	}
-	writeWikisYaml(t, dir, wikis)
-
-	t.Run("returns all wikis", func(t *testing.T) {
-		ids, err := getWikiIDs(dir)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(ids) != 2 || ids[0] != "main" || ids[1] != "wiki2" {
-			t.Errorf("got %v, want [main wiki2]", ids)
-		}
-	})
-
-	t.Run("missing wikis.yaml", func(t *testing.T) {
-		emptyDir := t.TempDir()
-		_, err := getWikiIDs(emptyDir)
-		if err == nil {
-			t.Fatal("expected error for missing wikis.yaml")
-		}
-	})
-}
-
 func TestGetWikiIDsForRestore(t *testing.T) {
 	dir := t.TempDir()
 	wikis := []farmsettings.Wiki{
@@ -187,9 +160,10 @@ func TestRestorePreservesDBPasswords(t *testing.T) {
 
 func TestGetRepoURL(t *testing.T) {
 	for _, tc := range []struct {
-		name string
-		env  map[string]string
-		want string
+		name    string
+		env     map[string]string
+		want    string
+		wantErr bool
 	}{
 		{
 			name: "RESTIC_REPOSITORY is set",
@@ -241,16 +215,25 @@ func TestGetRepoURL(t *testing.T) {
 				"AWS_S3_API":        "",
 				"AWS_S3_BUCKET":     "",
 			},
-			want: "s3:/",
+			wantErr: true,
 		},
 		{
-			name: "all vars absent",
-			env:  map[string]string{},
-			want: "s3:/",
+			name:    "all vars absent",
+			env:     map[string]string{},
+			wantErr: true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := getRepoURL(tc.env)
+			got, err := getRepoURL(tc.env)
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if got != tc.want {
 				t.Errorf("getRepoURL() = %q, want %q", got, tc.want)
 			}

--- a/cmd/backup/create.go
+++ b/cmd/backup/create.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
 	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
@@ -47,7 +48,7 @@ func takeSnapshot(orch orchestrators.Orchestrator, instance config.Installation,
 		return err
 	}
 
-	wikiIDs, err := getWikiIDs(instance.Path)
+	wikiIDs, err := farmsettings.GetWikiIDs(instance.Path)
 	if err != nil {
 		return err
 	}

--- a/cmd/backup/restore.go
+++ b/cmd/backup/restore.go
@@ -82,7 +82,7 @@ func restoreSnapshot(orch orchestrators.Orchestrator, instance config.Installati
 // and public assets from a backup, leaving shared files untouched.
 func restoreWiki(orch orchestrators.Orchestrator, instance config.Installation, wikiID string, env map[string]string) error {
 	// Validate that the wiki ID exists in the current installation's wikis.yaml
-	wikiIDs, err := getWikiIDs(instance.Path)
+	wikiIDs, err := farmsettings.GetWikiIDs(instance.Path)
 	if err != nil {
 		return err
 	}

--- a/cmd/config/get.go
+++ b/cmd/config/get.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -58,17 +57,4 @@ Key lookup is case-insensitive.`,
 
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Allow querying unrecognized keys")
 	return cmd
-}
-
-// resolveKey finds the actual key in envVars using case-insensitive matching
-// with hyphens treated as underscores. If no match is found, returns the
-// input uppercased with hyphens replaced by underscores.
-func resolveKey(envVars map[string]string, input string) string {
-	normalized := strings.ReplaceAll(input, "-", "_")
-	for k := range envVars {
-		if strings.EqualFold(k, normalized) {
-			return k
-		}
-	}
-	return strings.ToUpper(normalized)
 }

--- a/cmd/config/helpers.go
+++ b/cmd/config/helpers.go
@@ -1,0 +1,30 @@
+package config
+
+import "strings"
+
+// resolveKey finds the actual key in envVars using case-insensitive matching
+// with hyphens treated as underscores. If no match is found, returns the
+// input uppercased with hyphens replaced by underscores.
+func resolveKey(envVars map[string]string, input string) string {
+	normalized := strings.ReplaceAll(input, "-", "_")
+	for k := range envVars {
+		if strings.EqualFold(k, normalized) {
+			return k
+		}
+	}
+	return strings.ToUpper(normalized)
+}
+
+// isKnownKey reports whether key is in the knownKeys set or matches a
+// Restic backend prefix.
+func isKnownKey(key string) bool {
+	if knownKeys[key] {
+		return true
+	}
+	for _, prefix := range resticPrefixes {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -81,20 +81,6 @@ var knownKeys = map[string]bool{
 // of these prefixes is treated as known.
 var resticPrefixes = []string{"AWS_", "AZURE_", "B2_", "GOOGLE_", "OS_", "ST_", "RCLONE_"}
 
-// isKnownKey reports whether key is in the knownKeys set or matches a
-// Restic backend prefix.
-func isKnownKey(key string) bool {
-	if knownKeys[key] {
-		return true
-	}
-	for _, prefix := range resticPrefixes {
-		if strings.HasPrefix(key, prefix) {
-			return true
-		}
-	}
-	return false
-}
-
 // setting is a parsed KEY=VALUE pair.
 type setting struct {
 	key   string

--- a/cmd/upgrade/mysql_to_mariadb.go
+++ b/cmd/upgrade/mysql_to_mariadb.go
@@ -112,7 +112,7 @@ func dumpMySQL8Data(installPath string) (string, error) {
 
 	// Dump all user databases into a single file inside the container
 	dumpCmd := fmt.Sprintf("mysqldump --user=root --password=%s --databases %s --single-transaction --routines --triggers --events > /tmp/dump.sql",
-		shellEscape(password), strings.Join(databases, " "))
+		orchestrators.ShellQuote(password), strings.Join(databases, " "))
 	output, err = execute.Run("", "docker", "exec", containerName,
 		"bash", "-c", dumpCmd)
 	if err != nil {
@@ -185,11 +185,4 @@ func importMariaDBDump(installPath string, orch orchestrators.Orchestrator, dump
 
 	fmt.Println("  Database import complete")
 	return nil
-}
-
-// shellEscape escapes a string for use in a shell command passed to bash -c
-// via docker exec (not via the orchestrator's ExecWithError which uses
-// ShellQuote). We use single quotes here as well.
-func shellEscape(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/internal/devmode/devmode.go
+++ b/internal/devmode/devmode.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/execute"
 	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
@@ -227,18 +228,15 @@ func consolidateUserDir(installPath, codeDir, dirName, userDirName string) error
 func SetupDevEnvironment(installPath, baseImage string) error {
 	logging.Print("Setting up development environment...\n")
 
-	// Update .env file to set DEV_CODE_PATH and CANASTA_IMAGE
+	// Update .env file to set DEV_CODE_PATH and CANASTA_IMAGE.
+	// Uses SaveEnvVariable so that re-enabling dev mode updates
+	// existing entries rather than appending duplicates.
 	envPath := filepath.Join(installPath, ".env")
-	envContent, err := os.ReadFile(envPath)
-	if err != nil {
-		return fmt.Errorf("failed to read .env file: %w", err)
+	if err := canasta.SaveEnvVariable(envPath, "DEV_CODE_PATH", "./mediawiki-code"); err != nil {
+		return fmt.Errorf("failed to save DEV_CODE_PATH: %w", err)
 	}
-
-	// Append dev settings to .env
-	devSettings := fmt.Sprintf("\n# Development mode settings\nDEV_CODE_PATH=./mediawiki-code\nCANASTA_IMAGE=%s\n", baseImage)
-	envContent = append(envContent, []byte(devSettings)...)
-	if err := os.WriteFile(envPath, envContent, permissions.FilePermission); err != nil {
-		return fmt.Errorf("failed to update .env file: %w", err)
+	if err := canasta.SaveEnvVariable(envPath, "CANASTA_IMAGE", baseImage); err != nil {
+		return fmt.Errorf("failed to save CANASTA_IMAGE: %w", err)
 	}
 
 	// Write IDE configs with current host/port from .env

--- a/internal/execute/execute.go
+++ b/internal/execute/execute.go
@@ -3,7 +3,6 @@ package execute
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"os/exec"
 	"strings"
 
@@ -46,8 +45,8 @@ func defaultRun(path, command string, cmdArgs ...string) (string, error) {
 
 	logging.Print(fmt.Sprint(command, " ", strings.Join(cmdArgs, " ")))
 	cmd := exec.Command(command, cmdArgs...)
-	cmd.Stdout = io.MultiWriter(outWriter)
-	cmd.Stderr = io.MultiWriter(errWriter)
+	cmd.Stdout = outWriter
+	cmd.Stderr = errWriter
 
 	if path != "" {
 		cmd.Dir = path

--- a/internal/farmsettings/farmsettings_test.go
+++ b/internal/farmsettings/farmsettings_test.go
@@ -313,6 +313,41 @@ func TestWikiIDExistsNoFile(t *testing.T) {
 	}
 }
 
+func TestGetWikiIDs(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "config")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	filePath := filepath.Join(configDir, "wikis.yaml")
+
+	_, err := GenerateWikisYaml(filePath, "main", "localhost", "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := AddWiki("wiki2", dir, "localhost/wiki2", "", "wiki2"); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("returns all wikis", func(t *testing.T) {
+		ids, err := GetWikiIDs(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(ids) != 2 || ids[0] != "main" || ids[1] != "wiki2" {
+			t.Errorf("got %v, want [main wiki2]", ids)
+		}
+	})
+
+	t.Run("missing wikis.yaml", func(t *testing.T) {
+		emptyDir := t.TempDir()
+		_, err := GetWikiIDs(emptyDir)
+		if err == nil {
+			t.Fatal("expected error for missing wikis.yaml")
+		}
+	})
+}
+
 func TestWikiURLExists(t *testing.T) {
 	dir := t.TempDir()
 	configDir := filepath.Join(dir, "config")

--- a/internal/orchestrators/kubernetes.go
+++ b/internal/orchestrators/kubernetes.go
@@ -745,9 +745,10 @@ func (k *KubernetesOrchestrator) generateKustomization(installPath string, manag
 		kust.Patches = append(kust.Patches, buildNodePortPatch())
 	}
 
-	// 6. Observability stack (OpenSearch + Fluent Bit + Dashboards)
+	// 6–8. Read .env once for observability, elasticsearch, and image override checks
 	envPath := filepath.Join(installPath, ".env")
 	if envVars, err := canasta.GetEnvVariable(envPath); err == nil {
+		// 6. Observability stack (OpenSearch + Fluent Bit + Dashboards)
 		if canasta.IsObservabilityEnabled(envVars) {
 			kust.Resources = append(kust.Resources,
 				"kubernetes/log-pvcs.yaml",
@@ -763,18 +764,14 @@ func (k *KubernetesOrchestrator) generateKustomization(installPath string, manag
 				buildLogVolumePatch("db", "/var/log/mysql", "mariadb-logs"),
 			)
 		}
-	}
 
-	// 7. Elasticsearch (optional)
-	if envVars, err := canasta.GetEnvVariable(envPath); err == nil {
+		// 7. Elasticsearch (optional)
 		if canasta.IsElasticsearchEnabled(envVars) {
 			kust.Resources = append(kust.Resources, "kubernetes/elasticsearch.yaml")
 			kust.Patches = append(kust.Patches, buildElasticsearchInitPatch())
 		}
-	}
 
-	// 8. Image override (for local builds pushed to a registry)
-	if envVars, err := canasta.GetEnvVariable(envPath); err == nil {
+		// 8. Image override (for local builds pushed to a registry)
 		if canastaImage := envVars["CANASTA_IMAGE"]; canastaImage != "" {
 			// Parse "registry/repo:tag" into newName and newTag
 			newName := canastaImage


### PR DESCRIPTION
## Summary

Addresses the low-hanging fruit from #568 (code quality audit Round 6):

- **Remove duplicate `getWikiIDs`**: `cmd/backup/backup.go` reimplemented `farmsettings.GetWikiIDs` — replaced with a reference to the existing function
- **Remove duplicate `shellEscape`**: `cmd/upgrade/mysql_to_mariadb.go` duplicated `orchestrators.ShellQuote` — replaced with a call to the existing function
- **Remove unnecessary `io.MultiWriter` wrapper**: `internal/execute/execute.go` wrapped a single writer in `MultiWriter` — use the writer directly
- **Move shared helpers to dedicated file**: `resolveKey` (from `get.go`) and `isKnownKey` (from `set.go`) moved to `cmd/config/helpers.go` since both are used across `get.go`, `set.go`, and `unset.go`
- **Fix `SetupDevEnvironment` duplicate `.env` entries**: `internal/devmode/devmode.go` appended `DEV_CODE_PATH` and `CANASTA_IMAGE` via raw byte append, creating duplicates on re-enable — now uses `canasta.SaveEnvVariable`
- **Read `.env` once in `generateKustomization`**: `internal/orchestrators/kubernetes.go` called `canasta.GetEnvVariable` three times for observability, elasticsearch, and image override checks — consolidated into a single read
- **Return error from `getRepoURL` on empty env**: `cmd/backup/backup.go` produced `s3:/` when no backup repository was configured — now returns a clear error message

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] All 15 golangci-lint linters pass clean
- [x] Backup tests updated for new `getRepoURL` error return (empty env cases now expect errors)