### PR TITLE
Add gitops add and rm commands

### DIFF
--- a/cmd/gitops/add.go
+++ b/cmd/gitops/add.go
@@ -1,0 +1,34 @@
+package gitops
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/gitops"
+)
+
+func newAddCmd(instance *config.Installation) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add [files...]",
+		Short: "Stage files for the next gitops push",
+		Long: `Explicitly stage files to be included in the next gitops push.
+Only staged files will be committed when you run gitops push.`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runAdd(instance.Path, args)
+		},
+	}
+	return cmd
+}
+
+func runAdd(installPath string, files []string) error {
+	if err := gitops.Add(installPath, files...); err != nil {
+		return err
+	}
+	for _, f := range files {
+		fmt.Printf("Staged: %s\n", f)
+	}
+	return nil
+}

--- a/cmd/gitops/gitops.go
+++ b/cmd/gitops/gitops.go
@@ -35,6 +35,8 @@ git-crypt, and multi-server deployments with push/pull workflows.`,
 
 	gitopsCmd.AddCommand(newInitCmd(&instance))
 	gitopsCmd.AddCommand(newJoinCmd(&instance))
+	gitopsCmd.AddCommand(newAddCmd(&instance))
+	gitopsCmd.AddCommand(newRmCmd(&instance))
 	gitopsCmd.AddCommand(newPushCmd(&instance))
 	gitopsCmd.AddCommand(newPullCmd(&instance))
 	gitopsCmd.AddCommand(newStatusCmd(&instance))

--- a/cmd/gitops/push.go
+++ b/cmd/gitops/push.go
@@ -19,9 +19,10 @@ func newPushCmd(instance *config.Installation) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "push",
 		Short: "Push configuration changes to the git repository",
-		Long: `Stage all tracked configuration changes, commit, and push to the remote
-repository. When pull_requests is enabled in hosts.yaml, creates a branch
-and opens a pull request instead of pushing directly to main.`,
+		Long: `Commit staged changes and push to the remote repository. Files must be
+staged first using "canasta gitops add". When pull_requests is enabled in
+hosts.yaml, creates a branch and opens a pull request instead of pushing
+directly to main.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			result, err := runPush(instance.Path, message)
 			if err != nil {
@@ -61,15 +62,11 @@ func runPush(installPath, message string) (*gitops.PushResult, error) {
 		return nil, err
 	}
 
-	if err := gitops.AddAll(installPath); err != nil {
-		return nil, err
-	}
-
-	hasChanges, files, err := gitops.HasUncommittedChanges(installPath)
+	hasStaged, files, err := gitops.HasStagedChanges(installPath)
 	if err != nil {
 		return nil, err
 	}
-	if !hasChanges {
+	if !hasStaged {
 		return &gitops.PushResult{NoChanges: true}, nil
 	}
 

--- a/cmd/gitops/rm.go
+++ b/cmd/gitops/rm.go
@@ -1,0 +1,34 @@
+package gitops
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/gitops"
+)
+
+func newRmCmd(instance *config.Installation) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rm [files...]",
+		Short: "Remove files from the gitops repository",
+		Long: `Remove tracked files from the gitops repository. The removal is staged
+for the next gitops push.`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runRm(instance.Path, args)
+		},
+	}
+	return cmd
+}
+
+func runRm(installPath string, files []string) error {
+	if err := gitops.Remove(installPath, files...); err != nil {
+		return err
+	}
+	for _, f := range files {
+		fmt.Printf("Removed: %s\n", f)
+	}
+	return nil
+}

--- a/cmd/gitops/status.go
+++ b/cmd/gitops/status.go
@@ -49,16 +49,25 @@ func runStatus(installPath string) error {
 		fmt.Printf("Last applied:   %s\n", gitops.ShortHash(applied))
 	}
 
+	// Staged changes.
+	hasStaged, stagedFiles, err := gitops.HasStagedChanges(installPath)
+	if err == nil && hasStaged {
+		fmt.Printf("\nStaged for push (%d files):\n", len(stagedFiles))
+		for _, f := range stagedFiles {
+			fmt.Printf("  %s\n", f)
+		}
+	}
+
 	// Uncommitted changes.
 	hasChanges, files, err := gitops.HasUncommittedChanges(installPath)
 	if err == nil {
 		if hasChanges {
-			fmt.Printf("\nUncommitted changes (%d files):\n", len(files))
+			fmt.Printf("\nUnstaged changes (%d files):\n", len(files))
 			for _, f := range files {
 				fmt.Printf("  %s\n", f)
 			}
-		} else {
-			fmt.Println("\nNo uncommitted changes.")
+		} else if !hasStaged {
+			fmt.Println("\nNo changes.")
 		}
 	}
 

--- a/docs/guide/gitops.md
+++ b/docs/guide/gitops.md
@@ -4,7 +4,7 @@ Canasta supports git-based configuration management through the `canasta gitops`
 
 ## Overview
 
