### PR TITLE
test(gitops): add unit tests for repairBrokenSubmodules

### DIFF
--- a/cmd/gitops/init_test.go
+++ b/cmd/gitops/init_test.go
@@ -1,7 +1,10 @@
 package gitops
 
 import (
+	"bytes"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -73,4 +76,173 @@ func TestEnsureGitignoreEntriesNoFile(t *testing.T) {
 	if err := ensureGitignoreEntries(tmpDir); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+}
+
+func TestRepairBrokenSubmodules(t *testing.T) {
+	t.Setenv("GIT_ALLOW_PROTOCOL", "file")
+
+	t.Run("broken submodule repaired", func(t *testing.T) {
+		repoPath, _ := setupBrokenSubmoduleRepo(t, false)
+
+		repaired, err := repairBrokenSubmodules(repoPath)
+		if err != nil {
+			t.Fatalf("repairBrokenSubmodules returned error: %v", err)
+		}
+		if repaired != 1 {
+			t.Fatalf("expected 1 repaired submodule, got %d", repaired)
+		}
+
+		runGit(t, repoPath, "add", "-A")
+		runGit(t, repoPath, "commit", "-m", "repair submodule")
+
+		lsTree := runGit(t, repoPath, "ls-tree", "HEAD", "extensions/Foo")
+		if !strings.HasPrefix(lsTree, "160000") {
+			t.Fatalf("expected repaired submodule to be gitlink (160000), got: %q", lsTree)
+		}
+	})
+
+	t.Run("healthy submodule unchanged", func(t *testing.T) {
+		repoPath := t.TempDir()
+		remotePath := createGitRepoWithCommit(t, t.TempDir(), "submodule")
+
+		initGitRepo(t, repoPath)
+		runGit(t, repoPath, "submodule", "add", remotePath, "extensions/Foo")
+		runGit(t, repoPath, "commit", "-am", "add healthy submodule")
+
+		repaired, err := repairBrokenSubmodules(repoPath)
+		if err != nil {
+			t.Fatalf("repairBrokenSubmodules returned error: %v", err)
+		}
+		if repaired != 0 {
+			t.Fatalf("expected 0 repaired submodules, got %d", repaired)
+		}
+	})
+
+	t.Run("no gitmodules file", func(t *testing.T) {
+		repoPath := t.TempDir()
+		repaired, err := repairBrokenSubmodules(repoPath)
+		if err != nil {
+			t.Fatalf("repairBrokenSubmodules returned error: %v", err)
+		}
+		if repaired != 0 {
+			t.Fatalf("expected 0 repaired submodules, got %d", repaired)
+		}
+	})
+
+	t.Run("empty gitmodules", func(t *testing.T) {
+		repoPath := t.TempDir()
+		if err := os.WriteFile(filepath.Join(repoPath, ".gitmodules"), []byte(""), 0644); err != nil {
+			t.Fatalf("writing empty .gitmodules: %v", err)
+		}
+
+		repaired, err := repairBrokenSubmodules(repoPath)
+		if err != nil {
+			t.Fatalf("repairBrokenSubmodules returned error: %v", err)
+		}
+		if repaired != 0 {
+			t.Fatalf("expected 0 repaired submodules, got %d", repaired)
+		}
+	})
+
+	t.Run("broken gitlink file removed", func(t *testing.T) {
+		repoPath, brokenGitFile := setupBrokenSubmoduleRepo(t, true)
+
+		repaired, err := repairBrokenSubmodules(repoPath)
+		if err != nil {
+			t.Fatalf("repairBrokenSubmodules returned error: %v", err)
+		}
+		if repaired != 1 {
+			t.Fatalf("expected 1 repaired submodule, got %d", repaired)
+		}
+
+		content, err := os.ReadFile(brokenGitFile)
+		if err != nil {
+			t.Fatalf("reading post-repair .git file: %v", err)
+		}
+		if strings.Contains(string(content), "broken-gitlink-marker") {
+			t.Fatalf("expected stale gitlink file content to be removed, got: %q", string(content))
+		}
+	})
+}
+
+func setupBrokenSubmoduleRepo(t *testing.T, withBrokenGitFile bool) (string, string) {
+	t.Helper()
+
+	repoPath := t.TempDir()
+	remotePath := createGitRepoWithCommit(t, t.TempDir(), "submodule")
+	modulePath := filepath.Join(repoPath, "extensions", "Foo")
+
+	initGitRepo(t, repoPath)
+	if err := os.MkdirAll(modulePath, 0755); err != nil {
+		t.Fatalf("creating extension dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(modulePath, "README.md"), []byte("broken tree\n"), 0644); err != nil {
+		t.Fatalf("writing extension file: %v", err)
+	}
+	writeGitmodules(t, repoPath, "extensions/Foo", remotePath)
+
+	brokenGitFile := filepath.Join(modulePath, ".git")
+	if withBrokenGitFile {
+		if err := os.WriteFile(brokenGitFile, []byte("broken-gitlink-marker\n"), 0644); err != nil {
+			t.Fatalf("writing broken .git file: %v", err)
+		}
+	}
+
+	runGit(t, repoPath, "add", "-A")
+	if withBrokenGitFile {
+		runGit(t, repoPath, "commit", "-m", "broken submodule with stale gitlink file")
+	} else {
+		runGit(t, repoPath, "commit", "-m", "broken submodule committed as tree")
+	}
+
+	return repoPath, brokenGitFile
+}
+
+func writeGitmodules(t *testing.T, repoPath, submodulePath, submoduleURL string) {
+	t.Helper()
+	content := fmt.Sprintf(`[submodule "%s"]
+	path = %s
+	url = %s
+`, submodulePath, submodulePath, submoduleURL)
+	if err := os.WriteFile(filepath.Join(repoPath, ".gitmodules"), []byte(content), 0644); err != nil {
+		t.Fatalf("writing .gitmodules: %v", err)
+	}
+}
+
+func createGitRepoWithCommit(t *testing.T, repoPath, fileStem string) string {
+	t.Helper()
+	initGitRepo(t, repoPath)
+	file := fileStem + ".txt"
+	if err := os.WriteFile(filepath.Join(repoPath, file), []byte("content\n"), 0644); err != nil {
+		t.Fatalf("writing seed file: %v", err)
+	}
+	runGit(t, repoPath, "add", file)
+	runGit(t, repoPath, "commit", "-m", "initial commit")
+	return repoPath
+}
+
+func initGitRepo(t *testing.T, repoPath string) {
+	t.Helper()
+	runGit(t, repoPath, "init", "-b", "main")
+	runGit(t, repoPath, "config", "user.email", "test@example.com")
+	runGit(t, repoPath, "config", "user.name", "Test User")
+	runGit(t, repoPath, "config", "protocol.file.allow", "always")
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, out.String(), stderr.String())
+	}
+	return strings.TrimSpace(out.String())
 }

