### PR TITLE
Replace fragile text parsing in getComposeImages with JSON

### DIFF
--- a/internal/orchestrators/compose.go
+++ b/internal/orchestrators/compose.go
@@ -1,6 +1,7 @@
 package orchestrators
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -419,70 +420,56 @@ func (c *ComposeOrchestrator) CopyOverrideFile(installPath, sourceFilename, work
 	return nil
 }
 
-// getComposeImages returns a map of service name to ImageInfo
-func getComposeImages(installPath string, compose config.Orchestrator) (map[string]ImageInfo, error) {
-	images := make(map[string]ImageInfo)
+// composeImageEntry represents one element from "docker compose images --format json".
+type composeImageEntry struct {
+	ContainerName string `json:"ContainerName"`
+	Repository    string `json:"Repository"`
+	Tag           string `json:"Tag"`
+	ID            string `json:"ID"`
+}
 
-	output, err := runCompose(installPath, compose, "images")
+// getComposeImages returns a map of service name to ImageInfo.
+func getComposeImages(installPath string, compose config.Orchestrator) (map[string]ImageInfo, error) {
+	output, err := runCompose(installPath, compose, "images", "--format", "json")
 	if err != nil {
 		return nil, fmt.Errorf("failed to run docker compose images: %s", output)
 	}
 
-	lines := strings.Split(strings.TrimSpace(output), "\n")
-	headerFound := false
-	for _, line := range lines {
-		if line == "" || strings.HasPrefix(line, "time=") || strings.Contains(line, "level=") {
-			continue
-		}
-
-		if strings.HasPrefix(line, "CONTAINER") {
-			headerFound = true
-			continue
-		}
-
-		if !headerFound {
-			continue
-		}
-
-		fields := strings.Fields(line)
-		if len(fields) >= 4 {
-			containerName := fields[0]
-			parts := strings.Split(containerName, "-")
-			var service string
-			switch {
-			case len(parts) >= 3:
-				service = strings.Join(parts[1:len(parts)-1], "-")
-			case len(parts) == 2:
-				service = parts[0]
-			default:
-				parts = strings.Split(containerName, "_")
-				switch {
-				case len(parts) >= 3:
-					service = strings.Join(parts[1:len(parts)-1], "_")
-				case len(parts) == 2:
-					service = parts[0]
-				default:
-					service = containerName
-				}
-			}
-
-			if service == "" {
-				continue
-			}
-
-			imageRepo := fields[1]
-			imageTag := fields[2]
-			imageID := fields[3]
-
-			images[service] = ImageInfo{
-				Service: service,
-				Image:   imageRepo + ":" + imageTag,
-				ID:      imageID,
-			}
-		}
+	var entries []composeImageEntry
+	if err := json.Unmarshal([]byte(output), &entries); err != nil {
+		return nil, fmt.Errorf("failed to parse docker compose images output: %w", err)
 	}
 
+	project := filepath.Base(installPath)
+	images := make(map[string]ImageInfo, len(entries))
+	for _, e := range entries {
+		service := serviceFromContainer(e.ContainerName, project)
+		images[service] = ImageInfo{
+			Service: service,
+			Image:   e.Repository + ":" + e.Tag,
+			ID:      e.ID,
+		}
+	}
 	return images, nil
+}
+
+// serviceFromContainer extracts the service name from a Docker Compose
+// container name. Compose v2 uses "{project}-{service}-{number}".
+func serviceFromContainer(containerName, project string) string {
+	// Strip the project prefix and separator
+	after, found := strings.CutPrefix(containerName, project+"-")
+	if !found {
+		// Legacy underscore separator: {project}_{service}_{number}
+		after, found = strings.CutPrefix(containerName, project+"_")
+		if !found {
+			return containerName
+		}
+	}
+	// Strip the trailing "-{number}" or "_{number}"
+	if idx := strings.LastIndexAny(after, "-_"); idx > 0 {
+		return after[:idx]
+	}
+	return after
 }
 
 // syncComposeProfiles ensures COMPOSE_PROFILES matches the feature flags in

--- a/internal/orchestrators/compose_test.go
+++ b/internal/orchestrators/compose_test.go
@@ -1,0 +1,30 @@
+package orchestrators
+
+import "testing"
+
+func TestServiceFromContainer(t *testing.T) {
+	tests := []struct {
+		name          string
+		containerName string
+		project       string
+		want          string
+	}{
+		{"standard dash", "myproject-web-1", "myproject", "web"},
+		{"standard underscore", "myproject_web_1", "myproject", "web"},
+		{"multi-part service", "myproject-my-service-1", "myproject", "my-service"},
+		{"numeric suffix", "wiki-db-2", "wiki", "db"},
+		{"no match", "other-web-1", "myproject", "other-web-1"},
+		{"legacy underscore service", "proj_my_service_1", "proj", "my_service"},
+		{"project with hyphen", "my-project-web-1", "my-project", "web"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := serviceFromContainer(tt.containerName, tt.project)
+			if got != tt.want {
+				t.Errorf("serviceFromContainer(%q, %q) = %q, want %q",
+					tt.containerName, tt.project, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Switch `getComposeImages` from parsing the table output of `docker compose images` (which required heuristic container name splitting with nested switch logic) to using `--format json` for structured output
- Extract service name from container name using the known project prefix convention (`{project}-{service}-{number}`) instead of guessing separator positions
- Add `serviceFromContainer` helper with table-driven tests covering dash separators, underscore separators, multi-part service names, and unrecognized formats

Net -13 lines in `compose.go`, +30 lines in new test file.

Fixes an item from #568.