-In the simplest case, a single server uses gitops purely for version-controlled configuration backup — every change is committed and pushed to a remote repository. No pull requests, no multi-server coordination — just `canasta gitops push` after making changes.
+In the simplest case, a single server uses gitops purely for version-controlled configuration backup — every change is committed and pushed to a remote repository. No pull requests, no multi-server coordination — just `canasta gitops add` and `canasta gitops push` after making changes.
 
 The same architecture extends to multi-server deployments. Changes are made on a source server, tested, pushed to the repo with an optional pull request for peer review, and then pulled onto production servers.
 
@@ -251,10 +251,20 @@ The `pull_requests` setting controls how `canasta gitops push` behaves:
 
 1. Edit the settings file
 2. Test the change
-3. Push:
+3. Stage and push:
 
 ```bash
+canasta gitops add -i mywiki config/settings/global/MySettings.php
 canasta gitops push -i mywiki -m "Enable VisualEditor by default"
+```
+
+### Removing a file
+
+To remove a tracked file from the repository:
+
+```bash
+canasta gitops rm -i mywiki config/settings/global/OldSettings.php
+canasta gitops push -i mywiki -m "Remove obsolete settings file"
 ```
 
 If pull requests are enabled, review and merge the PR. Then on sink hosts:
@@ -299,9 +309,10 @@ To add a publicly available extension:
 git submodule add https://github.com/wikimedia/mediawiki-extensions-Cite.git extensions/Cite
 ```
 
-Then enable it in the appropriate settings file (e.g., `config/settings/global/extensions.php`), test, and push:
+Then enable it in the appropriate settings file (e.g., `config/settings/global/extensions.php`), test, stage, and push:
 
 ```bash
+canasta gitops add -i mywiki extensions/Cite config/settings/global/extensions.php
 canasta gitops push -i mywiki -m "Add Cite extension"
 ```
 
@@ -313,6 +324,7 @@ On sink hosts after pulling, run `canasta restart -i mywiki` and then `canasta m
 cd extensions/MyExtension
 git fetch && git checkout v2.0.0
 cd ../..
+canasta gitops add -i mywiki extensions/MyExtension
 canasta gitops push -i mywiki -m "Update MyExtension to v2.0.0"
 ```
 
@@ -355,6 +367,7 @@ cd extensions/MyExtension
 git checkout <commit-hash>
 cd ../..
 
+canasta gitops add -i mywiki extensions/MyExtension .gitmodules
 canasta gitops push -i mywiki -m "Convert MyExtension to submodule"
 ```
 
@@ -458,13 +471,13 @@ Each team member and server has its own GPG key. Access is granted per-identity 
 **Single server or small team** (pull requests disabled):
 
 ```
-[server] → edit & test → canasta gitops push → [git repo]
+[server] → edit & test → canasta gitops add → canasta gitops push → [git repo]
 ```
 
 **Multi-server with review** (pull requests enabled):
 
 ```
-[source] → edit & test → canasta gitops push → [PR] → review & merge → canasta gitops pull → [sink hosts]
+[source] → edit & test → canasta gitops add → canasta gitops push → [PR] → review & merge → canasta gitops pull → [sink hosts]
 ```
 
 ## Further reading

--- a/internal/gitops/git.go
+++ b/internal/gitops/git.go
@@ -179,7 +179,9 @@ func HasUncommittedChanges(path string) (bool, []string, error) {
 	if err != nil {
 		return false, nil, fmt.Errorf("git status: %w", err)
 	}
-	output = strings.TrimSpace(output)
+	// Trim only trailing whitespace — leading spaces are significant
+	// in porcelain format (e.g. " M file" means unstaged modification).
+	output = strings.TrimRight(output, " \t\n\r")
 	if output == "" {
 		return false, nil, nil
 	}

--- a/internal/gitops/git.go
+++ b/internal/gitops/git.go
@@ -160,16 +160,14 @@ func HasUncommittedChanges(path string) (bool, []string, error) {
 	}
 	var files []string
 	for _, line := range strings.Split(output, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
+		if len(line) < 4 {
 			continue
 		}
-		// porcelain format: "XY filename"
-		if len(line) > 3 {
-			files = append(files, line[3:])
-		} else {
-			files = append(files, line)
-		}
+		// porcelain format: "XY filename" where XY is a 2-char
+		// status code followed by a space — always 3 characters.
+		// Do not trim leading spaces: the first status character
+		// may itself be a space (e.g. " M file").
+		files = append(files, line[3:])
 	}
 	return true, files, nil
 }

--- a/internal/gitops/git.go
+++ b/internal/gitops/git.go
@@ -96,6 +96,31 @@ func AddAll(path string) error {
 	return nil
 }
 
