### PR TITLE
fix: preserve commit hash and check for dirty repos before submodule conversion

### DIFF
--- a/cmd/gitops/init.go
+++ b/cmd/gitops/init.go
@@ -118,6 +118,12 @@ func runInitBootstrap(installPath, hostName, role, repoURL, keyFile string, forc
 			strings.Join(dirty, "\n  "))
 	}
 
+	// Remove legacy .gitignore files from extensions/ and skins/ that were
+	// created by the old Canasta-DockerCompose template. These ignore
+	// everything in the directory, which prevents gitops from tracking
+	// extensions and skins.
+	removeLegacyGitignores(installPath)
+
 	fmt.Println("Initializing gitops repository...")
 
 	// 1. Initialize git repo.
@@ -322,6 +328,21 @@ func convertToSubmodules(installPath, dirName string) error {
 		logging.Print(fmt.Sprintf("Converted %s to submodule\n", relativePath))
 	}
 	return nil
+}
+
+// removeLegacyGitignores removes .gitignore files from extensions/ and skins/
+// that were created by the old Canasta-DockerCompose installation template.
+// These files ignore everything except .gitignore itself, which would prevent
+// gitops from tracking extensions and skins.
+func removeLegacyGitignores(installPath string) {
+	for _, dirName := range []string{"extensions", "skins"} {
+		gi := filepath.Join(installPath, dirName, ".gitignore")
+		if _, err := os.Stat(gi); err == nil {
+			if err := os.Remove(gi); err == nil {
+				fmt.Printf("Removed legacy %s/.gitignore\n", dirName)
+			}
+		}
+	}
 }
 
 func getGitRemoteURL(repoPath string) string {

--- a/cmd/gitops/init.go
+++ b/cmd/gitops/init.go
@@ -239,6 +239,8 @@ func runInitBootstrap(installPath, hostName, role, repoURL, keyFile string, forc
 
 // convertToSubmodules scans a directory (e.g., "extensions") for
 // subdirectories that are git repositories and converts them to submodules.
+// Directories with uncommitted changes are skipped. The commit that was
+// checked out is preserved after conversion.
 func convertToSubmodules(installPath, dirName string) error {
 	dir := filepath.Join(installPath, dirName)
 	entries, err := os.ReadDir(dir)
@@ -257,18 +259,41 @@ func convertToSubmodules(installPath, dirName string) error {
 		if _, err := os.Stat(gitDir); os.IsNotExist(err) {
 			continue
 		}
-		remoteURL := getGitRemoteURL(subDir)
-		if remoteURL == "" {
-			logging.Print(fmt.Sprintf("Skipping %s/%s: no remote URL found\n", dirName, entry.Name()))
+		relativePath := filepath.Join(dirName, entry.Name())
+
+		// Skip directories with uncommitted changes.
+		if dirty, err := isDirtyRepo(subDir); err != nil {
+			logging.Print(fmt.Sprintf("Skipping %s: could not check status: %v\n", relativePath, err))
+			continue
+		} else if dirty {
+			logging.Print(fmt.Sprintf("Skipping %s: has uncommitted changes\n", relativePath))
 			continue
 		}
-		relativePath := filepath.Join(dirName, entry.Name())
+
+		remoteURL := getGitRemoteURL(subDir)
+		if remoteURL == "" {
+			logging.Print(fmt.Sprintf("Skipping %s: no remote URL found\n", relativePath))
+			continue
+		}
+
+		// Record the current commit so we can restore it after conversion.
+		commitHash := getHeadCommit(subDir)
+
 		if err := os.RemoveAll(subDir); err != nil {
 			return fmt.Errorf("removing %s: %w", relativePath, err)
 		}
 		if err := gitops.SubmoduleAdd(installPath, remoteURL, relativePath); err != nil {
 			return fmt.Errorf("adding submodule %s: %w", relativePath, err)
 		}
+
+		// Check out the original commit so the submodule is pinned to the
+		// same version the user had, not the remote's default branch.
+		if commitHash != "" {
+			if _, err := execute.Run(subDir, "git", "checkout", commitHash); err != nil {
+				logging.Print(fmt.Sprintf("Warning: could not restore %s to commit %s: %v\n", relativePath, commitHash[:8], err))
+			}
+		}
+
 		logging.Print(fmt.Sprintf("Converted %s to submodule\n", relativePath))
 	}
 	return nil
@@ -276,6 +301,22 @@ func convertToSubmodules(installPath, dirName string) error {
 
 func getGitRemoteURL(repoPath string) string {
 	output, err := execute.Run(repoPath, "git", "remote", "get-url", "origin")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(output)
+}
+
+func isDirtyRepo(repoPath string) (bool, error) {
+	output, err := execute.Run(repoPath, "git", "status", "--porcelain")
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(output) != "", nil
+}
+
+func getHeadCommit(repoPath string) string {
+	output, err := execute.Run(repoPath, "git", "rev-parse", "HEAD")
 	if err != nil {
 		return ""
 	}

--- a/cmd/gitops/init.go
+++ b/cmd/gitops/init.go
@@ -111,6 +111,13 @@ func runInitBootstrap(installPath, hostName, role, repoURL, keyFile string, forc
 			"Use --force to overwrite the remote, or use \"canasta gitops join\" to join an existing repo")
 	}
 
+	// Check for extensions/skins with uncommitted changes before doing any work.
+	if dirty := findDirtyRepos(installPath); len(dirty) > 0 {
+		return fmt.Errorf("the following extensions/skins have uncommitted changes:\n  %s\n"+
+			"Commit or discard the changes, then re-run gitops init",
+			strings.Join(dirty, "\n  "))
+	}
+
 	fmt.Println("Initializing gitops repository...")
 
 	// 1. Initialize git repo.
@@ -237,10 +244,37 @@ func runInitBootstrap(installPath, hostName, role, repoURL, keyFile string, forc
 	return nil
 }
 
+// findDirtyRepos scans extensions/ and skins/ for git repositories with
+// uncommitted changes. Returns a list of relative paths (e.g.,
+// "extensions/Foo") that are dirty.
+func findDirtyRepos(installPath string) []string {
+	var dirty []string
+	for _, dirName := range []string{"extensions", "skins"} {
+		dir := filepath.Join(installPath, dirName)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			subDir := filepath.Join(dir, entry.Name())
+			if _, err := os.Stat(filepath.Join(subDir, ".git")); os.IsNotExist(err) {
+				continue
+			}
+			if isDirty, err := isDirtyRepo(subDir); err == nil && isDirty {
+				dirty = append(dirty, filepath.Join(dirName, entry.Name()))
+			}
+		}
+	}
+	return dirty
+}
+
 // convertToSubmodules scans a directory (e.g., "extensions") for
 // subdirectories that are git repositories and converts them to submodules.
-// Directories with uncommitted changes are skipped. The commit that was
-// checked out is preserved after conversion.
+// The commit that was checked out is preserved after conversion.
+// Callers must check for dirty repos before calling this function.
 func convertToSubmodules(installPath, dirName string) error {
 	dir := filepath.Join(installPath, dirName)
 	entries, err := os.ReadDir(dir)
@@ -260,15 +294,6 @@ func convertToSubmodules(installPath, dirName string) error {
 			continue
 		}
 		relativePath := filepath.Join(dirName, entry.Name())
-
-		// Skip directories with uncommitted changes.
-		if dirty, err := isDirtyRepo(subDir); err != nil {
-			logging.Print(fmt.Sprintf("Skipping %s: could not check status: %v\n", relativePath, err))
-			continue
-		} else if dirty {
-			logging.Print(fmt.Sprintf("Skipping %s: has uncommitted changes\n", relativePath))
-			continue
-		}
 
 		remoteURL := getGitRemoteURL(subDir)
 		if remoteURL == "" {

--- a/docs/guide/gitops.md
+++ b/docs/guide/gitops.md
@@ -91,9 +91,15 @@ If you don't have an installation yet:
 canasta create -i mywiki -w main -n wiki.example.com
 ```
 
-### 2. (Optional) Define custom keys
+### 2. Check for custom secrets
 
-If you use custom environment variables in your PHP settings (e.g., `getenv('MY_API_KEY')`), create a `custom-keys.yaml` file in the installation directory before running init:
+Before initializing gitops, review your `.env` file for any secrets or host-specific values beyond the built-in set. Gitops automatically extracts the following into encrypted per-host variables:
+
+- **Database and MediaWiki secrets:** `MYSQL_PASSWORD`, `WIKI_DB_PASSWORD`, `MW_SECRET_KEY`
+- **Backup credentials:** `RESTIC_REPOSITORY`, `RESTIC_PASSWORD`, and any key starting with `AWS_`, `AZURE_`, `B2_`, `GOOGLE_`, `OS_`, `ST_`, or `RCLONE_`
+- **Host-specific values:** `MW_SITE_SERVER`, `MW_SITE_FQDN`, `HTTP_PORT`, `HTTPS_PORT`
+
+Any `.env` key **not** in this list is committed as a literal value in `env.template`, which is **not encrypted**. If you have additional secrets (e.g., `getenv('MY_API_KEY')` in PHP settings, SMTP credentials), create a `custom-keys.yaml` file in the installation directory before running init:
 
 ```yaml
 keys:
@@ -106,6 +112,8 @@ Then set their values:
 ```bash
 canasta config set -i mywiki MY_API_KEY=... SMTP_PASSWORD=...
 ```
+
+If you don't have any custom secrets beyond the built-in set, you can skip this step.
 
 ### 3. Initialize gitops
 
@@ -168,7 +176,10 @@ At deploy time, `canasta gitops pull` renders the template with the host's vars 
 The following `.env` keys are automatically converted to placeholders:
 
 **Secrets** (differ per host):
-`MYSQL_PASSWORD`, `WIKI_DB_PASSWORD`, `MW_SECRET_KEY`
+`MYSQL_PASSWORD`, `WIKI_DB_PASSWORD`, `MW_SECRET_KEY`, `RESTIC_REPOSITORY`, `RESTIC_PASSWORD`
+
+**Backup backend credentials** (auto-detected by prefix):
+Any key starting with `AWS_`, `AZURE_`, `B2_`, `GOOGLE_`, `OS_`, `ST_`, or `RCLONE_`
 
 **Host-specific values:**
 `MW_SITE_SERVER`, `MW_SITE_FQDN`, `HTTPS_PORT`, `HTTP_PORT`

--- a/docs/guide/gitops.md
+++ b/docs/guide/gitops.md
@@ -31,7 +31,7 @@ The git repository contains:
 - **Environment template** — `env.template` with `{{placeholders}}` for host-specific values
 - **Per-host variables** — `hosts/{name}/vars.yaml` with secrets and host-specific values (encrypted by git-crypt)
 - **Host inventory** — `hosts.yaml` defining all servers and their roles
-- **Extensions and skins** — tracked as git submodules, pinned to specific versions
+- **Extensions and skins** — tracked as git submodules pinned to specific versions, or as regular files for custom extensions without their own repository
 - **Custom files** — `custom/` directory for Dockerfiles, scripts, or other deployment files
 - **Orchestrator overrides** — `docker-compose.override.yml` (if present)
 - **Public assets** — `public_assets/` directory (logos, favicons)
@@ -63,8 +63,8 @@ canasta-config/
 │           └── {wiki-id}/
 │               └── *.php
 ├── custom/                     # user files (Dockerfiles, extra configs, scripts)
-├── extensions/                 # git submodules
-├── skins/                      # git submodules
+├── extensions/                 # git submodules (or regular files for custom extensions)
+├── skins/                      # git submodules (or regular files for custom skins)
 ├── public_assets/
 ├── docker-compose.override.yml # if used
 ├── hosts/                      # per-host variables (encrypted by git-crypt)
@@ -255,7 +255,35 @@ canasta gitops diff -i mywiki
 
 Fetches without applying and shows what files would change.
 
-### Updating an extension
+## Extensions and skins
+
+Extensions and skins that have their own git repositories are tracked as **git submodules**, pinning each one to an exact commit. This ensures every server runs the same version and makes updates explicit and reviewable.
+
+### How init handles extensions and skins
+
+During `canasta gitops init`, the CLI scans the `extensions/` and `skins/` directories. Each subdirectory that contains a `.git` folder is automatically converted to a git submodule using its `origin` remote URL. The original directory is removed and re-added via `git submodule add`.
+
+Subdirectories that are **not** git repositories — such as custom extensions you wrote yourself or copied in without cloning — are left as regular files and committed directly to the repo. They are tracked like any other file, not as submodules. See [Custom extensions](#custom-extensions-without-a-git-repo) below.
+
+If a directory has a `.git` folder but no `origin` remote configured, it is skipped with a warning.
+
+### Adding a new extension or skin
+
+To add a publicly available extension:
+
+```bash
+git submodule add https://github.com/wikimedia/mediawiki-extensions-Cite.git extensions/Cite
+```
+
+Then enable it in the appropriate settings file (e.g., `config/settings/global/extensions.php`), test, and push:
+
+```bash
+canasta gitops push -i mywiki -m "Add Cite extension"
+```
+
+On sink hosts after pulling, run `canasta restart -i mywiki` and then `canasta maintenance update -i mywiki` to run any database migrations.
+
+### Updating an extension or skin
 
 ```bash
 cd extensions/MyExtension
@@ -264,15 +292,53 @@ cd ../..
 canasta gitops push -i mywiki -m "Update MyExtension to v2.0.0"
 ```
 
-On sink hosts after pulling, run `canasta maintenance update` if schema changes are expected.
+The submodule reference in the parent repo now points to the new commit. On sink hosts after pulling, run `canasta maintenance update` if the extension has schema changes.
 
-### Adding a new extension
+### Removing an extension or skin
+
+Remove the submodule and its configuration:
 
 ```bash
-git submodule add https://github.com/org/NewExtension.git extensions/NewExtension
+git submodule deinit -f extensions/MyExtension
+git rm -f extensions/MyExtension
 ```
 
-Add the `wfLoadExtension` call to the appropriate settings file, test, then push.
+Remove the `wfLoadExtension` or `wfLoadSkin` call from the settings file, then push.
+
+### Submodule initialization on new servers
+
+When a new server joins the gitops repo via `canasta gitops join`, or when an existing server runs `canasta gitops pull`, the CLI runs `git submodule update --init --recursive`. This clones all submodule repositories and checks out the exact commits recorded in the repo.
+
+This is necessary because git does not automatically clone submodules when cloning or pulling a repository — the submodule directories would otherwise be empty.
+
+### Converting a cloned extension to a submodule
+
+If you cloned an extension directly with `git clone` rather than adding it as a submodule, you need to convert it before gitops can track it properly. If you haven't run `canasta gitops init` yet, the init command handles this automatically. If gitops is already initialized:
+
+```bash
+# Note the remote URL and current commit
+cd extensions/MyExtension
+git remote get-url origin
+git rev-parse HEAD
+cd ../..
+
+# Remove the cloned directory and re-add as a submodule
+rm -rf extensions/MyExtension
+git submodule add https://github.com/org/MyExtension.git extensions/MyExtension
+
+# Check out the same commit you were on
+cd extensions/MyExtension
+git checkout <commit-hash>
+cd ../..
+
+canasta gitops push -i mywiki -m "Convert MyExtension to submodule"
+```
+
+### Custom extensions without a git repo
+
+Some extensions are custom code that doesn't live in a separate git repository — for example, a small extension you wrote specifically for your wiki. These are committed directly to the gitops repo as regular files, not submodules.
+
+Since they are regular files in the repo, they are automatically synced to all servers on `canasta gitops pull` without any submodule commands. However, they cannot be independently versioned or pinned to a specific commit the way submodules can.
 
 ## Adding a server
 

--- a/internal/gitops/template.go
+++ b/internal/gitops/template.go
@@ -43,7 +43,9 @@ func placeholderName(envKey string) string {
 
 // ExtractTemplate converts the contents of a .env file into an env.template
 // and a VarsMap. Keys listed in placeholderKeys have their values replaced
-// with {{placeholder}} syntax; all other keys are kept as literals.
+// with {{placeholder}} syntax. Keys matching any of the builtinSecretPrefixes
+// are also treated as placeholders automatically. All other keys are kept as
+// literals.
 //
 // The returned VarsMap contains the placeholder-name → original-value mapping.
 func ExtractTemplate(envContent string, placeholderKeys []string) (template string, vars VarsMap) {
@@ -73,7 +75,7 @@ func ExtractTemplate(envContent string, placeholderKeys []string) (template stri
 		key := trimmed[:eqIdx]
 		value := trimmed[eqIdx+1:]
 
-		if keySet[key] {
+		if keySet[key] || hasSecretPrefix(key) {
 			phName := placeholderName(key)
 			vars[phName] = stripQuotes(value)
 			lines = append(lines, key+"={{"+phName+"}}")
@@ -84,6 +86,17 @@ func ExtractTemplate(envContent string, placeholderKeys []string) (template stri
 
 	template = strings.Join(lines, "\n")
 	return template, vars
+}
+
+// hasSecretPrefix returns true if the key matches any of the
+// builtinSecretPrefixes (e.g., AWS_, AZURE_, B2_).
+func hasSecretPrefix(key string) bool {
+	for _, prefix := range builtinSecretPrefixes {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // stripQuotes removes surrounding double quotes from a value, matching the

--- a/internal/gitops/template_test.go
+++ b/internal/gitops/template_test.go
@@ -90,6 +90,46 @@ HTTPS_PORT=443`
 	}
 }
 
+func TestExtractTemplateSecretPrefixes(t *testing.T) {
+	// Test credentials are fake/example values from AWS documentation.
+	//nolint:gosec
+	env := `RESTIC_REPOSITORY=rest:http://repo.example/repo
+RESTIC_PASSWORD=hunter2
+AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+B2_ACCOUNT_ID=abc123
+SOME_LITERAL=hello`
+
+	// Use AllPlaceholderKeys (which includes RESTIC_* as built-in secrets)
+	// with no custom keys. AWS_*/B2_* are caught by prefix detection.
+	tmpl, vars := ExtractTemplate(env, AllPlaceholderKeys(nil))
+
+	// All secret keys should be replaced with placeholders.
+	for _, key := range []string{"restic_repository", "restic_password",
+		"aws_access_key_id", "aws_secret_access_key", "b2_account_id"} {
+		if _, ok := vars[key]; !ok {
+			t.Errorf("expected %s in vars", key)
+		}
+	}
+
+	// Literal should remain.
+	if strings.Contains(tmpl, "{{some_literal}}") {
+		t.Error("SOME_LITERAL should not be a placeholder")
+	}
+	if !strings.Contains(tmpl, "SOME_LITERAL=hello") {
+		t.Error("SOME_LITERAL should remain as a literal")
+	}
+
+	// Verify round-trip.
+	rendered, err := RenderTemplate(tmpl, vars)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rendered != env {
+		t.Errorf("round-trip failed.\ngot:\n%s\nwant:\n%s", rendered, env)
+	}
+}
+
 func TestExtractAndRenderRoundTrip(t *testing.T) {
 	env := `MW_SITE_SERVER=https://wiki.example.com
 MYSQL_PASSWORD=secret123

--- a/internal/gitops/types.go
+++ b/internal/gitops/types.go
@@ -75,6 +75,8 @@ var builtinSecretKeys = []string{
 	"MYSQL_PASSWORD",
 	"WIKI_DB_PASSWORD",
 	"MW_SECRET_KEY",
+	"RESTIC_REPOSITORY",
+	"RESTIC_PASSWORD",
 }
 
 // builtinHostKeys are .env keys whose values are host-specific but not
@@ -84,4 +86,18 @@ var builtinHostKeys = []string{
 	"MW_SITE_FQDN",
 	"HTTPS_PORT",
 	"HTTP_PORT",
+}
+
+// builtinSecretPrefixes are .env key prefixes for backup backend
+// credentials. Any key matching one of these prefixes is automatically
+// treated as a secret placeholder. This matches the prefix list in
+// cmd/config/set.go.
+var builtinSecretPrefixes = []string{
+	"AWS_",
+	"AZURE_",
+	"B2_",
+	"GOOGLE_",
+	"OS_",
+	"ST_",
+	"RCLONE_",
 }


### PR DESCRIPTION
## Summary

- `convertToSubmodules` now fails early when extension/skin directories have uncommitted changes, instead of silently destroying them
- After converting a cloned repo to a submodule, the original commit is checked out so the pinned version is preserved
- Removes legacy `.gitignore` files from `extensions/` and `skins/` that were created by the old Canasta-DockerCompose template (these ignore everything in the directory, preventing gitops from tracking extensions and skins)
- Auto-detects backup credentials (`RESTIC_REPOSITORY`, `RESTIC_PASSWORD`, and keys matching backup backend prefixes like `AWS_*`, `AZURE_*`, `B2_*`) as secret placeholders so they are stored encrypted in per-host `vars.yaml` instead of committed as literals in `env.template`
- Expands the extensions/skins documentation in the gitops guide with sections on adding, updating, removing, submodule initialization on new servers, converting cloned repos, and custom extensions
- Updates the custom keys documentation to list all auto-detected keys and remind users to check for additional secrets before running init

## Related issue(s)

Fixes #594

## Test plan

Tested both old and new behavior:

**Old behavior (main):**
- Dirty extension (uncommitted changes): silently destroyed during conversion
- Extension pinned to a specific commit: commit lost, submodule pointed to remote HEAD instead

**New behavior (this PR):**
- [x] Run `canasta gitops init` with an extension that has uncommitted changes — init fails early with an actionable error listing the dirty directories; no git repo or other artifacts are created
- [x] Run `canasta gitops init` with an extension checked out at a specific commit — submodule is pinned to that exact commit after conversion
- [x] Run `canasta gitops init` with a clean cloned extension — converted to submodule normally
- [x] Run `canasta gitops init` with a custom extension (no `.git` directory) — committed as a regular file
- [x] Run `canasta gitops init` with a legacy `extensions/.gitignore` — file is removed with a visible informational message
- [x] Unit tests verify backup credentials (RESTIC_*, AWS_*, B2_*) are extracted as placeholders and round-trip correctly