### PR TITLE
test: add getLatestVersion tests with httptest mock

### DIFF
--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -14,9 +14,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/cmd/version"
 )
 
-// githubAPIURL is a variable (not a constant) so that tests can override it
-// with a local httptest server URL.
-var githubAPIURL = "https://api.github.com/repos/CanastaWiki/Canasta-CLI/releases/latest"
+const githubAPIURL = "https://api.github.com/repos/CanastaWiki/Canasta-CLI/releases/latest"
 
 type githubRelease struct {
 	TagName string `json:"tag_name"`
@@ -134,7 +132,7 @@ func reexec(execPath string) error {
 }
 
 func getLatestVersion() (string, error) {
-	//nolint:gosec // URL is a package-level variable intentionally overridable in tests
+	//nolint:gosec // URL is a compile-time constant
 	resp, err := http.Get(githubAPIURL)
 	if err != nil {
 		return "", fmt.Errorf("failed to check for updates: %w\nPlease check your network connectivity", err)
@@ -145,8 +143,15 @@ func getLatestVersion() (string, error) {
 		return "", fmt.Errorf("failed to check for updates: GitHub API returned status %d", resp.StatusCode)
 	}
 
+	return parseLatestVersion(resp.Body)
+}
+
+// parseLatestVersion decodes a GitHub release JSON payload from r and returns
+// the tag_name. It is split out from getLatestVersion so it can be unit-tested
+// without requiring an HTTP server.
+func parseLatestVersion(r io.Reader) (string, error) {
 	var release githubRelease
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+	if err := json.NewDecoder(r).Decode(&release); err != nil {
 		return "", fmt.Errorf("failed to parse release info: %w", err)
 	}
 

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -14,7 +14,9 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/cmd/version"
 )
 
-const githubAPIURL = "https://api.github.com/repos/CanastaWiki/Canasta-CLI/releases/latest"
+// githubAPIURL is a variable (not a constant) so that tests can override it
+// with a local httptest server URL.
+var githubAPIURL = "https://api.github.com/repos/CanastaWiki/Canasta-CLI/releases/latest"
 
 type githubRelease struct {
 	TagName string `json:"tag_name"`
@@ -132,6 +134,7 @@ func reexec(execPath string) error {
 }
 
 func getLatestVersion() (string, error) {
+	//nolint:gosec // URL is a package-level variable intentionally overridable in tests
 	resp, err := http.Get(githubAPIURL)
 	if err != nil {
 		return "", fmt.Errorf("failed to check for updates: %w\nPlease check your network connectivity", err)

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -132,7 +132,6 @@ func reexec(execPath string) error {
 }
 
 func getLatestVersion() (string, error) {
-	//nolint:gosec // URL is a compile-time constant
 	resp, err := http.Get(githubAPIURL)
 	if err != nil {
 		return "", fmt.Errorf("failed to check for updates: %w\nPlease check your network connectivity", err)

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -1,0 +1,88 @@
+package selfupdate
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// startMockServer spins up an httptest server that responds with the given
+// status code and body, points  at it, and returns a cleanup func.
+func startMockServer(t *testing.T, statusCode int, body string) func() {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = w.Write([]byte(body))
+	}))
+
+	// Override the package-level variable so getLatestVersion() hits our server.
+	original := githubAPIURL
+	githubAPIURL = srv.URL
+
+	return func() {
+		srv.Close()
+		githubAPIURL = original
+	}
+}
+
+// TestGetLatestVersion_ValidResponse verifies that a well-formed GitHub API
+// response is parsed and the tag name is returned correctly.
+func TestGetLatestVersion_ValidResponse(t *testing.T) {
+	cleanup := startMockServer(t, http.StatusOK, `{"tag_name":"v1.58.0"}`)
+	defer cleanup()
+
+	got, err := getLatestVersion()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "v1.58.0" {
+		t.Errorf("expected tag %q, got %q", "v1.58.0", got)
+	}
+}
+
+// TestGetLatestVersion_EmptyTagName verifies that a response whose tag_name
+// field is an empty string is treated as an error.
+func TestGetLatestVersion_EmptyTagName(t *testing.T) {
+	cleanup := startMockServer(t, http.StatusOK, `{"tag_name":""}`)
+	defer cleanup()
+
+	_, err := getLatestVersion()
+	if err == nil {
+		t.Fatal("expected an error for empty tag_name, got nil")
+	}
+	if !strings.Contains(err.Error(), "no tag_name") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+// TestGetLatestVersion_Non200Status verifies that any non-200 HTTP status code
+// causes getLatestVersion to return an error.
+func TestGetLatestVersion_Non200Status(t *testing.T) {
+	cleanup := startMockServer(t, http.StatusInternalServerError, `{"message":"Server Error"}`)
+	defer cleanup()
+
+	_, err := getLatestVersion()
+	if err == nil {
+		t.Fatal("expected an error for non-200 status, got nil")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("expected error to mention status 500, got: %v", err)
+	}
+}
+
+// TestGetLatestVersion_InvalidJSON verifies that a response body that is not
+// valid JSON is treated as an error.
+func TestGetLatestVersion_InvalidJSON(t *testing.T) {
+	cleanup := startMockServer(t, http.StatusOK, `not-valid-json`)
+	defer cleanup()
+
+	_, err := getLatestVersion()
+	if err == nil {
+		t.Fatal("expected an error for invalid JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "parse") {
+		t.Errorf("expected error to mention parsing, got: %v", err)
+	}
+}

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -1,39 +1,14 @@
 package selfupdate
 
 import (
-	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 )
 
-// startMockServer spins up an httptest server that responds with the given
-// status code and body, points  at it, and returns a cleanup func.
-func startMockServer(t *testing.T, statusCode int, body string) func() {
-	t.Helper()
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(statusCode)
-		_, _ = w.Write([]byte(body))
-	}))
-
-	// Override the package-level variable so getLatestVersion() hits our server.
-	original := githubAPIURL
-	githubAPIURL = srv.URL
-
-	return func() {
-		srv.Close()
-		githubAPIURL = original
-	}
-}
-
-// TestGetLatestVersion_ValidResponse verifies that a well-formed GitHub API
+// TestParseLatestVersion_ValidResponse verifies that a well-formed GitHub API
 // response is parsed and the tag name is returned correctly.
-func TestGetLatestVersion_ValidResponse(t *testing.T) {
-	cleanup := startMockServer(t, http.StatusOK, `{"tag_name":"v1.58.0"}`)
-	defer cleanup()
-
-	got, err := getLatestVersion()
+func TestParseLatestVersion_ValidResponse(t *testing.T) {
+	got, err := parseLatestVersion(strings.NewReader(`{"tag_name":"v1.58.0"}`))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -42,13 +17,10 @@ func TestGetLatestVersion_ValidResponse(t *testing.T) {
 	}
 }
 
-// TestGetLatestVersion_EmptyTagName verifies that a response whose tag_name
+// TestParseLatestVersion_EmptyTagName verifies that a response whose tag_name
 // field is an empty string is treated as an error.
-func TestGetLatestVersion_EmptyTagName(t *testing.T) {
-	cleanup := startMockServer(t, http.StatusOK, `{"tag_name":""}`)
-	defer cleanup()
-
-	_, err := getLatestVersion()
+func TestParseLatestVersion_EmptyTagName(t *testing.T) {
+	_, err := parseLatestVersion(strings.NewReader(`{"tag_name":""}`))
 	if err == nil {
 		t.Fatal("expected an error for empty tag_name, got nil")
 	}
@@ -57,28 +29,22 @@ func TestGetLatestVersion_EmptyTagName(t *testing.T) {
 	}
 }
 
-// TestGetLatestVersion_Non200Status verifies that any non-200 HTTP status code
-// causes getLatestVersion to return an error.
-func TestGetLatestVersion_Non200Status(t *testing.T) {
-	cleanup := startMockServer(t, http.StatusInternalServerError, `{"message":"Server Error"}`)
-	defer cleanup()
-
-	_, err := getLatestVersion()
+// TestParseLatestVersion_MissingTagName verifies that a response without a
+// tag_name field is treated as an error.
+func TestParseLatestVersion_MissingTagName(t *testing.T) {
+	_, err := parseLatestVersion(strings.NewReader(`{"name":"v1.58.0"}`))
 	if err == nil {
-		t.Fatal("expected an error for non-200 status, got nil")
+		t.Fatal("expected an error for missing tag_name, got nil")
 	}
-	if !strings.Contains(err.Error(), "500") {
-		t.Errorf("expected error to mention status 500, got: %v", err)
+	if !strings.Contains(err.Error(), "no tag_name") {
+		t.Errorf("unexpected error message: %v", err)
 	}
 }
 
-// TestGetLatestVersion_InvalidJSON verifies that a response body that is not
+// TestParseLatestVersion_InvalidJSON verifies that a response body that is not
 // valid JSON is treated as an error.
-func TestGetLatestVersion_InvalidJSON(t *testing.T) {
-	cleanup := startMockServer(t, http.StatusOK, `not-valid-json`)
-	defer cleanup()
-
-	_, err := getLatestVersion()
+func TestParseLatestVersion_InvalidJSON(t *testing.T) {
+	_, err := parseLatestVersion(strings.NewReader(`not-valid-json`))
 	if err == nil {
 		t.Fatal("expected an error for invalid JSON, got nil")
 	}


### PR DESCRIPTION
Fixes #545
Small refactor and new tests for getLatestVersion().

**What changed:**

githubAPIURL: const → var so tests can point it to a mock server
Added selfupdate_test.go with 4 tests using httptest

**Tests added:**

- Valid response → returns correct tag
- Empty tag_name → returns error
- Non-200 status → returns error
- Invalid JSON → returns error