### PR TITLE
Add git user config to CI integration workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,6 +17,10 @@ jobs:
         go-version: '1.25'
     - name: Install git-crypt
       run: sudo apt-get update && sudo apt-get install -y git-crypt
+    - name: Configure git for CI
+      run: |
+        git config --global user.name "CI"
+        git config --global user.email "ci@canasta.wiki"
     - name: Add runner to www-data group
       # Canasta containers run as www-data, so bind-mounted directories
       # (e.g. config/) become owned by that group. The host user must be


### PR DESCRIPTION
## Summary

- Adds `git config --global user.name` and `user.email` to the CI integration workflow (required by gitops test, which runs `git commit`)
- Fixes gitops test bare repo to use `main` as default branch (matching what gitops pushes to), instead of `master`

## Test plan

- [ ] Gitops integration test passes in CI
- [ ] All other integration tests unaffected