### PR TITLE
Fix nil panic, duplicate restart logic, and .env comment parsing

### DIFF
--- a/cmd/config/helpers.go
+++ b/cmd/config/helpers.go
@@ -1,6 +1,12 @@
 package config
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
+)
 
 // resolveKey finds the actual key in envVars using case-insensitive matching
 // with hyphens treated as underscores. If no match is found, returns the
@@ -27,4 +33,26 @@ func isKnownKey(key string) bool {
 		}
 	}
 	return false
+}
+
+// restartInstance performs the UpdateConfig → Stop → optional kind cluster
+// recreation → Start sequence shared by config set and config unset.
+func restartInstance(orch *orchestrators.Orchestrator, instance config.Installation, portKeyChanged bool) error {
+	fmt.Println("Applying configuration and restarting...")
+	if err := (*orch).UpdateConfig(instance.Path); err != nil {
+		return fmt.Errorf("failed to update config: %w", err)
+	}
+	if err := (*orch).Stop(instance); err != nil {
+		return fmt.Errorf("failed to stop instance: %w", err)
+	}
+	if instance.KindCluster != "" && portKeyChanged {
+		if err := recreateKindCluster(instance); err != nil {
+			return err
+		}
+	}
+	if err := (*orch).Start(instance); err != nil {
+		return fmt.Errorf("failed to start instance: %w", err)
+	}
+	fmt.Println("Done.")
+	return nil
 }

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -164,30 +164,14 @@ Use --no-restart to skip the restart (useful for batching multiple changes).`,
 				return nil
 			}
 
-			// Restart: UpdateConfig → Stop → (recreate kind cluster if needed) → Start
-			fmt.Println("Applying configuration and restarting...")
-			if err := (*orch).UpdateConfig(instance.Path); err != nil {
-				return fmt.Errorf("failed to update config: %w", err)
-			}
-			if err := (*orch).Stop(*instance); err != nil {
-				return fmt.Errorf("failed to stop instance: %w", err)
-			}
-			// Recreate kind cluster at most once if any port key changed
-			if instance.KindCluster != "" {
-				for _, s := range settings {
-					if portKeys[s.key] {
-						if err := recreateKindCluster(*instance); err != nil {
-							return err
-						}
-						break
-					}
+			portKeyChanged := false
+			for _, s := range settings {
+				if portKeys[s.key] {
+					portKeyChanged = true
+					break
 				}
 			}
-			if err := (*orch).Start(*instance); err != nil {
-				return fmt.Errorf("failed to start instance: %w", err)
-			}
-			fmt.Println("Done.")
-			return nil
+			return restartInstance(orch, *instance, portKeyChanged)
 		},
 	}
 

--- a/cmd/config/unset.go
+++ b/cmd/config/unset.go
@@ -76,24 +76,7 @@ is removed. The instance is then restarted unless --no-restart is specified.`,
 				return nil
 			}
 
-			// Restart: UpdateConfig → Stop → (recreate kind cluster if port key) → Start
-			fmt.Println("Applying configuration and restarting...")
-			if err := (*orch).UpdateConfig(instance.Path); err != nil {
-				return fmt.Errorf("failed to update config: %w", err)
-			}
-			if err := (*orch).Stop(*instance); err != nil {
-				return fmt.Errorf("failed to stop instance: %w", err)
-			}
-			if instance.KindCluster != "" && portKeyChanged {
-				if err := recreateKindCluster(*instance); err != nil {
-					return err
-				}
-			}
-			if err := (*orch).Start(*instance); err != nil {
-				return fmt.Errorf("failed to start instance: %w", err)
-			}
-			fmt.Println("Done.")
-			return nil
+			return restartInstance(orch, *instance, portKeyChanged)
 		},
 	}
 

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -180,6 +180,9 @@ func UpdateEnvFile(customEnvPath, installPath, workingDir, rootDBpass, wikiDBpas
 	if err != nil {
 		return err
 	}
+	if len(domainNames) == 0 {
+		return fmt.Errorf("no domain names found in wikis.yaml")
+	}
 	if err := SaveEnvVariable(filepath.Join(installPath, ".env"), "MW_SITE_SERVER", "https://"+domainNames[0]); err != nil {
 		return err
 	}
@@ -790,6 +793,10 @@ func GetEnvVariable(envPath string) (map[string]string, error) {
 	data := strings.TrimSuffix(string(fileData), "\n")
 	variableList := strings.Split(data, "\n")
 	for _, variable := range variableList {
+		line := strings.TrimSpace(variable)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
 		// Use SplitN to only split on first "=" - values may contain "=" characters
 		list := strings.SplitN(variable, "=", 2)
 		if len(list) < 2 {

--- a/internal/canasta/canasta_test.go
+++ b/internal/canasta/canasta_test.go
@@ -16,7 +16,7 @@ func TestGetEnvVariable(t *testing.T) {
 	dir := t.TempDir()
 	envPath := filepath.Join(dir, ".env")
 
-	content := "KEY1=value1\n# this is a comment\nKEY2=value2\n\nEMPTY=\nKEY_WITH_EQUALS=abc=def\nKEY=a=b\nQUOTED=\"hello world\"\n"
+	content := "KEY1=value1\n# this is a comment\n# COMMENTED_OUT=hidden\nKEY2=value2\n\nEMPTY=\nKEY_WITH_EQUALS=abc=def\nKEY=a=b\nQUOTED=\"hello world\"\n"
 	if err := os.WriteFile(envPath, []byte(content), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -41,6 +41,11 @@ func TestGetEnvVariable(t *testing.T) {
 		if got := vars[tt.key]; got != tt.want {
 			t.Errorf("GetEnvVariable()[%s] = %q, want %q", tt.key, got, tt.want)
 		}
+	}
+
+	// Comments with = signs should not be parsed as key-value pairs
+	if _, ok := vars["# COMMENTED_OUT"]; ok {
+		t.Error("comment line with = sign should not be parsed as key-value pair")
 	}
 }
 


### PR DESCRIPTION
## Summary

Continuation of #568 (code quality audit), stacked on #569.

- **Nil panic in `UpdateEnvFile`**: `canasta.go:183` accessed `domainNames[0]` without checking if the slice was empty. Added defensive check.
- **Duplicate restart logic in config set/unset**: Identical restart sequences (UpdateConfig → Stop → optional kind cluster recreation → Start) in `set.go` and `unset.go` extracted into shared `restartInstance` helper in `helpers.go`.
- **`GetEnvVariable` doesn't skip comments**: Lines like `# FOO=bar` were parsed as key-value pairs. Now skips comment lines (starting with `#`) and blank lines.

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] All 15 golangci-lint linters pass clean
- [x] Added test assertion that comment lines with `=` signs are excluded from parsed env vars