### PR TITLE
Extract shared stack file walking logic

### DIFF
--- a/internal/orchestrators/compose.go
+++ b/internal/orchestrators/compose.go
@@ -1,9 +1,7 @@
 package orchestrators
 
 import (
-	"bytes"
 	"fmt"
-	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,7 +12,6 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/execute"
 	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators/compose"
-	"github.com/CanastaWiki/Canasta-CLI/internal/permissions"
 )
 
 const (
@@ -65,87 +62,11 @@ func (c *ComposeOrchestrator) WriteStackFiles(installPath string) error {
 // UpdateStackFiles compares embedded Docker Compose files with on-disk versions
 // and overwrites any that differ. Returns true if anything changed.
 func (c *ComposeOrchestrator) UpdateStackFiles(installPath string, dryRun bool) (bool, error) {
-	changed := false
-	err := fs.WalkDir(compose.StackFiles, "files", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		relPath, err := filepath.Rel("files", path)
-		if err != nil {
-			return err
-		}
-		if relPath == "." {
-			return nil
-		}
-		targetPath := filepath.Join(installPath, relPath)
-		if d.IsDir() {
-			if !dryRun {
-				return os.MkdirAll(targetPath, permissions.DirectoryPermission)
-			}
-			return nil
-		}
-		if d.Name() == ".gitkeep" {
-			return nil
-		}
-		embedded, err := compose.StackFiles.ReadFile(path)
-		if err != nil {
-			return fmt.Errorf("failed to read embedded file %s: %w", path, err)
-		}
-		existing, readErr := os.ReadFile(targetPath)
-		if readErr == nil && bytes.Equal(existing, embedded) {
-			return nil // unchanged
-		}
-		changed = true
-		if dryRun {
-			if readErr != nil {
-				fmt.Printf("  Would create %s\n", relPath)
-			} else {
-				fmt.Printf("  Would update %s\n", relPath)
-			}
-			return nil
-		}
-		if readErr != nil {
-			fmt.Printf("  Creating %s\n", relPath)
-		} else {
-			fmt.Printf("  Updating %s\n", relPath)
-		}
-		return os.WriteFile(targetPath, embedded, permissions.FilePermission)
-	})
-	return changed, err
+	return updateStackFiles(compose.StackFiles, "files", installPath, dryRun)
 }
 
-// walkStackFiles walks the embedded stack files and writes them to installPath.
-// If noClobber is true (create mode), existing files are skipped.
 func (c *ComposeOrchestrator) walkStackFiles(installPath string, overwrite bool) error {
-	return fs.WalkDir(compose.StackFiles, "files", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		relPath, err := filepath.Rel("files", path)
-		if err != nil {
-			return err
-		}
-		if relPath == "." {
-			return nil
-		}
-		targetPath := filepath.Join(installPath, relPath)
-		if d.IsDir() {
-			return os.MkdirAll(targetPath, permissions.DirectoryPermission)
-		}
-		if d.Name() == ".gitkeep" {
-			return nil
-		}
-		if !overwrite {
-			if _, err := os.Stat(targetPath); err == nil {
-				return nil // no-clobber
-			}
-		}
-		data, err := compose.StackFiles.ReadFile(path)
-		if err != nil {
-			return fmt.Errorf("failed to read embedded file %s: %w", path, err)
-		}
-		return os.WriteFile(targetPath, data, permissions.FilePermission)
-	})
+	return writeStackFiles(compose.StackFiles, "files", installPath, overwrite)
 }
 
 // GetDevFiles returns the list of compose files needed for dev mode.

