### PR TITLE
Fix gitops status truncating modified file paths

### DIFF
--- a/internal/gitops/git.go
+++ b/internal/gitops/git.go
@@ -154,7 +154,9 @@ func HasUncommittedChanges(path string) (bool, []string, error) {
 	if err != nil {
 		return false, nil, fmt.Errorf("git status: %w", err)
 	}
-	output = strings.TrimSpace(output)
+	// Trim only trailing whitespace — leading spaces are significant
+	// in porcelain format (e.g. " M file" means unstaged modification).
+	output = strings.TrimRight(output, " \t\n\r")
 	if output == "" {
 		return false, nil, nil
 	}

--- a/internal/gitops/git.go
+++ b/internal/gitops/git.go
@@ -160,16 +160,14 @@ func HasUncommittedChanges(path string) (bool, []string, error) {
 	}
 	var files []string
 	for _, line := range strings.Split(output, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
+		if len(line) < 4 {
 			continue
 		}
-		// porcelain format: "XY filename"
-		if len(line) > 3 {
-			files = append(files, line[3:])
-		} else {
-			files = append(files, line)
-		}
+		// porcelain format: "XY filename" where XY is a 2-char
+		// status code followed by a space — always 3 characters.
+		// Do not trim leading spaces: the first status character
+		// may itself be a space (e.g. " M file").
+		files = append(files, line[3:])
 	}
 	return true, files, nil
 }

--- a/internal/gitops/git_test.go
+++ b/internal/gitops/git_test.go
@@ -1,0 +1,41 @@
+package gitops
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParsePorcelainLines(t *testing.T) {
+	// Simulate git status --porcelain output with mixed status codes.
+	// " M" = modified but unstaged, "??" = untracked, "M " = staged.
+	porcelain := strings.Join([]string{
+		" M config/.smw.json",
+		" M extensions/wikivisor/SkinSettings.php",
+		"?? extensions/wikivisor/skins/chameleon/old.custom.scss",
+		"M  extensions/wikivisor/skins/chameleon/custom.scss",
+	}, "\n")
+
+	want := []string{
+		"config/.smw.json",
+		"extensions/wikivisor/SkinSettings.php",
+		"extensions/wikivisor/skins/chameleon/old.custom.scss",
+		"extensions/wikivisor/skins/chameleon/custom.scss",
+	}
+
+	var files []string
+	for _, line := range strings.Split(porcelain, "\n") {
+		if len(line) < 4 {
+			continue
+		}
+		files = append(files, line[3:])
+	}
+
+	if len(files) != len(want) {
+		t.Fatalf("got %d files, want %d", len(files), len(want))
+	}
+	for i, f := range files {
+		if f != want[i] {
+			t.Errorf("file[%d] = %q, want %q", i, f, want[i])
+		}
+	}
+}

--- a/internal/gitops/git_test.go
+++ b/internal/gitops/git_test.go
@@ -22,6 +22,10 @@ func TestParsePorcelainLines(t *testing.T) {
 		"extensions/wikivisor/skins/chameleon/custom.scss",
 	}
 
+	// Use TrimRight (not TrimSpace) to preserve leading spaces in
+	// the first line's status code.
+	porcelain = strings.TrimRight(porcelain, " \t\n\r")
+
 	var files []string
 	for _, line := range strings.Split(porcelain, "\n") {
 		if len(line) < 4 {
@@ -37,5 +41,25 @@ func TestParsePorcelainLines(t *testing.T) {
 		if f != want[i] {
 			t.Errorf("file[%d] = %q, want %q", i, f, want[i])
 		}
+	}
+}
+
+func TestParsePorcelainLeadingSpacePreserved(t *testing.T) {
+	// Regression test: when the first line starts with " M" (unstaged
+	// modification), TrimSpace on the whole output would strip the
+	// leading space, causing line[3:] to clip the first path character.
+	porcelain := " M config/.smw.json\n?? extensions/newfile\n"
+
+	trimmed := strings.TrimRight(porcelain, " \t\n\r")
+	lines := strings.Split(trimmed, "\n")
+
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+	if got := lines[0][3:]; got != "config/.smw.json" {
+		t.Errorf("first file = %q, want %q", got, "config/.smw.json")
+	}
+	if got := lines[1][3:]; got != "extensions/newfile" {
+		t.Errorf("second file = %q, want %q", got, "extensions/newfile")
 	}
 }


### PR DESCRIPTION
## Summary

- Fix `HasUncommittedChanges` stripping the first character from modified file paths in `canasta gitops status` output (e.g. `onfig/.smw.json` instead of `config/.smw.json`)
- Two bugs: per-line `TrimSpace` removed the leading space from ` M` status codes, and whole-output `TrimSpace` also stripped it from the first line
- Replace `TrimSpace` with `TrimRight` for the whole output, remove per-line trimming entirely
- Add unit tests covering porcelain line parsing and leading-space preservation

Fixes #635

## Test plan

- [x] Run `canasta gitops status` on an instance with both unstaged modifications and untracked files
- [x] Verify all file paths are displayed correctly with no truncation
- [x] `go test ./internal/gitops/` passes
- [x] Local integration test with registered Canasta instance confirms ` M config/.smw.json` displays as `config/.smw.json`