### PR TITLE
Add git-crypt and git config to CI integration workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,6 +15,8 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: '1.25'
+    - name: Install git-crypt
+      run: sudo apt-get update && sudo apt-get install -y git-crypt
     - name: Add runner to www-data group
       # Canasta containers run as www-data, so bind-mounted directories
       # (e.g. config/) become owned by that group. The host user must be

--- a/tests/integration/gitops_test.go
+++ b/tests/integration/gitops_test.go
@@ -15,6 +15,10 @@ import (
 // bare repository (no SSH/credentials needed), makes a configuration change,
 // pushes it, and verifies the commit appears in the remote.
 func TestGitops_InitAndPush(t *testing.T) {
+	if _, err := exec.LookPath("git-crypt"); err != nil {
+		t.Skip("git-crypt not installed, skipping gitops test")
+	}
+
 	inst := createTestInstance(t, "inttest-gitops")
 
 	// Create a bare git repo to use as the remote

--- a/tests/integration/gitops_test.go
+++ b/tests/integration/gitops_test.go
@@ -15,10 +15,6 @@ import (
 // bare repository (no SSH/credentials needed), makes a configuration change,
 // pushes it, and verifies the commit appears in the remote.
 func TestGitops_InitAndPush(t *testing.T) {
-	if _, err := exec.LookPath("git-crypt"); err != nil {
-		t.Skip("git-crypt not installed, skipping gitops test")
-	}
-
 	inst := createTestInstance(t, "inttest-gitops")
 
 	// Create a bare git repo to use as the remote


### PR DESCRIPTION
## Summary

- Installs `git-crypt` in the integration workflow (required by gitops test)
- Configures `git user.name`/`user.email` in CI (required for git commit in gitops init)
- Adds `t.Skip` guard to gitops test when `git-crypt` is unavailable

Note: the underlying code issues are fixed separately in #630 (git config check) and #631 (backup restore overwrite). This PR ensures the CI environment has the necessary tools and config.

## Test plan

- [ ] Integration workflow runs without git-crypt/git-config errors
- [ ] All integration tests pass

Fixes the failure in https://github.com/CanastaWiki/Canasta-CLI/actions/runs/22927260846