### PR TITLE
test: add missing unit tests for extensionsskins disable and CheckEnabled

### DIFF
--- a/internal/extensionsskins/extensionsskins_test.go
+++ b/internal/extensionsskins/extensionsskins_test.go
@@ -330,7 +330,10 @@ func TestDisableSkin(t *testing.T) {
 		t.Fatalf("Disable skin: %v", err)
 	}
 
-	cfg, _ := readConfig(configPath(inst.Path, ""))
+	cfg, err := readConfig(configPath(inst.Path, ""))
+	if err != nil {
+		t.Fatalf("readConfig: %v", err)
+	}
 	if slices.Contains(cfg.Skins, "Vector") {
 		t.Error("Vector should be removed from skins")
 	}
@@ -352,7 +355,10 @@ func TestDisablePerWikiExtension(t *testing.T) {
 	}
 
 	// Per-wiki config should have Cite removed but VisualEditor intact.
-	wikiCfg, _ := readConfig(configPath(inst.Path, "docs"))
+	wikiCfg, err := readConfig(configPath(inst.Path, "docs"))
+	if err != nil {
+		t.Fatalf("readConfig: %v", err)
+	}
 	if slices.Contains(wikiCfg.Extensions, "Cite") {
 		t.Error("Cite should be removed from per-wiki config")
 	}

--- a/internal/extensionsskins/extensionsskins_test.go
+++ b/internal/extensionsskins/extensionsskins_test.go
@@ -91,14 +91,16 @@ var skinConstants = Item{
 }
 
 func TestConfigPath(t *testing.T) {
-	got := configPath("/srv/canasta/myinstance", "")
-	want := "/srv/canasta/myinstance/config/settings/global/settings.yaml"
+	base := filepath.Join("/srv", "canasta", "myinstance")
+
+	got := configPath(base, "")
+	want := filepath.Join(base, "config", "settings", "global", "settings.yaml")
 	if got != want {
 		t.Errorf("configPath global = %q, want %q", got, want)
 	}
 
-	got = configPath("/srv/canasta/myinstance", "docs")
-	want = "/srv/canasta/myinstance/config/settings/wikis/docs/settings.yaml"
+	got = configPath(base, "docs")
+	want = filepath.Join(base, "config", "settings", "wikis", "docs", "settings.yaml")
 	if got != want {
 		t.Errorf("configPath per-wiki = %q, want %q", got, want)
 	}
@@ -316,5 +318,69 @@ func TestCheckEnabled(t *testing.T) {
 	_, err = CheckEnabled("Missing", "", inst, extConstants)
 	if err == nil {
 		t.Error("expected error for non-enabled extension")
+	}
+}
+
+func TestDisableSkin(t *testing.T) {
+	inst := newTestInstance(t)
+	_ = Enable("Vector", "", inst, skinConstants)
+	_ = Enable("Timeless", "", inst, skinConstants)
+
+	if err := Disable("Vector", "", inst, skinConstants); err != nil {
+		t.Fatalf("Disable skin: %v", err)
+	}
+
+	cfg, _ := readConfig(configPath(inst.Path, ""))
+	if slices.Contains(cfg.Skins, "Vector") {
+		t.Error("Vector should be removed from skins")
+	}
+	if !slices.Contains(cfg.Skins, "Timeless") {
+		t.Error("Timeless should still be present in skins")
+	}
+	if len(cfg.Extensions) != 0 {
+		t.Errorf("extensions should be unaffected, got %v", cfg.Extensions)
+	}
+}
+
+func TestDisablePerWikiExtension(t *testing.T) {
+	inst := newTestInstance(t)
+	_ = Enable("Cite", "docs", inst, extConstants)
+	_ = Enable("VisualEditor", "docs", inst, extConstants)
+
+	if err := Disable("Cite", "docs", inst, extConstants); err != nil {
+		t.Fatalf("Disable per-wiki extension: %v", err)
+	}
+
+	// Per-wiki config should have Cite removed but VisualEditor intact.
+	wikiCfg, _ := readConfig(configPath(inst.Path, "docs"))
+	if slices.Contains(wikiCfg.Extensions, "Cite") {
+		t.Error("Cite should be removed from per-wiki config")
+	}
+	if !slices.Contains(wikiCfg.Extensions, "VisualEditor") {
+		t.Error("VisualEditor should still be present in per-wiki config")
+	}
+
+	// Global config must not have been created.
+	globalPath := configPath(inst.Path, "")
+	if _, err := os.Stat(globalPath); !os.IsNotExist(err) {
+		t.Error("global config should not exist after per-wiki disable")
+	}
+}
+
+func TestCheckEnabledSkin(t *testing.T) {
+	inst := newTestInstance(t)
+	_ = Enable("Vector", "", inst, skinConstants)
+
+	name, err := CheckEnabled("Vector", "", inst, skinConstants)
+	if err != nil {
+		t.Fatalf("CheckEnabled skin: %v", err)
+	}
+	if name != "Vector" {
+		t.Errorf("expected 'Vector', got %q", name)
+	}
+
+	_, err = CheckEnabled("Timeless", "", inst, skinConstants)
+	if err == nil {
+		t.Error("expected error for non-enabled skin")
 	}
 }


### PR DESCRIPTION
**Description:**

The Canasta CLI lets you enable and disable MediaWiki extensions and skins. While the underlying logic was working correctly, several scenarios had no automated tests covering them:

- Disabling a skin was never tested
- Disabling an extension scoped to a specific wiki was never tested
- Checking whether a skin is enabled was never tested
- Without these tests, a future code change could silently break any of these behaviors without anyone knowing until it hit production.

This PR adds tests for all three missing cases, and also fixes an existing test that used hardcoded Unix-style paths, which caused it to fail on Windows.

**Related issue(s):**

Fixes #541

**Notes for reviewer:**

All 17 tests passing. No changes to production code, test file only.

**Checklist:**
[x] Tested (go test ./internal/extensionsskins/... -v)