### PR TITLE
Replace shell-based self-update with pure Go (#581)

### DIFF
--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -72,18 +72,9 @@ func downloadAndInstall(latestVersion, execPath string) error {
 		latestVersion, runtime.GOOS, runtime.GOARCH,
 	)
 
-	// Try to create temp file in the same directory as the target binary
-	// (same filesystem enables atomic os.Rename). Fall back to OS temp dir
-	// if the directory isn't writable — sudo mv will handle the final move.
-	dir := filepath.Dir(execPath)
-	tmpFile, err := os.CreateTemp(dir, ".canasta-update-*")
+	tmpFile, err := os.CreateTemp("", ".canasta-update-*")
 	if err != nil {
-		if os.IsPermission(err) {
-			tmpFile, err = os.CreateTemp("", ".canasta-update-*")
-		}
-		if err != nil {
-			return fmt.Errorf("failed to create temp file: %w", err)
-		}
+		return fmt.Errorf("failed to create temp file: %w", err)
 	}
 	tmpPath := tmpFile.Name()
 	defer os.Remove(tmpPath)

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"syscall"
@@ -71,15 +72,18 @@ func downloadAndInstall(latestVersion, execPath string) error {
 		latestVersion, runtime.GOOS, runtime.GOARCH,
 	)
 
-	// Create temp file in the same directory as the target binary
-	// (same filesystem ensures os.Rename is atomic)
+	// Try to create temp file in the same directory as the target binary
+	// (same filesystem enables atomic os.Rename). Fall back to OS temp dir
+	// if the directory isn't writable — sudo mv will handle the final move.
 	dir := filepath.Dir(execPath)
 	tmpFile, err := os.CreateTemp(dir, ".canasta-update-*")
 	if err != nil {
 		if os.IsPermission(err) {
-			return fmt.Errorf("permission denied writing to %s\nTry: sudo canasta upgrade, or fix ownership of the binary directory", dir)
+			tmpFile, err = os.CreateTemp("", ".canasta-update-*")
 		}
-		return fmt.Errorf("failed to create temp file: %w", err)
+		if err != nil {
+			return fmt.Errorf("failed to create temp file: %w", err)
+		}
 	}
 	tmpPath := tmpFile.Name()
 	defer os.Remove(tmpPath)
@@ -110,12 +114,19 @@ func downloadAndInstall(latestVersion, execPath string) error {
 		return fmt.Errorf("failed to set permissions: %w", err)
 	}
 
-	// Atomic replace
-	if err := os.Rename(tmpPath, execPath); err != nil {
-		if os.IsPermission(err) {
-			return fmt.Errorf("permission denied replacing %s\nTry: sudo canasta upgrade, or fix ownership of the binary", execPath)
-		}
-		return fmt.Errorf("failed to replace binary: %w", err)
+	// Try direct rename first (works if same filesystem and user has write access)
+	if err := os.Rename(tmpPath, execPath); err == nil {
+		return nil
+	}
+
+	// Rename failed (permission denied or cross-filesystem) — use sudo mv
+	fmt.Println("Elevated permissions required to update the binary.")
+	cmd := exec.Command("sudo", "mv", tmpPath, execPath)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to move updated binary to %s: %w", execPath, err)
 	}
 
 	return nil

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -7,16 +7,13 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
+	"runtime"
 	"syscall"
 
 	"github.com/CanastaWiki/Canasta-CLI/cmd/version"
 )
 
