### PR TITLE
Fix gitops test: use main as bare repo default branch

### DIFF
--- a/tests/integration/gitops_test.go
+++ b/tests/integration/gitops_test.go
@@ -19,7 +19,7 @@ func TestGitops_InitAndPush(t *testing.T) {
 
 	// Create a bare git repo to use as the remote
 	bareRepo := t.TempDir()
-	if out, err := exec.Command("git", "init", "--bare", bareRepo).CombinedOutput(); err != nil {
+	if out, err := exec.Command("git", "init", "--bare", "-b", "main", bareRepo).CombinedOutput(); err != nil {
 		t.Fatalf("git init --bare failed: %v\n%s", err, out)
 	}
 


### PR DESCRIPTION
## Summary

- Changes `git init --bare` to `git init --bare -b main` in the gitops integration test
- The bare repo defaults to `master` on some systems (including the CI runner), but gitops pushes to `main`
- The `git log` verification step failed because HEAD pointed to the empty `master` branch

## Test plan

- [ ] `TestGitops_InitAndPush` passes in CI