### PR TITLE
Fix backup files owned by root when using local repository

### DIFF
--- a/internal/orchestrators/backup.go
+++ b/internal/orchestrators/backup.go
@@ -62,7 +62,7 @@ func runResticDocker(installPath, envPath, volName string, args ...string) (stri
 		"-v", volName + ":/currentsnapshot",
 	}
 
-	cmdArgs = append(cmdArgs, "restic/restic")
+	cmdArgs = append(cmdArgs, "restic/restic", "--cache-dir", "/tmp/restic-cache")
 	cmdArgs = append(cmdArgs, args...)
 
 	output, err := execute.Run(installPath, cmdArgs[0], cmdArgs[1:]...)
@@ -80,6 +80,7 @@ func runResticDocker(installPath, envPath, volName string, args ...string) (stri
 // "/currentsnapshot/config") to a host path.
 func restoreFromVolume(volName, installPath string, dirs map[string]string) error {
 	cmdArgs := []string{"docker", "run", "--rm",
+		"--user", currentUser(),
 		"-v", volName + ":/currentsnapshot:ro",
 		"-v", installPath + ":/install",
 	}

--- a/internal/orchestrators/compose.go
+++ b/internal/orchestrators/compose.go
@@ -383,11 +383,12 @@ func (c *ComposeOrchestrator) RunBackup(installPath, envPath string, volumes map
 // local repository path. This is Compose-specific since K8s rejects local repos.
 func runResticDockerWithBindMount(installPath, envPath, volName, repoPath string, args ...string) (string, error) {
 	cmdArgs := []string{"docker", "run", "--rm", "-i", "--env-file", envPath,
+		"--user", currentUser(),
 		"-v", volName + ":/currentsnapshot",
 		"-v", repoPath + ":" + repoPath,
 	}
 
-	cmdArgs = append(cmdArgs, "restic/restic")
+	cmdArgs = append(cmdArgs, "restic/restic", "--cache-dir", "/tmp/restic-cache")
 	cmdArgs = append(cmdArgs, args...)
 
 	output, err := execute.Run(installPath, cmdArgs[0], cmdArgs[1:]...)

--- a/internal/orchestrators/orchestrator.go
+++ b/internal/orchestrators/orchestrator.go
@@ -2,12 +2,20 @@ package orchestrators
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
 	"github.com/CanastaWiki/Canasta-CLI/internal/execute"
 	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 )
+
+// currentUser returns "UID:GID" for the current process, used with
+// docker run --user so that files written to bind-mounted host paths
+// are owned by the invoking user rather than root.
+func currentUser() string {
+	return fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid())
+}
 
 // Service name constants for container orchestration.
 const (


### PR DESCRIPTION
## Summary

- Run restic and restore Docker containers as the current user (`--user UID:GID`) instead of root, so files written to host paths are owned by the invoking user
- Use `--cache-dir /tmp/restic-cache` for restic to avoid "unable to open cache" warning when running as non-root

## Details

When `RESTIC_REPOSITORY` points to a local filesystem path, the restic container writes backup repository files via a bind mount. Since the container runs as root, all files end up `root:root` on the host. The same issue affects `restoreFromVolume`, which copies restored files to the host installation directory.

The fix adds `--user UID:GID` (via `os.Getuid()`/`os.Getgid()`) to:
- `runResticDockerWithBindMount` — writes to the local backup repository
- `restoreFromVolume` — writes restored files to the host

`stageToVolume` is intentionally left as root since it writes to a Docker volume (not host paths) and needs root to clean up previous root-owned files in the volume.

**Note:** Users with existing root-owned local backup repositories (created before this fix) will need to `chown -R` them to match their user before using the updated CLI.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] Manual: `canasta backup init` with local `RESTIC_REPOSITORY` — repo files owned by current user
- [x] Manual: `canasta backup create` — snapshot files owned by current user, no cache warning
- [x] Manual: `canasta backup restore` — restored files owned by current user

Ref #578