### PR TITLE
Fix formatting issues in guide docs

### DIFF
--- a/docs/guide/backup.md
+++ b/docs/guide/backup.md
@@ -109,20 +109,20 @@ If the new instance uses a different domain name than the original, you must upd
 
 1. Edit `config/wikis.yaml` and change the `url` field for each wiki to the new domain:
 
-   ```yaml
-   wikis:
-   - id: main
-     url: newdomain.example.com
-     name: main
-   ```
+    ```yaml
+    wikis:
+    - id: main
+      url: newdomain.example.com
+      name: main
+    ```
 
 2. Update the `.env` file to match:
 
-   ```bash
-   canasta config set -i other-instance MW_SITE_SERVER=https://newdomain.example.com MW_SITE_FQDN=newdomain.example.com
-   ```
+    ```bash
+    canasta config set -i other-instance MW_SITE_SERVER=https://newdomain.example.com MW_SITE_FQDN=newdomain.example.com
+    ```
 
-   This also regenerates the Caddyfile and restarts the instance.
+    This also regenerates the Caddyfile and restarts the instance.
 
 ### Inspecting a backup
 

--- a/docs/guide/general-concepts.md
+++ b/docs/guide/general-concepts.md
@@ -37,7 +37,8 @@ For production use, 8 GB or more of total system memory is recommended, especial
 Every Canasta installation has an **installation ID** — a name you choose when creating it with the `-i` flag:
 
 ```bash
-canasta create -i myinstance -w main -n localhost```
+canasta create -i myinstance -w main -n localhost
+```
 
 The installation ID is used to refer to the installation in all subsequent commands:
 
@@ -158,7 +159,7 @@ The `url` field uses `domain/path` format without the protocol. The Caddyfile is
 The `name` field in `wikis.yaml` controls the wiki's display name (`$wgSitename` in MediaWiki). It defaults to the wiki ID if not set. The name is initially set with the `-t` (`--site-name`) flag of `canasta create` or `canasta add`:
 
 ```bash
-canasta create -i myinstance -w docs -n example.com-t "Project Documentation"
+canasta create -i myinstance -w docs -n example.com -t "Project Documentation"
 ```
 
 To change it later, edit the `name` field directly in `config/wikis.yaml`:
@@ -291,19 +292,22 @@ Use this option for fully private wikis where the logo should not be visible to 
 To migrate an existing MediaWiki installation into Canasta, prepare a database dump (`.sql` or `.sql.gz` file) and pass it with the `-d` flag:
 
 ```bash
-canasta create -i myinstance -w main -n localhost -d ./backup.sql.gz```
+canasta create -i myinstance -w main -n localhost -d ./backup.sql.gz
+```
 
 You can also provide a per-wiki settings file and an environment file with password overrides:
 
 ```bash
-canasta create -i myinstance -w main -n localhost -d ./backup.sql.gz -l ./my-settings.php -e ./custom.env```
+canasta create -i myinstance -w main -n localhost -d ./backup.sql.gz -l ./my-settings.php -e ./custom.env
+```
 
 The `-l` flag (`--wiki-settings`) copies the specified file to `config/settings/wikis/{wiki-id}/`, preserving the filename. Use it to bring over custom settings from an existing wiki.
 
 To import a database into an additional wiki in an existing installation, use `canasta add` with the `--database` flag:
 
 ```bash
-canasta add -i myinstance -w docs -u example.com/docs -d ./docs-backup.sql.gz```
+canasta add -i myinstance -w docs -u example.com/docs -d ./docs-backup.sql.gz
+```
 
 See the [CLI Reference](../cli/canasta_create.md) for the full list of flags.
 
@@ -466,7 +470,7 @@ CADDY_AUTO_HTTPS=off
 ```
 
 ```bash
-canasta create -i myinstance -w main -n example.com-e custom.env
+canasta create -i myinstance -w main -n example.com -e custom.env
 ```
 
 This generates a Caddyfile with `http://` site addresses so Caddy listens on port 80 only.
@@ -498,7 +502,7 @@ HTTPS_PORT=8443
 ```
 
 ```bash
-canasta create -i staging -w testwiki -n localhost:8443-e custom.env
+canasta create -i staging -w testwiki -n localhost:8443 -e custom.env
 ```
 
 ### Existing installation
@@ -523,10 +527,10 @@ Each installation must use unique ports. This applies to both Docker Compose and
 # Docker Compose installation on default ports (80/443)
 canasta create -i production -w mainwiki -n localhost
 # Docker Compose installation on custom ports
-canasta create -i staging -w testwiki -n localhost:8443-e custom.env
+canasta create -i staging -w testwiki -n localhost:8443 -e custom.env
 
 # Local Kubernetes installation on different custom ports
-canasta create -o k8s --create-cluster -i dev-k8s -w devwiki -n localhost:9443-e another.env
+canasta create -o k8s --create-cluster -i dev-k8s -w devwiki -n localhost:9443 -e another.env
 ```
 
 Access them at `https://localhost`, `https://localhost:8443`, and `https://localhost:9443`.

--- a/docs/guide/wiki-farms.md
+++ b/docs/guide/wiki-farms.md
@@ -45,7 +45,8 @@ canasta create -i myfarm -w mainwiki -n example.com
 # Add a second wiki at example.com/docs
 canasta add -i myfarm -w docs -u example.com/docs
 # Add a third wiki at example.com/internal
-canasta add -i myfarm -w internal -u example.com/internal```
+canasta add -i myfarm -w internal -u example.com/internal
+```
 
 Users access these at `https://example.com`, `https://example.com/docs`, and `https://example.com/internal`.
 
@@ -54,14 +55,20 @@ Users access these at `https://example.com`, `https://example.com/docs`, and `ht
 Each wiki uses a different subdomain. This requires DNS records pointing each subdomain to your Canasta server. Caddy handles SSL/HTTPS automatically for all configured domains.
 
 ```bash
-canasta create -i myfarm -w mainwiki -n wiki.example.comcanasta add -i myfarm -w docs -u docs.example.comcanasta add -i myfarm -w community -u community.example.com```
+canasta create -i myfarm -w mainwiki -n wiki.example.com
+canasta add -i myfarm -w docs -u docs.example.com
+canasta add -i myfarm -w community -u community.example.com
+```
 
 ### Mixed
 
 You can combine both approaches:
 
 ```bash
-canasta create -i myfarm -w mainwiki -n example.comcanasta add -i myfarm -w docs -u example.com/docscanasta add -i myfarm -w community -u community.example.com```
+canasta create -i myfarm -w mainwiki -n example.com
+canasta add -i myfarm -w docs -u example.com/docs
+canasta add -i myfarm -w community -u community.example.com
+```
 
 ---
 


### PR DESCRIPTION
## Summary

- Fix closing ``` on same line as content in code blocks (general-concepts.md, wiki-farms.md)
- Fix missing spaces before flags in command examples (general-concepts.md)
- Fix multiple commands concatenated on one line (wiki-farms.md)
- Fix numbered list indentation in backup guide (backup.md)

## Test plan

- [ ] Verify code blocks render correctly at https://docs.canasta.wiki/guide/general-concepts/
- [ ] Verify code blocks render correctly at https://docs.canasta.wiki/guide/wiki-farms/
- [ ] Verify numbered list at https://docs.canasta.wiki/guide/backup/#restoring-a-backup-to-a-different-instance