### PR TITLE
Standardize path resolution at command entry points

### DIFF
--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -131,6 +131,13 @@ an existing database dump instead of running the installer.`,
 				fmt.Printf("Generated admin password for wiki '%s'\n", wikiID)
 			}
 
+			// Resolve relative file paths to absolute
+			for _, p := range []*string{&databasePath, &wikiSettingsPath} {
+				if *p != "" && !filepath.IsAbs(*p) {
+					*p = filepath.Join(workingDir, *p)
+				}
+			}
+
 			instance, err = canasta.CheckCanastaID(instance)
 			if err != nil {
 				return err
@@ -148,7 +155,6 @@ an existing database dump instead of running the installer.`,
 				Admin:            admin,
 				AdminPassword:    adminPassword,
 				WikiDBUser:       wikidbuser,
-				WorkingDir:       workingDir,
 			})
 			if err != nil {
 				return err
@@ -187,7 +193,6 @@ type AddWikiOptions struct {
 	Admin            string
 	AdminPassword    string
 	WikiDBUser       string
-	WorkingDir       string
 }
 
 // AddWiki accepts the Canasta instance info, wiki ID, site name, domain and path of the new wiki, database info, and the initial admin info, then creates a new wiki in the Canasta instance.
@@ -241,7 +246,7 @@ func AddWiki(opts AddWikiOptions) error {
 
 	// Copy Settings.php - use custom file if provided, otherwise use template
 	if opts.WikiSettingsPath != "" {
-		err = canasta.CopyWikiSettingFile(opts.Instance.Path, opts.WikiID, opts.WikiSettingsPath, opts.WorkingDir)
+		err = canasta.CopyWikiSettingFile(opts.Instance.Path, opts.WikiID, opts.WikiSettingsPath)
 		if err != nil {
 			return err
 		}

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -93,9 +93,11 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
 				}
 			}
 
-			// Resolve relative database path to absolute (relative to working directory)
-			if databasePath != "" && !filepath.IsAbs(databasePath) {
-				databasePath = filepath.Join(workingDir, databasePath)
+			// Resolve all relative file paths to absolute (relative to working directory)
+			for _, p := range []*string{&databasePath, &envFile, &wikiSettingsPath, &globalSettingsPath, &composerFile, &override} {
+				if *p != "" && !filepath.IsAbs(*p) {
+					*p = filepath.Join(workingDir, *p)
+				}
 			}
 
 			// Always generate database passwords
@@ -114,11 +116,7 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
 			// non-standard HTTPS port, append the port to the default domain
 			// so that wikis.yaml is generated with the correct URL.
 			if !cmd.Flags().Changed("domain-name") && envFile != "" {
-				envFilePath := envFile
-				if !filepath.IsAbs(envFilePath) {
-					envFilePath = filepath.Join(workingDir, envFilePath)
-				}
-				envVars, envErr := canasta.GetEnvVariable(envFilePath)
+				envVars, envErr := canasta.GetEnvVariable(envFile)
 				if envErr != nil {
 					return envErr
 				}
@@ -146,7 +144,6 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
 			if err = createCanasta(createOptions{
 				CanastaInfo:        canastaInfo,
 				Orch:               orch,
-				WorkingDir:         workingDir,
 				Path:               path,
 				WikiID:             wikiID,
 				SiteName:           siteName,
@@ -216,7 +213,6 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
 type createOptions struct {
 	CanastaInfo        canasta.CanastaVariables
 	Orch               orchestrators.Orchestrator
-	WorkingDir         string
 	Path               string
 	WikiID             string
 	SiteName           string
@@ -286,7 +282,7 @@ func createCanasta(opts createOptions) error {
 			return err
 		}
 	}
-	if err := canasta.UpdateEnvFile(opts.EnvFile, path, opts.WorkingDir, opts.CanastaInfo.RootDBPassword, opts.CanastaInfo.WikiDBPassword); err != nil {
+	if err := canasta.UpdateEnvFile(opts.EnvFile, path, opts.CanastaInfo.RootDBPassword, opts.CanastaInfo.WikiDBPassword); err != nil {
 		return err
 	}
 	// Always set CANASTA_IMAGE in .env so the installation is pinned to a
@@ -300,18 +296,18 @@ func createCanasta(opts createOptions) error {
 	}
 	// If custom per-wiki settings file provided, overwrite the Settings.php for this wiki
 	if opts.WikiSettingsPath != "" && opts.WikiID != "" {
-		if err := canasta.CopyWikiSettingFile(path, opts.WikiID, opts.WikiSettingsPath, opts.WorkingDir); err != nil {
+		if err := canasta.CopyWikiSettingFile(path, opts.WikiID, opts.WikiSettingsPath); err != nil {
 			return err
 		}
 	}
 	// If custom global settings file provided, copy to config/settings/
 	if opts.GlobalSettingsPath != "" {
-		if err := canasta.CopyGlobalSettingFile(path, opts.GlobalSettingsPath, opts.WorkingDir); err != nil {
+		if err := canasta.CopyGlobalSettingFile(path, opts.GlobalSettingsPath); err != nil {
 			return err
 		}
 	}
 	if opts.ComposerFile != "" {
-		if err := canasta.CopyComposerFile(path, opts.ComposerFile, opts.WorkingDir); err != nil {
+		if err := canasta.CopyComposerFile(path, opts.ComposerFile); err != nil {
 			return err
 		}
 	}
@@ -358,7 +354,7 @@ func createCanasta(opts createOptions) error {
 		if !ok {
 			return fmt.Errorf("--override is only supported with Docker Compose")
 		}
-		if err := compose.CopyOverrideFile(path, opts.Override, opts.WorkingDir); err != nil {
+		if err := compose.CopyOverrideFile(path, opts.Override); err != nil {
 			return err
 		}
 	}

--- a/cmd/import/import.go
+++ b/cmd/import/import.go
@@ -73,8 +73,15 @@ To create a new wiki from a database dump, use the --database flag with
 				return err
 			}
 
+			// Resolve relative file paths to absolute
+			for _, p := range []*string{&databasePath, &settingsPath} {
+				if *p != "" && !filepath.IsAbs(*p) {
+					*p = filepath.Join(workingDir, *p)
+				}
+			}
+
 			fmt.Printf("Importing database into wiki '%s' in Canasta instance '%s'...\n", wikiID, instance.ID)
-			if err := importDatabase(orch, instance, wikiID, databasePath, settingsPath, workingDir); err != nil {
+			if err := importDatabase(orch, instance, wikiID, databasePath, settingsPath); err != nil {
 				return err
 			}
 			fmt.Println("Done.")
@@ -99,7 +106,7 @@ To create a new wiki from a database dump, use the --database flag with
 	return importCmd
 }
 
-func importDatabase(orch orchestrators.Orchestrator, instance config.Installation, wikiID, databasePath, settingsPath, workingDir string) error {
+func importDatabase(orch orchestrators.Orchestrator, instance config.Installation, wikiID, databasePath, settingsPath string) error {
 	// Read database password from .env
 	envVariables, err := canasta.GetEnvVariable(filepath.Join(instance.Path, ".env"))
 	if err != nil {
@@ -115,7 +122,7 @@ func importDatabase(orch orchestrators.Orchestrator, instance config.Installatio
 
 	// If settings file provided, copy it to the wiki's config directory
 	if settingsPath != "" {
-		err = canasta.CopyWikiSettingFile(instance.Path, wikiID, settingsPath, workingDir)
+		err = canasta.CopyWikiSettingFile(instance.Path, wikiID, settingsPath)
 		if err != nil {
 			return err
 		}

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -143,14 +143,11 @@ func copyTemplate(destPath string, upgrading bool) error {
 // The base .env is provided by the installation template (CopyInstallationTemplate).
 // This function merges any custom env file if provided,
 // and then applies the DB passwords and domain configuration.
-func UpdateEnvFile(customEnvPath, installPath, workingDir, rootDBpass, wikiDBpass string) error {
+func UpdateEnvFile(customEnvPath, installPath, rootDBpass, wikiDBpass string) error {
 	yamlPath := filepath.Join(installPath, "config", "wikis.yaml")
 
 	// If custom env file provided, merge its values
 	if customEnvPath != "" {
-		if !filepath.IsAbs(customEnvPath) {
-			customEnvPath = filepath.Join(workingDir, customEnvPath)
-		}
 		logging.Print(fmt.Sprintf("Merging overrides from %s into %s/.env\n", customEnvPath, installPath))
 
 		// Read custom env file
@@ -286,12 +283,7 @@ func CopySetting(installPath, id string) error {
 
 // CopyWikiSettingFile copies a user-provided Settings.php file to the wiki's config directory
 // Used when importing a wiki with a custom Settings.php
-func CopyWikiSettingFile(installPath, wikiID, settingsFilePath, workingDir string) error {
-	// Make path absolute if it's relative
-	if !filepath.IsAbs(settingsFilePath) {
-		settingsFilePath = filepath.Join(workingDir, settingsFilePath)
-	}
-
+func CopyWikiSettingFile(installPath, wikiID, settingsFilePath string) error {
 	id := NormalizeWikiID(wikiID)
 	dirPath := filepath.Join(installPath, "config", "settings", "wikis", id)
 
@@ -313,12 +305,7 @@ func CopyWikiSettingFile(installPath, wikiID, settingsFilePath, workingDir strin
 
 // CopyGlobalSettingFile copies a user-provided settings file to config/settings/global/ directory
 // The original filename is preserved
-func CopyGlobalSettingFile(installPath, settingsFilePath, workingDir string) error {
-	// Make path absolute if it's relative
-	if !filepath.IsAbs(settingsFilePath) {
-		settingsFilePath = filepath.Join(workingDir, settingsFilePath)
-	}
-
+func CopyGlobalSettingFile(installPath, settingsFilePath string) error {
 	// Get the original filename
 	filename := filepath.Base(settingsFilePath)
 	dirPath := filepath.Join(installPath, "config", "settings", "global")
@@ -611,10 +598,7 @@ func CreateCaddyfileGlobal(installPath string) error {
 }
 
 // CopyComposerFile copies a user-provided composer.local.json to config/composer.local.json.
-func CopyComposerFile(installPath, sourceFilename, workingDir string) error {
-	if !filepath.IsAbs(sourceFilename) {
-		sourceFilename = filepath.Join(workingDir, sourceFilename)
-	}
+func CopyComposerFile(installPath, sourceFilename string) error {
 	destPath := filepath.Join(installPath, "config", "composer.local.json")
 	logging.Print(fmt.Sprintf("Copying %s to %s\n", sourceFilename, destPath))
 	output, err := execute.Run("", "cp", sourceFilename, destPath)

--- a/internal/orchestrators/compose.go
+++ b/internal/orchestrators/compose.go
@@ -403,12 +403,9 @@ func (c *ComposeOrchestrator) RestoreFromBackupVolume(installPath string, dirs m
 	return restoreFromVolume(backupVolumeName(installPath), installPath, dirs)
 }
 
-func (c *ComposeOrchestrator) CopyOverrideFile(installPath, sourceFilename, workingDir string) error {
+func (c *ComposeOrchestrator) CopyOverrideFile(installPath, sourceFilename string) error {
 	if sourceFilename != "" {
 		logging.Print("Copying override file\n")
-		if !filepath.IsAbs(sourceFilename) {
-			sourceFilename = filepath.Join(workingDir, sourceFilename)
-		}
 		var overrideFilename = filepath.Join(installPath, "docker-compose.override.yml")
 		logging.Print(fmt.Sprintf("Copying %s to %s\n", sourceFilename, overrideFilename))
 		output, err := execute.Run("", "cp", sourceFilename, overrideFilename)


### PR DESCRIPTION
## Summary

- Moves relative-to-absolute path resolution from 5 internal functions to the cmd/ layer where the working directory is already known
- Removes the `workingDir` parameter from `UpdateEnvFile`, `CopyWikiSettingFile`, `CopyGlobalSettingFile`, `CopyComposerFile`, and `CopyOverrideFile`
- Removes the `WorkingDir` field from `createOptions` and `AddWikiOptions` structs
- Each command resolves all file paths once at the top of `RunE` using a compact loop

## Details

Previously, relative path resolution was scattered across 5 internal functions, each independently checking `filepath.IsAbs` and joining with a `workingDir` parameter passed down from the command layer. This was inconsistent (some commands resolved paths early, others deep inside called functions) and required threading `workingDir` through option structs.

Now all file paths are resolved to absolute at the command entry point (`RunE`), and internal functions always receive absolute paths.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes

Ref #568