### PR TITLE
Check git user.name and user.email before gitops operations

### DIFF
--- a/internal/gitops/prereqs.go
+++ b/internal/gitops/prereqs.go
@@ -3,10 +3,12 @@ package gitops
 import (
 	"fmt"
 	"strings"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/execute"
 )
 
-// CheckPrereqs verifies that required external tools are installed.
-// If needGH is true, it also checks for the GitHub CLI.
+// CheckPrereqs verifies that required external tools and configuration
+// are present. If needGH is true, it also checks for the GitHub CLI.
 func CheckPrereqs(needGH bool) error {
 	var missing []string
 
@@ -20,6 +22,36 @@ func CheckPrereqs(needGH bool) error {
 
 	if len(missing) > 0 {
 		return fmt.Errorf("missing required tools:\n  - %s", strings.Join(missing, "\n  - "))
+	}
+
+	if err := checkGitConfig(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// checkGitConfig verifies that git user.name and user.email are configured.
+// These are required for git commit, which gitops init and push use.
+func checkGitConfig() error {
+	var missing []string
+
+	name, err := execute.Run("", "git", "config", "user.name")
+	if err != nil || strings.TrimSpace(name) == "" {
+		missing = append(missing, "user.name")
+	}
+
+	email, err := execute.Run("", "git", "config", "user.email")
+	if err != nil || strings.TrimSpace(email) == "" {
+		missing = append(missing, "user.email")
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("git %s must be configured before using gitops.\n"+
+			"Run:\n"+
+			"  git config --global user.name \"Your Name\"\n"+
+			"  git config --global user.email \"you@example.com\"",
+			strings.Join(missing, " and "))
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Adds an upfront check in `CheckPrereqs` for `git config user.name` and `user.email`
- Gives a clear error message with the exact commands to run if either is missing
- Without this, `gitops init` fails with a cryptic `git commit: exit status 128`

## Test plan

- [ ] Unset git user.name/email, run `canasta gitops init` — verify clear error message
- [ ] Set them back, run `canasta gitops init` — verify it proceeds normally

Fixes #628