+// Remove stages the removal of files from the repository.
+func Remove(path string, files ...string) error {
+	args := append([]string{"rm", "-r"}, files...)
+	_, err := execute.Run(path, "git", args...)
+	if err != nil {
+		return fmt.Errorf("git rm: %w", err)
+	}
+	return nil
+}
+
+// HasStagedChanges checks whether the index has staged changes ready to
+// commit. Returns true if there are staged changes, along with a list of
+// staged file paths.
+func HasStagedChanges(path string) (bool, []string, error) {
+	output, err := execute.Run(path, "git", "diff", "--cached", "--name-only")
+	if err != nil {
+		return false, nil, fmt.Errorf("git diff --cached: %w", err)
+	}
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return false, nil, nil
+	}
+	return true, strings.Split(output, "\n"), nil
+}
+
 // Commit creates a commit with the given message. Returns the short
 // commit hash.
 func Commit(path, message string) (string, error) {

--- a/internal/gitops/git_test.go
+++ b/internal/gitops/git_test.go
@@ -1,0 +1,41 @@
+package gitops
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParsePorcelainLines(t *testing.T) {
+	// Simulate git status --porcelain output with mixed status codes.
+	// " M" = modified but unstaged, "??" = untracked, "M " = staged.
+	porcelain := strings.Join([]string{
+		" M config/.smw.json",
+		" M extensions/wikivisor/SkinSettings.php",
+		"?? extensions/wikivisor/skins/chameleon/old.custom.scss",
+		"M  extensions/wikivisor/skins/chameleon/custom.scss",
+	}, "\n")
+
+	want := []string{
+		"config/.smw.json",
+		"extensions/wikivisor/SkinSettings.php",
+		"extensions/wikivisor/skins/chameleon/old.custom.scss",
+		"extensions/wikivisor/skins/chameleon/custom.scss",
+	}
+
+	var files []string
+	for _, line := range strings.Split(porcelain, "\n") {
+		if len(line) < 4 {
+			continue
+		}
+		files = append(files, line[3:])
+	}
+
+	if len(files) != len(want) {
+		t.Fatalf("got %d files, want %d", len(files), len(want))
+	}
+	for i, f := range files {
+		if f != want[i] {
+			t.Errorf("file[%d] = %q, want %q", i, f, want[i])
+		}
+	}
+}

--- a/internal/gitops/git_test.go
+++ b/internal/gitops/git_test.go
@@ -22,6 +22,10 @@ func TestParsePorcelainLines(t *testing.T) {
 		"extensions/wikivisor/skins/chameleon/custom.scss",
 	}
 
+	// Use TrimRight (not TrimSpace) to preserve leading spaces in
+	// the first line's status code.
+	porcelain = strings.TrimRight(porcelain, " \t\n\r")
+
 	var files []string
 	for _, line := range strings.Split(porcelain, "\n") {
 		if len(line) < 4 {
@@ -37,5 +41,25 @@ func TestParsePorcelainLines(t *testing.T) {
 		if f != want[i] {
 			t.Errorf("file[%d] = %q, want %q", i, f, want[i])
 		}
+	}
+}
+
+func TestParsePorcelainLeadingSpacePreserved(t *testing.T) {
+	// Regression test: when the first line starts with " M" (unstaged
+	// modification), TrimSpace on the whole output would strip the
+	// leading space, causing line[3:] to clip the first path character.
+	porcelain := " M config/.smw.json\n?? extensions/newfile\n"
+
+	trimmed := strings.TrimRight(porcelain, " \t\n\r")
+	lines := strings.Split(trimmed, "\n")
+
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+	if got := lines[0][3:]; got != "config/.smw.json" {
+		t.Errorf("first file = %q, want %q", got, "config/.smw.json")
+	}
+	if got := lines[1][3:]; got != "extensions/newfile" {
+		t.Errorf("second file = %q, want %q", got, "extensions/newfile")
 	}
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,8 @@ nav:
     - gitops:
       - Overview: cli/canasta_gitops.md
       - init: cli/canasta_gitops_init.md
+      - add: cli/canasta_gitops_add.md
+      - rm: cli/canasta_gitops_rm.md
       - push: cli/canasta_gitops_push.md
       - pull: cli/canasta_gitops_pull.md
       - status: cli/canasta_gitops_status.md


### PR DESCRIPTION
## Summary

- Add `canasta gitops add` to explicitly stage files for the next push
- Add `canasta gitops rm` to stage file removals
- Change `gitops push` to only commit explicitly staged files instead of running `git add -A`, which could commit unintended files
- Update `gitops status` to show staged and unstaged changes separately
- Update docs and mkdocs nav

Fixes #637

## Test plan

- [x] Run `canasta gitops add <file>` and verify file is staged
- [x] Run `canasta gitops rm <file>` and verify file removal is staged
- [x] Run `canasta gitops push` with no staged files — reports nothing to push
- [x] Run `canasta gitops push` after staging — commits only staged files
- [x] Run `canasta gitops status` and verify it shows staged and unstaged separately
- [x] Verify untracked files are NOT auto-committed by push
- [x] Local integration test with registered Canasta instance passes all scenarios