### PR TITLE
Fix SaveEnvVariable to deduplicate entries

### DIFF
--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -762,22 +762,24 @@ func SaveEnvVariable(envPath, key, value string) error {
 	data := string(file)
 	list := strings.Split(data, "\n")
 	found := false
-	for index, line := range list {
+	result := make([]string, 0, len(list))
+	for _, line := range list {
 		if strings.HasPrefix(line, key+"=") {
-			list[index] = fmt.Sprintf("%s=%s", key, value)
+			if found {
+				// Skip duplicate entries for the same key
+				continue
+			}
+			result = append(result, fmt.Sprintf("%s=%s", key, value))
 			found = true
-			break
+			continue
 		}
+		result = append(result, line)
 	}
 	if !found {
-		// Append new key=value pair
-		list = append(list, fmt.Sprintf("%s=%s", key, value))
+		result = append(result, fmt.Sprintf("%s=%s", key, value))
 	}
-	lines := strings.Join(list, "\n")
-	if err := os.WriteFile(envPath, []byte(lines), permissions.FilePermission); err != nil {
-		return err
-	}
-	return nil
+	lines := strings.Join(result, "\n")
+	return os.WriteFile(envPath, []byte(lines), permissions.FilePermission)
 }
 
 // Get values saved inside the .env at the envPath

--- a/internal/canasta/canasta_test.go
+++ b/internal/canasta/canasta_test.go
@@ -104,6 +104,42 @@ func TestSaveEnvVariable(t *testing.T) {
 	}
 }
 
+func TestSaveEnvVariableDeduplicates(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+
+	// Start with a file that has duplicate keys (e.g., from prior raw appends)
+	initial := "KEY1=first\nKEY2=keep\nKEY1=second\nKEY1=third\n"
+	if err := os.WriteFile(envPath, []byte(initial), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Save should update the first occurrence and remove duplicates
+	if err := SaveEnvVariable(envPath, "KEY1", "updated"); err != nil {
+		t.Fatalf("SaveEnvVariable() error = %v", err)
+	}
+
+	data, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := strings.Count(string(data), "KEY1=")
+	if count != 1 {
+		t.Errorf("expected 1 occurrence of KEY1, got %d in:\n%s", count, data)
+	}
+
+	vars, err := GetEnvVariable(envPath)
+	if err != nil {
+		t.Fatalf("GetEnvVariable() error = %v", err)
+	}
+	if vars["KEY1"] != "updated" {
+		t.Errorf("KEY1 = %q, want \"updated\"", vars["KEY1"])
+	}
+	if vars["KEY2"] != "keep" {
+		t.Errorf("KEY2 = %q, want \"keep\"", vars["KEY2"])
+	}
+}
+
 func TestDeleteEnvVariable(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Summary
- `SaveEnvVariable` previously used `break` after finding the first matching key, leaving any duplicate entries (from prior raw appends) untouched
- Now updates the first occurrence and removes subsequent duplicates, matching the approach used by `DeleteEnvVariable`
- Adds test for the deduplication behavior

Fixes an item from #568.