### PR TITLE
Use %w instead of %s/%v for error wrapping

### DIFF
--- a/cmd/maintenance/extension.go
+++ b/cmd/maintenance/extension.go
@@ -111,7 +111,7 @@ func listExtensionsWithMaintenanceWith(orch orchestrators.Orchestrator, inst con
 	for _, id := range wikiIDs {
 		exts, err := getLoadedExtensions(orch, inst.Path, id)
 		if err != nil {
-			return fmt.Errorf("failed to query loaded extensions for wiki %q: %v", id, err)
+			return fmt.Errorf("failed to query loaded extensions for wiki %q: %w", id, err)
 		}
 		for _, ext := range exts {
 			loaded[ext] = true
@@ -168,7 +168,7 @@ func listExtensionScriptsWith(orch orchestrators.Orchestrator, inst config.Insta
 	for _, id := range wikiIDs {
 		exts, err := getLoadedExtensions(orch, inst.Path, id)
 		if err != nil {
-			return fmt.Errorf("failed to query loaded extensions for wiki %q: %v", id, err)
+			return fmt.Errorf("failed to query loaded extensions for wiki %q: %w", id, err)
 		}
 		for _, ext := range exts {
 			if ext == extName {
@@ -235,7 +235,7 @@ func runExtensionScriptWith(orch orchestrators.Orchestrator, inst config.Install
 	// Check that the extension is loaded for the target wiki
 	exts, err := getLoadedExtensions(orch, inst.Path, checkWiki)
 	if err != nil {
-		return fmt.Errorf("failed to query loaded extensions for wiki %q: %v", checkWiki, err)
+		return fmt.Errorf("failed to query loaded extensions for wiki %q: %w", checkWiki, err)
 	}
 	loaded := false
 	for _, ext := range exts {
@@ -273,7 +273,7 @@ func runExtensionScriptWith(orch orchestrators.Orchestrator, inst config.Install
 
 	fmt.Printf("Running %s%s...\n", cleanedScript, wikiMsg)
 	if err := orch.ExecStreaming(inst.Path, orchestrators.ServiceWeb, cmd); err != nil {
-		return fmt.Errorf("%s failed%s: %v", cleanedScript, wikiMsg, err)
+		return fmt.Errorf("%s failed%s: %w", cleanedScript, wikiMsg, err)
 	}
 
 	fmt.Printf("Completed %s%s\n", cleanedScript, wikiMsg)

--- a/cmd/maintenance/maintenanceScript.go
+++ b/cmd/maintenance/maintenanceScript.go
@@ -107,7 +107,7 @@ func runMaintenanceScriptWith(orch orchestrators.Orchestrator, inst config.Insta
 	fmt.Println("Running maintenance script " + cleanedScript)
 	if err := orch.ExecStreaming(inst.Path, orchestrators.ServiceWeb,
 		"php maintenance/"+cleanedScript+wikiFlag); err != nil {
-		return fmt.Errorf("maintenance script failed: %v", err)
+		return fmt.Errorf("maintenance script failed: %w", err)
 	}
 	fmt.Println("Completed running maintenance script")
 	return nil

--- a/cmd/maintenance/maintenanceUpdate.go
+++ b/cmd/maintenance/maintenanceUpdate.go
@@ -85,7 +85,7 @@ func runMaintenanceUpdate(instance config.Installation, wikiID string, skipJobs,
 		fmt.Printf("Running runJobs.php%s...\n", wikiMsg)
 		if err := orch.ExecStreaming(instance.Path, orchestrators.ServiceWeb,
 			"php maintenance/runJobs.php"+wikiFlag); err != nil {
-			return fmt.Errorf("runJobs.php failed%s: %v", wikiMsg, err)
+			return fmt.Errorf("runJobs.php failed%s: %w", wikiMsg, err)
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -358,7 +358,7 @@ func GetConfigDir() (string, error) {
 		// Checks if this is running as root
 		currentUser, err := user.Current()
 		if err != nil {
-			return "", fmt.Errorf("unable to get the current user: %s", err)
+			return "", fmt.Errorf("unable to get the current user: %w", err)
 		}
 
 		if currentUser.Username == "root" {

--- a/internal/devmode/devmode.go
+++ b/internal/devmode/devmode.go
@@ -132,7 +132,7 @@ func ExtractMediaWikiCode(installPath, baseImage string) error {
 	if output, err := cmd.CombinedOutput(); err != nil {
 		// Clean up container on failure
 		_, _ = execute.Run("", "docker", "rm", "-f", containerName)
-		return fmt.Errorf("failed to copy code from container: %s (output: %s)", err, string(output))
+		return fmt.Errorf("failed to copy code from container: %w (output: %s)", err, string(output))
 	}
 
 	// Remove the temporary container

--- a/internal/farmsettings/farmsettings.go
+++ b/internal/farmsettings/farmsettings.go
@@ -133,7 +133,7 @@ func GetWikiIDs(installPath string) ([]string, error) {
 	filePath := filepath.Join(installPath, "config", "wikis.yaml")
 	ids, _, _, err := ReadWikisYaml(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read wikis.yaml: %v", err)
+		return nil, fmt.Errorf("failed to read wikis.yaml: %w", err)
 	}
 	return ids, nil
 }

--- a/internal/maintenance/update.go
+++ b/internal/maintenance/update.go
@@ -22,7 +22,7 @@ func RunUpdatePhp(instance config.Installation, orch orchestrators.Orchestrator,
 	fmt.Printf("Running update.php%s...\n", wikiMsg)
 	if err := orch.ExecStreaming(instance.Path, orchestrators.ServiceWeb,
 		"php maintenance/update.php --quick"+wikiFlag); err != nil {
-		return fmt.Errorf("update.php failed%s: %v", wikiMsg, err)
+		return fmt.Errorf("update.php failed%s: %w", wikiMsg, err)
 	}
 	return nil
 }

--- a/internal/mediawiki/mediawiki.go
+++ b/internal/mediawiki/mediawiki.go
@@ -275,7 +275,7 @@ func RemoveDatabase(installPath, id string, orch orchestrators.Orchestrator) err
 	command := fmt.Sprintf("echo 'DROP DATABASE IF EXISTS %s;' | mariadb -h db -u root -p%s", orchestrators.ShellQuote(id), orchestrators.ShellQuote(envVariables["MYSQL_PASSWORD"]))
 	output, err := orch.ExecWithError(installPath, orchestrators.ServiceDB, command)
 	if err != nil {
-		return fmt.Errorf("error while dropping database '%s': %v. Output: %s", id, err, output)
+		return fmt.Errorf("error while dropping database '%s': %w. Output: %s", id, err, output)
 	}
 
 	return nil

--- a/internal/orchestrators/compose.go
+++ b/internal/orchestrators/compose.go
@@ -59,7 +59,7 @@ func (c *ComposeOrchestrator) CheckDependencies() error {
 	}
 	cmd := composeCommand(compose, "version")
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("docker compose is not available (%s)", err)
+		return fmt.Errorf("docker compose is not available: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- 13 `fmt.Errorf` calls wrapped errors with `%s` or `%v`, which discards the error chain and prevents `errors.Is`/`errors.As` from working
- Switch all to `%w` for proper error wrapping per Go conventions
- 9 files changed, purely mechanical substitution

Fixes an item from #568.