### PR TITLE
fix: update CANASTA_IMAGE during upgrade when version changes

### DIFF
--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -686,9 +686,10 @@ func removeLegacyGitDir(installPath string, dryRun bool) (bool, error) {
 	return true, nil
 }
 
-// backfillCanastaImage sets CANASTA_IMAGE in .env for installations that
-// predate the canasta create change that writes it. Without this variable,
-// docker-compose falls back to the "latest" tag, bypassing version pinning.
+// backfillCanastaImage ensures CANASTA_IMAGE in .env matches the current
+// CLI's default image tag. This handles both installations that predate the
+// CANASTA_IMAGE variable and installations where the CLI was upgraded to a
+// newer version but the image tag was not updated.
 func backfillCanastaImage(installPath string, dryRun bool) (bool, error) {
 	envPath := filepath.Join(installPath, ".env")
 
@@ -696,11 +697,12 @@ func backfillCanastaImage(installPath string, dryRun bool) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if val, ok := envVars["CANASTA_IMAGE"]; ok && val != "" {
-		return false, nil
-	}
 
 	image := canasta.GetDefaultImage()
+
+	if val, ok := envVars["CANASTA_IMAGE"]; ok && val == image {
+		return false, nil
+	}
 
 	if dryRun {
 		fmt.Printf("  Would set CANASTA_IMAGE=%s in .env\n", image)

--- a/cmd/upgrade/upgrade_test.go
+++ b/cmd/upgrade/upgrade_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 )
 
 func TestRemoveSkipBinaryAsHex(t *testing.T) {
@@ -239,8 +241,13 @@ func TestBackfillCanastaImage(t *testing.T) {
 			wantChanged: true,
 		},
 		{
-			name:        "already set",
+			name:        "outdated version",
 			envContent:  "CANASTA_IMAGE=ghcr.io/canastawiki/canasta:3.3.1\nMYSQL_PASSWORD=secret\n",
+			wantChanged: true,
+		},
+		{
+			name:        "already current",
+			envContent:  "CANASTA_IMAGE=" + canasta.GetDefaultImage() + "\nMYSQL_PASSWORD=secret\n",
 			wantChanged: false,
 		},
 		{


### PR DESCRIPTION
## Summary

- `backfillCanastaImage` now compares the current `CANASTA_IMAGE` value against the CLI's default image tag and updates it when they differ
- Previously it only set `CANASTA_IMAGE` if the key was missing entirely, leaving outdated versions unchanged after a CLI upgrade
- Updated existing test case and added a new "already current" test case

## Related issue(s)

Fixes #600

## Test plan

- [x] Unit test: outdated version (`canasta:3.3.1`) is updated to current default
- [x] Unit test: current version is left unchanged (no unnecessary writes)
- [x] Unit test: missing key is still backfilled
- [x] Unit test: empty value is still backfilled
- [x] Unit test: dry run reports change without modifying file