### PR TITLE
Remove unnecessary sudo from wget and chmod in install.sh (#583)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -198,7 +198,7 @@ download_and_install() {
   fi
 
   echo "Downloading Canasta CLI version $VERSION for $platform..."
-  if ! sudo wget -q $WGET_SHOW_PROGRESS "$canasta_url" -O "$tmpfile"; then
+  if ! wget -q $WGET_SHOW_PROGRESS "$canasta_url" -O "$tmpfile"; then
     echo "Platform-specific binary not found. Trying generic binary (backward compatibility)..."
 
     # Fall back to generic binary name for older releases
@@ -208,14 +208,14 @@ download_and_install() {
       canasta_url="https://github.com/CanastaWiki/Canasta-CLI/releases/download/v${VERSION}/canasta"
     fi
 
-    if ! sudo wget -q $WGET_SHOW_PROGRESS "$canasta_url" -O "$tmpfile"; then
+    if ! wget -q $WGET_SHOW_PROGRESS "$canasta_url" -O "$tmpfile"; then
       echo "Download failed. The version you specified might not exist."
       echo "Please use '-l' or '--list' flag to see the available versions or try again."
       exit 1
     fi
   fi
   echo "Download was successful; now installing Canasta CLI."
-  sudo chmod u=rwx,g=xr,o=x "$tmpfile"
+  chmod u=rwx,g=xr,o=x "$tmpfile"
   if ! sudo mv "$tmpfile" "$TARGET"; then
     echo "Installation failed. Please try again."
     exit 1


### PR DESCRIPTION
## Summary

- Remove `sudo` from `wget` calls that download to a user-owned temp file
- Remove `sudo` from `chmod` on the same temp file
- Keep `sudo` only on the final `mv` to the install target (`/usr/local/bin`)

## Details

The temp file is created by `mktemp` and is owned by the current user. `wget` and `chmod` don't need elevated privileges to write to and modify a file the user already owns.

Only the `mv` to the install target needs `sudo`, since the default target is `/usr/local/bin/canasta`.

## Test plan

- [x] Manual: run `install.sh -v 3.4.0 -t /tmp/canasta-install-test`, verify download and installation succeed
- [x] Manual: verify the installed binary has correct permissions

Fixes #583