### PR TITLE
fix: gitignore config/backup/ in gitops default template

### DIFF
--- a/cmd/gitops/init.go
+++ b/cmd/gitops/init.go
@@ -351,6 +351,59 @@ func removeLegacyGitignores(installPath string) {
 	}
 }
 
+// requiredGitignoreEntries lists patterns that must be present in the
+// .gitignore of every gitops repo. When new entries are added to the default
+// template, add them here so existing repos get backfilled on next push.
+var requiredGitignoreEntries = []struct {
+	pattern string
+	comment string
+}{
+	{"config/backup/", "# Database dumps created by canasta backup"},
+}
+
+// ensureGitignoreEntries appends any missing required entries to the repo's
+// .gitignore. This backfills repos that were initialized before the entries
+// were added to the default template.
+func ensureGitignoreEntries(installPath string) error {
+	giPath := filepath.Join(installPath, ".gitignore")
+	data, err := os.ReadFile(giPath)
+	if err != nil {
+		return nil // no .gitignore means not a gitops repo
+	}
+	content := string(data)
+	lines := strings.Split(content, "\n")
+
+	var toAdd []struct{ pattern, comment string }
+	for _, req := range requiredGitignoreEntries {
+		found := false
+		for _, line := range lines {
+			if strings.TrimSpace(line) == req.pattern {
+				found = true
+				break
+			}
+		}
+		if !found {
+			toAdd = append(toAdd, req)
+		}
+	}
+
+	if len(toAdd) == 0 {
+		return nil
+	}
+
+	// Ensure trailing newline before appending.
+	if !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+
+	for _, entry := range toAdd {
+		content += "\n" + entry.comment + "\n" + entry.pattern + "\n"
+		fmt.Printf("Added %s to .gitignore\n", entry.pattern)
+	}
+
+	return os.WriteFile(giPath, []byte(content), 0644)
+}
+
 func getGitRemoteURL(repoPath string) string {
 	output, err := execute.Run(repoPath, "git", "remote", "get-url", "origin")
 	if err != nil {

--- a/cmd/gitops/init.go
+++ b/cmd/gitops/init.go
@@ -401,7 +401,20 @@ func ensureGitignoreEntries(installPath string) error {
 		fmt.Printf("Added %s to .gitignore\n", entry.pattern)
 	}
 
-	return os.WriteFile(giPath, []byte(content), 0644)
+	if err := os.WriteFile(giPath, []byte(content), 0644); err != nil {
+		return err
+	}
+
+	// Remove any already-tracked files that are now gitignored.
+	for _, entry := range toAdd {
+		dir := filepath.Join(installPath, strings.TrimSuffix(entry.pattern, "/"))
+		if _, statErr := os.Stat(dir); statErr == nil {
+			// Ignore errors — the path may not be tracked.
+			execute.Run(installPath, "git", "rm", "-r", "--cached", "--quiet", dir)
+		}
+	}
+
+	return nil
 }
 
 func getGitRemoteURL(repoPath string) string {

--- a/cmd/gitops/init.go
+++ b/cmd/gitops/init.go
@@ -409,7 +409,8 @@ func ensureGitignoreEntries(installPath string) error {
 	for _, entry := range toAdd {
 		dir := filepath.Join(installPath, strings.TrimSuffix(entry.pattern, "/"))
 		if _, statErr := os.Stat(dir); statErr == nil {
-			// Ignore errors — the path may not be tracked.
+			// The path may not be tracked, so ignore errors.
+			//nolint:errcheck
 			execute.Run(installPath, "git", "rm", "-r", "--cached", "--quiet", dir)
 		}
 	}

--- a/cmd/gitops/init_test.go
+++ b/cmd/gitops/init_test.go
@@ -1,0 +1,76 @@
+package gitops
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsureGitignoreEntries(t *testing.T) {
+	tests := []struct {
+		name        string
+		initial     string
+		wantAdded   bool
+		wantPattern string
+	}{
+		{
+			name:        "missing entry gets added",
+			initial:     "# existing\n.env\nimages/\n",
+			wantAdded:   true,
+			wantPattern: "config/backup/",
+		},
+		{
+			name:        "entry already present",
+			initial:     ".env\nconfig/backup/\nimages/\n",
+			wantAdded:   false,
+			wantPattern: "config/backup/",
+		},
+		{
+			name:        "no trailing newline",
+			initial:     ".env\nimages/",
+			wantAdded:   true,
+			wantPattern: "config/backup/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			giPath := filepath.Join(tmpDir, ".gitignore")
+			if err := os.WriteFile(giPath, []byte(tt.initial), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := ensureGitignoreEntries(tmpDir); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			got, err := os.ReadFile(giPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			content := string(got)
+
+			if tt.wantAdded {
+				if !strings.Contains(content, tt.wantPattern) {
+					t.Errorf("expected .gitignore to contain %q, got:\n%s", tt.wantPattern, content)
+				}
+			} else {
+				// Count occurrences — should appear exactly once.
+				count := strings.Count(content, tt.wantPattern)
+				if count != 1 {
+					t.Errorf("expected exactly 1 occurrence of %q, got %d in:\n%s", tt.wantPattern, count, content)
+				}
+			}
+		})
+	}
+}
+
+func TestEnsureGitignoreEntriesNoFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	// No .gitignore file — should be a no-op, not an error.
+	if err := ensureGitignoreEntries(tmpDir); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cmd/gitops/push.go
+++ b/cmd/gitops/push.go
@@ -55,6 +55,12 @@ func runPush(installPath, message string) (*gitops.PushResult, error) {
 		return nil, err
 	}
 
+	// Ensure the .gitignore has all required entries (backfill for repos
+	// initialized before new entries were added to the default template).
+	if err := ensureGitignoreEntries(installPath); err != nil {
+		return nil, err
+	}
+
 	if err := gitops.AddAll(installPath); err != nil {
 		return nil, err
 	}

--- a/docs/guide/gitops.md
+++ b/docs/guide/gitops.md
@@ -42,6 +42,7 @@ The git repository contains:
 - `config/admin-password_*` — generated from vars at deploy time
 - `docker-compose.yml` — managed by the Canasta CLI
 - `config/Caddyfile` — auto-generated from wikis.yaml on restart
+- `config/backup/` — database dumps created by `canasta backup`
 - `images/` — uploaded files (covered by `canasta backup`)
 
 ## Repository structure

--- a/internal/gitops/defaults/gitignore
+++ b/internal/gitops/defaults/gitignore
@@ -8,6 +8,9 @@ docker-compose.yml
 # Auto-generated from wikis.yaml on restart
 config/Caddyfile
 
+# Database dumps created by canasta backup
+config/backup/
+
 # Uploaded files (use canasta backup)
 images/
 


### PR DESCRIPTION
## Summary

- Add `config/backup/` to the default gitops `.gitignore` template
- Update gitops documentation to list `config/backup/` in the "What is NOT tracked" section
- Backfill existing repos: `canasta gitops push` checks for missing required gitignore entries, appends them, and runs `git rm --cached` to untrack any already-committed files

`canasta backup create` stores temporary database dumps in `config/backup/`. These are cleaned up after the backup completes, but if a backup fails partway through, the dumps persist. Without a gitignore entry, `canasta gitops init` will commit these potentially multi-GB files to the repository.

Fixes #602

## Test plan

- [x] Verify `config/backup/` is present in the default gitignore template
- [x] Verify gitops documentation lists `config/backup/` in "What is NOT tracked"
- [x] Simulate existing repo without `config/backup/` in `.gitignore` — backfill adds the entry on push
- [x] Verify `git rm --cached` untracks already-committed backup files while preserving them on disk
- [x] Verify backfill is idempotent (second run is a no-op)
- [x] Verify no error when `.gitignore` is missing (non-gitops repo)
- [x] Unit tests pass for `ensureGitignoreEntries`
- [x] Full test suite passes
- [x] Linter passes
- [x] Backup code paths unchanged — no risk to `canasta backup create/restore`