--- a/internal/orchestrators/kubernetes.go
+++ b/internal/orchestrators/kubernetes.go
@@ -1,9 +1,7 @@
 package orchestrators
 
 import (
-	"bytes"
 	"fmt"
-	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -64,53 +62,7 @@ func (k *KubernetesOrchestrator) WriteStackFiles(installPath string) error {
 }
 
 func (k *KubernetesOrchestrator) UpdateStackFiles(installPath string, dryRun bool) (bool, error) {
-	changed := false
-	err := fs.WalkDir(kubernetes.StackFiles, "files/kubernetes", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		relPath, err := filepath.Rel("files", path)
-		if err != nil {
-			return err
-		}
-		if relPath == "." {
-			return nil
-		}
-		targetPath := filepath.Join(installPath, relPath)
-		if d.IsDir() {
-			if !dryRun {
-				return os.MkdirAll(targetPath, permissions.DirectoryPermission)
-			}
-			return nil
-		}
-		if d.Name() == ".gitkeep" {
-			return nil
-		}
-		embedded, err := kubernetes.StackFiles.ReadFile(path)
-		if err != nil {
-			return fmt.Errorf("failed to read embedded file %s: %w", path, err)
-		}
-		existing, readErr := os.ReadFile(targetPath)
-		if readErr == nil && bytes.Equal(existing, embedded) {
-			return nil // unchanged
-		}
-		changed = true
-		if dryRun {
-			if readErr != nil {
-				fmt.Printf("  Would create %s\n", relPath)
-			} else {
-				fmt.Printf("  Would update %s\n", relPath)
-			}
-			return nil
-		}
-		if readErr != nil {
-			fmt.Printf("  Creating %s\n", relPath)
-		} else {
-			fmt.Printf("  Updating %s\n", relPath)
-		}
-		return os.WriteFile(targetPath, embedded, permissions.FilePermission)
-	})
-	return changed, err
+	return updateStackFiles(kubernetes.StackFiles, "files/kubernetes", installPath, dryRun)
 }
 
 func (k *KubernetesOrchestrator) Start(instance config.Installation) error {
@@ -966,35 +918,7 @@ func (k *KubernetesOrchestrator) MigrateConfig(installPath string, dryRun bool) 
 // Only manifest YAMLs under files/kubernetes/ are written; the template is skipped.
 // If overwrite is false (create mode), existing files are skipped.
 func (k *KubernetesOrchestrator) walkStackFiles(installPath string, overwrite bool) error {
-	return fs.WalkDir(kubernetes.StackFiles, "files/kubernetes", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		relPath, err := filepath.Rel("files", path)
-		if err != nil {
-			return err
-		}
-		if relPath == "." {
-			return nil
-		}
-		targetPath := filepath.Join(installPath, relPath)
-		if d.IsDir() {
-			return os.MkdirAll(targetPath, permissions.DirectoryPermission)
-		}
-		if d.Name() == ".gitkeep" {
-			return nil
-		}
-		if !overwrite {
-			if _, err := os.Stat(targetPath); err == nil {
-				return nil // no-clobber
-			}
-		}
-		data, err := kubernetes.StackFiles.ReadFile(path)
-		if err != nil {
-			return fmt.Errorf("failed to read embedded file %s: %w", path, err)
-		}
-		return os.WriteFile(targetPath, data, permissions.FilePermission)
-	})
+	return writeStackFiles(kubernetes.StackFiles, "files/kubernetes", installPath, overwrite)
 }
 
 // getRunningPod finds a running pod for the given service label in a namespace.

--- a/internal/orchestrators/stackfiles.go
+++ b/internal/orchestrators/stackfiles.go
@@ -1,0 +1,98 @@
+package orchestrators
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/permissions"
+)
+
+// writeStackFiles walks an embedded FS and writes files to installPath.
+// If overwrite is false, existing files are skipped (no-clobber).
+func writeStackFiles(stackFS embed.FS, root, installPath string, overwrite bool) error {
+	return fs.WalkDir(stackFS, root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		relPath, err := filepath.Rel("files", path)
+		if err != nil {
+			return err
+		}
+		if relPath == "." {
+			return nil
+		}
+		targetPath := filepath.Join(installPath, relPath)
+		if d.IsDir() {
+			return os.MkdirAll(targetPath, permissions.DirectoryPermission)
+		}
+		if d.Name() == ".gitkeep" {
+			return nil
+		}
+		if !overwrite {
+			if _, err := os.Stat(targetPath); err == nil {
+				return nil // no-clobber
+			}
+		}
+		data, err := stackFS.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read embedded file %s: %w", path, err)
+		}
+		return os.WriteFile(targetPath, data, permissions.FilePermission)
+	})
+}
+
+// updateStackFiles walks an embedded FS, compares with on-disk versions,
+// and overwrites any that differ. Returns true if anything changed.
+func updateStackFiles(stackFS embed.FS, root, installPath string, dryRun bool) (bool, error) {
+	changed := false
+	err := fs.WalkDir(stackFS, root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		relPath, err := filepath.Rel("files", path)
+		if err != nil {
+			return err
+		}
+		if relPath == "." {
+			return nil
+		}
+		targetPath := filepath.Join(installPath, relPath)
+		if d.IsDir() {
+			if !dryRun {
+				return os.MkdirAll(targetPath, permissions.DirectoryPermission)
+			}
+			return nil
+		}
+		if d.Name() == ".gitkeep" {
+			return nil
+		}
+		embedded, err := stackFS.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read embedded file %s: %w", path, err)
+		}
+		existing, readErr := os.ReadFile(targetPath)
+		if readErr == nil && bytes.Equal(existing, embedded) {
+			return nil // unchanged
+		}
+		changed = true
+		if dryRun {
+			if readErr != nil {
+				fmt.Printf("  Would create %s\n", relPath)
+			} else {
+				fmt.Printf("  Would update %s\n", relPath)
+			}
+			return nil
+		}
+		if readErr != nil {
+			fmt.Printf("  Creating %s\n", relPath)
+		} else {
+			fmt.Printf("  Updating %s\n", relPath)
+		}
+		return os.WriteFile(targetPath, embedded, permissions.FilePermission)
+	})
+	return changed, err
+}


### PR DESCRIPTION
## Summary
- `walkStackFiles` and `UpdateStackFiles` were near-identical (97-98%) in both `compose.go` and `kubernetes.go`, differing only in the embedded FS and root path
- Extracted `writeStackFiles` and `updateStackFiles` into a new `stackfiles.go` and made both orchestrators delegate to them
- Net -61 lines (removed 159, added 98 in shared file)

Fixes an item from #568.