-const (
-	githubAPIURL = "https://api.github.com/repos/CanastaWiki/Canasta-CLI/releases/latest"
-	installShURL = "https://raw.githubusercontent.com/CanastaWiki/Canasta-CLI/main/install.sh"
-)
+const githubAPIURL = "https://api.github.com/repos/CanastaWiki/Canasta-CLI/releases/latest"
 
 type githubRelease struct {
 	TagName string `json:"tag_name"`
@@ -56,7 +53,7 @@ func CheckAndUpdate() (bool, error) {
 		return false, fmt.Errorf("failed to resolve binary path: %w", err)
 	}
 
-	// Download and run install.sh to update the binary
+	// Download and install the updated binary
 	if err := downloadAndInstall(latestVersion, execPath); err != nil {
 		return false, err
 	}
@@ -68,59 +65,57 @@ func CheckAndUpdate() (bool, error) {
 }
 
 func downloadAndInstall(latestVersion, execPath string) error {
-	// Download install.sh to a temp file
-	tmpFile, err := os.CreateTemp("", "canasta-install-*.sh")
+	// Build download URL for the platform-specific binary
+	url := fmt.Sprintf(
+		"https://github.com/CanastaWiki/Canasta-CLI/releases/download/%s/canasta-%s-%s",
+		latestVersion, runtime.GOOS, runtime.GOARCH,
+	)
+
+	// Create temp file in the same directory as the target binary
+	// (same filesystem ensures os.Rename is atomic)
+	dir := filepath.Dir(execPath)
+	tmpFile, err := os.CreateTemp(dir, ".canasta-update-*")
 	if err != nil {
+		if os.IsPermission(err) {
+			return fmt.Errorf("permission denied writing to %s\nTry: sudo canasta upgrade, or fix ownership of the binary directory", dir)
+		}
 		return fmt.Errorf("failed to create temp file: %w", err)
 	}
-	defer os.Remove(tmpFile.Name())
+	tmpPath := tmpFile.Name()
+	defer os.Remove(tmpPath)
 
-	resp, err := http.Get(installShURL)
+	// URL is constructed from trusted constants and runtime.GOOS/GOARCH
+	//nolint:gosec
+	resp, err := http.Get(url)
 	if err != nil {
-		return fmt.Errorf("failed to download install script: %w", err)
+		return fmt.Errorf("failed to download update: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to download install script: HTTP %d", resp.StatusCode)
+		return fmt.Errorf("failed to download update: HTTP %d from %s", resp.StatusCode, url)
 	}
 
 	if _, err := io.Copy(tmpFile, resp.Body); err != nil {
-		return fmt.Errorf("failed to write install script: %w", err)
+		return fmt.Errorf("failed to write update: %w", err)
 	}
 	tmpFile.Close()
 
-	// Strip "v" prefix for install.sh: "v1.58.0" -> "1.58.0"
-	ver := strings.TrimPrefix(latestVersion, "v")
-
-	// Run install.sh with flags to perform the update
-	// We use a subprocess here rather than exec because we need to continue after
-	bashPath, err := findBash()
+	// Preserve permissions of the existing binary
+	info, err := os.Stat(execPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to stat current binary: %w", err)
+	}
+	if err := os.Chmod(tmpPath, info.Mode()); err != nil {
+		return fmt.Errorf("failed to set permissions: %w", err)
 	}
 
-	// Use os/exec to run the install script
-	cmd := &syscall.ProcAttr{
-		Dir:   "",
-		Env:   os.Environ(),
-		Files: []uintptr{os.Stdin.Fd(), os.Stdout.Fd(), os.Stderr.Fd()},
-	}
-
-	pid, err := syscall.ForkExec(bashPath, []string{"bash", tmpFile.Name(), "-v", ver, "-t", execPath, "--skip-checks"}, cmd)
-	if err != nil {
-		return fmt.Errorf("failed to run install script: %w", err)
-	}
-
-	// Wait for the install script to complete
-	var ws syscall.WaitStatus
-	_, err = syscall.Wait4(pid, &ws, 0, nil)
-	if err != nil {
-		return fmt.Errorf("failed waiting for install script: %w", err)
-	}
-
-	if !ws.Exited() || ws.ExitStatus() != 0 {
-		return fmt.Errorf("install script failed with status %d", ws.ExitStatus())
+	// Atomic replace
+	if err := os.Rename(tmpPath, execPath); err != nil {
+		if os.IsPermission(err) {
+			return fmt.Errorf("permission denied replacing %s\nTry: sudo canasta upgrade, or fix ownership of the binary", execPath)
+		}
+		return fmt.Errorf("failed to replace binary: %w", err)
 	}
 
 	return nil
@@ -132,16 +127,6 @@ func reexec(execPath string) error {
 
 	// Use syscall.Exec to replace this process with the new binary
 	return syscall.Exec(execPath, args, os.Environ())
-}
-
-func findBash() (string, error) {
-	paths := []string{"/bin/bash", "/usr/bin/bash", "/usr/local/bin/bash"}
-	for _, p := range paths {
-		if _, err := os.Stat(p); err == nil {
-			return p, nil
-		}
-	}
-	return "", fmt.Errorf("bash not found")
 }
 
 func getLatestVersion() (string, error) {


### PR DESCRIPTION
## Summary

- Replace `install.sh`/`bash`/`sudo wget` self-update with pure Go: download via `net/http`, then `os.Rename` or `sudo mv`
- Eliminate dependencies on `bash` and `wget` during self-update
- Use `sudo` only for the final move when the binary is in a privileged directory (e.g. `/usr/local/bin`)
- Remove `findBash()` and `installShURL` constant (no longer needed)

## Details

The self-update called `install.sh`, which used `sudo wget` to download the binary to a temp file. This failed for users without `sudo` access (e.g. `mediawiki` service accounts) with a misleading "Permission denied" / "Please use '--list' flag" error.

The new implementation:
1. Downloads the platform-specific binary via `net/http.Get` to the OS temp dir
2. Preserves permissions of the existing binary via `os.Stat`/`os.Chmod`
3. Tries `os.Rename` first (works if same filesystem and user has write access)
4. Falls back to `sudo mv` if rename fails, prompting for a password only when needed

This avoids running the entire upgrade as root (which could cause ownership problems on config files) while still supporting privileged install locations.

`install.sh` is kept for standalone first-time installation.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] Manual: build with a fake old version, run `canasta upgrade`, verify it downloads and replaces the binary
- [x] Manual: test as non-root user with binary in `/usr/local/bin` — verify sudo prompt appears only for the move

Fixes #581