### PR TITLE
Add backup purge command with scheduled purge support

### DIFF
--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -67,6 +67,7 @@ and RESTIC_PASSWORD to be configured in the installation's .env file.`,
 	backupCmd.AddCommand(newFilesCmd(&orch, &instance, &envPath, &repoURL))
 	backupCmd.AddCommand(newCheckCmd(&orch, &instance, &envPath, &repoURL))
 	backupCmd.AddCommand(newDiffCmd(&orch, &instance, &envPath, &repoURL))
+	backupCmd.AddCommand(newPurgeCmd(&orch, &instance, &envPath, &repoURL))
 	backupCmd.AddCommand(newScheduleCmd(&instance))
 
 	backupCmd.PersistentFlags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")

--- a/cmd/backup/purge.go
+++ b/cmd/backup/purge.go
@@ -1,0 +1,66 @@
+package backup
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
+)
+
+func newPurgeCmd(orch *orchestrators.Orchestrator, instance *config.Installation, envPath, repoURL *string) *cobra.Command {
+	var (
+		olderThan string
+		keepLast  int
+		dryRun    bool
+	)
+
+	purgeCmd := &cobra.Command{
+		Use:   "purge",
+		Short: "Remove old backups based on retention policy",
+		Long: `Remove backup snapshots that exceed the specified retention policy and
+reclaim disk space. At least one retention flag (--older-than or --keep-last)
+is required.`,
+		Example: `  # Remove backups older than 30 days
+  canasta backup purge -i myinstance --older-than 30d
+
+  # Keep only the 10 most recent backups
+  canasta backup purge -i myinstance --keep-last 10
+
+  # Combine: keep last 5 and anything within 14 days
+  canasta backup purge -i myinstance --older-than 14d --keep-last 5
+
+  # Preview what would be removed
+  canasta backup purge -i myinstance --older-than 30d --dry-run`,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if olderThan == "" && keepLast == 0 {
+				return fmt.Errorf("at least one of --older-than or --keep-last is required")
+			}
+
+			args := []string{"-r", *repoURL, "forget", "--prune"}
+
+			if olderThan != "" {
+				args = append(args, "--keep-within", olderThan)
+			}
+			if keepLast > 0 {
+				args = append(args, "--keep-last", fmt.Sprintf("%d", keepLast))
+			}
+			if dryRun {
+				args = append(args, "--dry-run")
+			}
+
+			output, err := runBackup(*orch, instance.Path, *envPath, nil, args...)
+			if err != nil {
+				return err
+			}
+			fmt.Print(output)
+			return nil
+		},
+	}
+
+	purgeCmd.Flags().StringVar(&olderThan, "older-than", "", "Remove snapshots older than this duration (e.g., 30d, 6m, 1y)")
+	purgeCmd.Flags().IntVar(&keepLast, "keep-last", 0, "Always keep the N most recent snapshots")
+	purgeCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show what would be removed without actually removing")
+	return purgeCmd
+}