--- a/cmd/gitops/init_test.go
+++ b/cmd/gitops/init_test.go
@@ -79,7 +79,7 @@ func TestRepairBrokenSubmodules(t *testing.T) {
 	t.Setenv("GIT_ALLOW_PROTOCOL", "file")
 
 	t.Run("broken submodule repaired", func(t *testing.T) {
-		repoPath, _ := setupBrokenSubmoduleRepo(t, false)
+		repoPath := setupBrokenSubmoduleRepo(t, false)
 
 		repaired, err := repairBrokenSubmodules(repoPath)
 		if err != nil {
@@ -140,7 +140,7 @@ func TestRepairBrokenSubmodules(t *testing.T) {
 	})
 
 	t.Run("broken gitlink file removed", func(t *testing.T) {
-		repoPath, _ := setupBrokenSubmoduleRepo(t, true)
+		repoPath := setupBrokenSubmoduleRepo(t, true)
 
 		repaired, err := repairBrokenSubmodules(repoPath)
 		if err != nil {

--- a/cmd/gitops/init_test.go
+++ b/cmd/gitops/init_test.go
@@ -1,10 +1,7 @@
 package gitops
 
 import (
-	"bytes"
-	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -92,12 +89,10 @@ func TestRepairBrokenSubmodules(t *testing.T) {
 			t.Fatalf("expected 1 repaired submodule, got %d", repaired)
 		}
 
-		runGit(t, repoPath, "add", "-A")
-		runGit(t, repoPath, "commit", "-m", "repair submodule")
-
-		lsTree := runGit(t, repoPath, "ls-tree", "HEAD", "extensions/Foo")
-		if !strings.HasPrefix(lsTree, "160000") {
-			t.Fatalf("expected repaired submodule to be gitlink (160000), got: %q", lsTree)
+		// index already has 160000 after submodule add, no commit needed
+		staged := runGit(t, repoPath, "ls-files", "--stage", "extensions/Foo")
+		if !strings.HasPrefix(staged, "160000") {
+			t.Fatalf("expected staged submodule to be gitlink (160000), got: %q", staged)
 		}
 	})
 
@@ -145,7 +140,7 @@ func TestRepairBrokenSubmodules(t *testing.T) {
 	})
 
 	t.Run("broken gitlink file removed", func(t *testing.T) {
-		repoPath, brokenGitFile := setupBrokenSubmoduleRepo(t, true)
+		repoPath, _ := setupBrokenSubmoduleRepo(t, true)
 
 		repaired, err := repairBrokenSubmodules(repoPath)
 		if err != nil {
@@ -155,94 +150,9 @@ func TestRepairBrokenSubmodules(t *testing.T) {
 			t.Fatalf("expected 1 repaired submodule, got %d", repaired)
 		}
 
-		content, err := os.ReadFile(brokenGitFile)
-		if err != nil {
-			t.Fatalf("reading post-repair .git file: %v", err)
-		}
-		if strings.Contains(string(content), "broken-gitlink-marker") {
-			t.Fatalf("expected stale gitlink file content to be removed, got: %q", string(content))
+		staged := runGit(t, repoPath, "ls-files", "--stage", "extensions/Foo")
+		if !strings.HasPrefix(staged, "160000") {
+			t.Fatalf("expected repaired submodule to be gitlink (160000), got: %q", staged)
 		}
 	})
-}
-
-func setupBrokenSubmoduleRepo(t *testing.T, withBrokenGitFile bool) (string, string) {
-	t.Helper()
-
-	repoPath := t.TempDir()
-	remotePath := createGitRepoWithCommit(t, t.TempDir(), "submodule")
-	modulePath := filepath.Join(repoPath, "extensions", "Foo")
-
-	initGitRepo(t, repoPath)
-	if err := os.MkdirAll(modulePath, 0755); err != nil {
-		t.Fatalf("creating extension dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(modulePath, "README.md"), []byte("broken tree\n"), 0644); err != nil {
-		t.Fatalf("writing extension file: %v", err)
-	}
-	writeGitmodules(t, repoPath, "extensions/Foo", remotePath)
-
-	brokenGitFile := filepath.Join(modulePath, ".git")
-	if withBrokenGitFile {
-		if err := os.WriteFile(brokenGitFile, []byte("broken-gitlink-marker\n"), 0644); err != nil {
-			t.Fatalf("writing broken .git file: %v", err)
-		}
-	}
-
-	runGit(t, repoPath, "add", "-A")
-	if withBrokenGitFile {
-		runGit(t, repoPath, "commit", "-m", "broken submodule with stale gitlink file")
-	} else {
-		runGit(t, repoPath, "commit", "-m", "broken submodule committed as tree")
-	}
-
-	return repoPath, brokenGitFile
-}
-
-func writeGitmodules(t *testing.T, repoPath, submodulePath, submoduleURL string) {
-	t.Helper()
-	content := fmt.Sprintf(`[submodule "%s"]
-	path = %s
-	url = %s
-`, submodulePath, submodulePath, submoduleURL)
-	if err := os.WriteFile(filepath.Join(repoPath, ".gitmodules"), []byte(content), 0644); err != nil {
-		t.Fatalf("writing .gitmodules: %v", err)
-	}
-}
-
-func createGitRepoWithCommit(t *testing.T, repoPath, fileStem string) string {
-	t.Helper()
-	initGitRepo(t, repoPath)
-	file := fileStem + ".txt"
-	if err := os.WriteFile(filepath.Join(repoPath, file), []byte("content\n"), 0644); err != nil {
-		t.Fatalf("writing seed file: %v", err)
-	}
-	runGit(t, repoPath, "add", file)
-	runGit(t, repoPath, "commit", "-m", "initial commit")
-	return repoPath
-}
-
-func initGitRepo(t *testing.T, repoPath string) {
-	t.Helper()
-	runGit(t, repoPath, "init", "-b", "main")
-	runGit(t, repoPath, "config", "user.email", "test@example.com")
-	runGit(t, repoPath, "config", "user.name", "Test User")
-	runGit(t, repoPath, "config", "protocol.file.allow", "always")
-}
-
-func runGit(t *testing.T, dir string, args ...string) string {
-	t.Helper()
-
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
-
-	var out bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
-
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("git %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, out.String(), stderr.String())
-	}
-	return strings.TrimSpace(out.String())
 }

--- a/cmd/gitops/testutil_test.go
+++ b/cmd/gitops/testutil_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func setupBrokenSubmoduleRepo(t *testing.T, withBrokenGitFile bool) (string, string) {
+func setupBrokenSubmoduleRepo(t *testing.T, withBrokenGitFile bool) string {
 	t.Helper()
 
 	repoPath := t.TempDir()
@@ -40,7 +40,7 @@ func setupBrokenSubmoduleRepo(t *testing.T, withBrokenGitFile bool) (string, str
 		runGit(t, repoPath, "commit", "-m", "broken submodule committed as tree")
 	}
 
-	return repoPath, brokenGitFile
+	return repoPath
 }
 
 func writeGitmodules(t *testing.T, repoPath, submodulePath, submoduleURL string) {

--- a/cmd/gitops/testutil_test.go
+++ b/cmd/gitops/testutil_test.go
@@ -1,0 +1,93 @@
+package gitops
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func setupBrokenSubmoduleRepo(t *testing.T, withBrokenGitFile bool) (string, string) {
+	t.Helper()
+
+	repoPath := t.TempDir()
+	remotePath := createGitRepoWithCommit(t, t.TempDir(), "submodule")
+	modulePath := filepath.Join(repoPath, "extensions", "Foo")
+
+	initGitRepo(t, repoPath)
+	if err := os.MkdirAll(modulePath, 0755); err != nil {
+		t.Fatalf("creating extension dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(modulePath, "README.md"), []byte("broken tree\n"), 0644); err != nil {
+		t.Fatalf("writing extension file: %v", err)
+	}
+	writeGitmodules(t, repoPath, "extensions/Foo", remotePath)
+
+	brokenGitFile := filepath.Join(modulePath, ".git")
+	if withBrokenGitFile {
+		if err := os.WriteFile(brokenGitFile, []byte("broken-gitlink-marker\n"), 0644); err != nil {
+			t.Fatalf("writing broken .git file: %v", err)
+		}
+	}
+
+	runGit(t, repoPath, "add", "-A")
+	if withBrokenGitFile {
+		runGit(t, repoPath, "commit", "-m", "broken submodule with stale gitlink file")
+	} else {
+		runGit(t, repoPath, "commit", "-m", "broken submodule committed as tree")
+	}
+
+	return repoPath, brokenGitFile
+}
+
+func writeGitmodules(t *testing.T, repoPath, submodulePath, submoduleURL string) {
+	t.Helper()
+	content := fmt.Sprintf(`[submodule "%s"]
+	path = %s
+	url = %s
+`, submodulePath, submodulePath, submoduleURL)
+	if err := os.WriteFile(filepath.Join(repoPath, ".gitmodules"), []byte(content), 0644); err != nil {
+		t.Fatalf("writing .gitmodules: %v", err)
+	}
+}
+
+func createGitRepoWithCommit(t *testing.T, repoPath, fileStem string) string {
+	t.Helper()
+	initGitRepo(t, repoPath)
+	file := fileStem + ".txt"
+	if err := os.WriteFile(filepath.Join(repoPath, file), []byte("content\n"), 0644); err != nil {
+		t.Fatalf("writing seed file: %v", err)
+	}
+	runGit(t, repoPath, "add", file)
+	runGit(t, repoPath, "commit", "-m", "initial commit")
+	return repoPath
+}
+
+func initGitRepo(t *testing.T, repoPath string) {
+	t.Helper()
+	runGit(t, repoPath, "init", "-b", "main")
+	runGit(t, repoPath, "config", "user.email", "test@example.com")
+	runGit(t, repoPath, "config", "user.name", "Test User")
+	runGit(t, repoPath, "config", "protocol.file.allow", "always")
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), err, out.String(), stderr.String())
+	}
+	return strings.TrimSpace(out.String())
+}


### PR DESCRIPTION
## Summary
Adds unit test coverage for repairBrokenSubmodules in cmd/gitops/init_test.go.

## Whats done
- broken submodule committed as a tree is repaired
- healthy submodule is unchanged
- missing .gitmodules returns 0 with no error
- empty .gitmodules returns 0 with no error
- broken gitlink file case is repaired correctly

## Notes
- verifies repaired submodules via git index mode (160000)
- moves git test helpers into cmd/gitops/testutil_test.go for reuse

Reference: #608