### PR TITLE
Fix gitops integration test to stage files before push

### DIFF
--- a/tests/integration/gitops_test.go
+++ b/tests/integration/gitops_test.go
@@ -84,7 +84,12 @@ func TestGitops_InitAndPush(t *testing.T) {
 		t.Fatalf("failed to write test settings file: %v", err)
 	}
 
-	// Push the change
+	// Stage and push the change
+	out, err = inst.run(t, "gitops", "add", "-i", inst.ID, "config/settings/global/GitopsTest.php")
+	if err != nil {
+		t.Fatalf("gitops add failed: %v\n%s", err, out)
+	}
+
 	out, err = inst.run(t, "gitops", "push", "-i", inst.ID, "-m", "Add test settings file")
 	if err != nil {
 		t.Fatalf("gitops push failed: %v\n%s", err, out)


### PR DESCRIPTION
## Summary

- Add `gitops add` call before `gitops push` in `TestGitops_InitAndPush`
- After #638 changed push to only commit explicitly staged files, the test needs to stage files first

Fixes #640

## Test plan

- [x] Unit tests pass locally
- [ ] Integration test `TestGitops_InitAndPush` passes in CI