### PR TITLE
Remove legacy .gitignore from config/ and config/settings/

### DIFF
--- a/cmd/gitops/init.go
+++ b/cmd/gitops/init.go
@@ -330,12 +330,18 @@ func convertToSubmodules(installPath, dirName string) error {
 	return nil
 }
 
-// removeLegacyGitignores removes .gitignore files from extensions/ and skins/
-// that were created by the old Canasta-DockerCompose installation template.
-// These files ignore everything except .gitignore itself, which would prevent
-// gitops from tracking extensions and skins.
+// removeLegacyGitignores removes .gitignore files left over from the old
+// Canasta-DockerCompose installation template. These files ignore everything
+// except .gitignore itself, which prevents gitops from tracking the contents
+// of these directories.
 func removeLegacyGitignores(installPath string) {
-	for _, dirName := range []string{"extensions", "skins"} {
+	dirs := []string{
+		"extensions",
+		"skins",
+		"config",
+		filepath.Join("config", "settings"),
+	}
+	for _, dirName := range dirs {
 		gi := filepath.Join(installPath, dirName, ".gitignore")
 		if _, err := os.Stat(gi); err == nil {
 			if err := os.Remove(gi); err == nil {


### PR DESCRIPTION
## Summary

- Extends `removeLegacyGitignores` to also clean `config/` and `config/settings/`, not just `extensions/` and `skins/`
- Without this, old Canasta-DockerCompose installations have `.gitignore` files that prevent `gitops init` from tracking PHP settings and configuration files

## Related issue(s)

Fixes #597

## Test plan

- [x] Confirmed that `config/.gitignore` and `config/settings/.gitignore` exist on a production Canasta instance upgraded from the old template
- [x] Run `canasta gitops init` on an installation with these legacy files — both removed with informational messages and `config/settings/` contents are fully tracked