--- a/cmd/backup/purge.go
+++ b/cmd/backup/purge.go
@@ -38,7 +38,7 @@ is required.`,
 				return fmt.Errorf("at least one of --older-than or --keep-last is required")
 			}
 
-			args := []string{"-r", *repoURL, "forget", "--prune"}
+			args := []string{"-r", *repoURL, "forget", "--group-by", "paths", "--prune"}
 
 			if olderThan != "" {
 				args = append(args, "--keep-within", olderThan)

--- a/cmd/backup/schedule.go
+++ b/cmd/backup/schedule.go
@@ -267,7 +267,7 @@ func purgeFromLine(line string) string {
 	if len(fields) == 0 {
 		return ""
 	}
-	return fields[0]
+	return strings.Trim(fields[0], "'\"")
 }
 
 func validateCron(cron string) error {

--- a/cmd/backup/schedule.go
+++ b/cmd/backup/schedule.go
@@ -29,23 +29,34 @@ logged to backup.log in the installation directory.`,
 }
 
 func newScheduleSetCmd(instance *config.Installation) *cobra.Command {
-	return &cobra.Command{
+	var purgeOlderThan string
+
+	cmd := &cobra.Command{
 		Use:   "set [cron expression]",
 		Short: "Set a recurring backup schedule",
 		Long: `Schedule recurring backups using a cron expression. This adds or
 updates a crontab entry that runs 'canasta backup create' on the
 specified schedule. Backup output is logged to backup.log in the
-installation directory.`,
+installation directory.
+
+Use --purge-older-than to automatically purge old backups after each
+scheduled backup.`,
 		Example: `  # Schedule daily backups at 2:00 AM
   canasta backup schedule set -i myinstance "0 2 * * *"
 
   # Schedule hourly backups
-  canasta backup schedule set -i myinstance "0 * * * *"`,
+  canasta backup schedule set -i myinstance "0 * * * *"
+
+  # Schedule daily backups and purge anything older than 30 days
+  canasta backup schedule set -i myinstance --purge-older-than 30d "0 2 * * *"`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			return scheduleBackup(*instance, strings.Join(args, " "))
+			return scheduleBackup(*instance, strings.Join(args, " "), purgeOlderThan)
 		},
 	}
+
+	cmd.Flags().StringVar(&purgeOlderThan, "purge-older-than", "", "Purge backups older than this after each scheduled backup (e.g., 30d, 6m)")
+	return cmd
 }
 
 func newScheduleListCmd(instance *config.Installation) *cobra.Command {
@@ -109,7 +120,7 @@ func writeCrontab(lines []string) error {
 	return nil
 }
 
-func scheduleBackup(instance config.Installation, cronExpression string) error {
+func scheduleBackup(instance config.Installation, cronExpression, purgeOlderThan string) error {
 	if err := validateCron(cronExpression); err != nil {
 		return err
 	}
@@ -122,7 +133,11 @@ func scheduleBackup(instance config.Installation, cronExpression string) error {
 	logPath := filepath.Join(instance.Path, "backup.log")
 	quotedLogPath := orchestrators.ShellQuote(logPath)
 	rotateCmd := fmt.Sprintf("find %s -size +10M -exec mv {} %s \\;", quotedLogPath, orchestrators.ShellQuote(logPath+".1"))
-	cmdStr := fmt.Sprintf("%s %s && %s backup create -i %s --tag scheduled-$(date +\\%%Y\\%%m\\%%d\\%%H\\%%M\\%%S) >> %s 2>&1", cronExpression, rotateCmd, executable, instance.ID, quotedLogPath)
+	backupCmd := fmt.Sprintf("%s backup create -i %s --tag scheduled-$(date +\\%%Y\\%%m\\%%d\\%%H\\%%M\\%%S)", executable, instance.ID)
+	if purgeOlderThan != "" {
+		backupCmd += fmt.Sprintf(" && %s backup purge -i %s --older-than %s", executable, instance.ID, orchestrators.ShellQuote(purgeOlderThan))
+	}
+	cmdStr := fmt.Sprintf("%s %s && %s >> %s 2>&1", cronExpression, rotateCmd, backupCmd, quotedLogPath)
 
 	logging.Print(fmt.Sprintf("Scheduling backup with cron: %s", cronExpression))
 
@@ -169,6 +184,9 @@ func listSchedule(instance config.Installation) error {
 	for _, line := range lines {
 		if strings.Contains(line, identifier) {
 			fmt.Printf("Instance '%s' is scheduled for backup at: %s\n", instance.ID, cronFromLine(line))
+			if purge := purgeFromLine(line); purge != "" {
+				fmt.Printf("Auto-purge: snapshots older than %s\n", purge)
+			}
 			return nil
 		}
 	}
@@ -235,6 +253,21 @@ func cronFromLine(line string) string {
 		return strings.Join(fields[:5], " ")
 	}
 	return line
+}
+
+// purgeFromLine extracts the --older-than value from a crontab line, if present.
+func purgeFromLine(line string) string {
+	const flag = "--older-than "
+	idx := strings.Index(line, flag)
+	if idx < 0 {
+		return ""
+	}
+	rest := line[idx+len(flag):]
+	fields := strings.Fields(rest)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
 }
 
 func validateCron(cron string) error {

--- a/docs/guide/backup.md
+++ b/docs/guide/backup.md
@@ -144,6 +144,27 @@ canasta backup diff -i myinstance --snapshot1 abc123 --snapshot2 def456
 canasta backup delete -i myinstance -s abc123
 ```
 
+### Purging old backups
+
+Remove backups that exceed a retention policy:
+
+```bash
+# Remove backups older than 30 days
+canasta backup purge -i myinstance --older-than 30d
+
+# Keep only the 10 most recent backups
+canasta backup purge -i myinstance --keep-last 10
+
+# Combine both: keep last 5 and anything within 14 days
+canasta backup purge -i myinstance --older-than 14d --keep-last 5
+```
+
+Use `--dry-run` to preview what would be removed without actually deleting anything:
+
+```bash
+canasta backup purge -i myinstance --older-than 30d --dry-run
+```
+
 ### Scheduling recurring backups
 
 Set up automatic backups using a cron expression:
@@ -154,6 +175,13 @@ canasta backup schedule set -i myinstance "0 2 * * *"
 
 # Every 6 hours
 canasta backup schedule set -i myinstance "0 */6 * * *"
+```
+
+To automatically purge old backups after each scheduled backup, add `--purge-older-than`:
+
+```bash
+# Daily backups, keeping the last 30 days
+canasta backup schedule set -i myinstance --purge-older-than 30d "0 2 * * *"
 ```
 
 If you reschedule with a new expression, the existing schedule is replaced. To schedule multiple times, combine them in one expression (e.g., `"0 0 * * 2,5"` for Tuesdays and Fridays).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,7 @@ nav:
       - check: cli/canasta_backup_check.md
       - diff: cli/canasta_backup_diff.md
       - unlock: cli/canasta_backup_unlock.md
+      - purge: cli/canasta_backup_purge.md
       - schedule: cli/canasta_backup_schedule.md
     - sitemap:
       - Overview: cli/canasta_sitemap.md


### PR DESCRIPTION
## Summary

- Add `canasta backup purge` command to remove old snapshots by retention policy (`--older-than`, `--keep-last`, `--dry-run`)
- Add `--purge-older-than` flag to `backup schedule set` to auto-purge after each scheduled backup
- `backup schedule list` now shows auto-purge policy when configured
- Use `--group-by paths` so retention policies apply across all snapshots (each backup container gets a unique hostname)

Closes #586

## Test plan

- [x] Run `canasta backup purge -i <id> --older-than 30d --dry-run` and verify it shows what would be removed
- [x] Run `canasta backup purge -i <id> --keep-last 2` and verify only the 2 most recent are kept
- [x] Run `canasta backup purge` with no retention flags and verify it errors
- [x] Run `canasta backup schedule set -i <id> --purge-older-than 30d "0 2 * * *"` and verify crontab includes purge step
- [x] Run `canasta backup schedule list -i <id>` and verify it shows the auto-purge policy
- [x] Run `canasta backup schedule set -i <id> "0 2 * * *"` (without purge) and verify no purge step in crontab