### PR TITLE
Add wikis.yaml templating for gitops

### DIFF
--- a/cmd/gitops/init.go
+++ b/cmd/gitops/init.go
@@ -184,7 +184,25 @@ func runInitBootstrap(installPath, hostName, role, repoURL, keyFile string, forc
 		return err
 	}
 
-	// 6. Read admin passwords and add to vars.
+	// 6. Extract wikis.yaml template.
+	wikisContent, err := gitops.LoadWikisYAML(installPath)
+	if err != nil {
+		return err
+	}
+	if wikisContent != "" {
+		wikisTemplate, wikisVars, err := gitops.ExtractWikisTemplate(wikisContent)
+		if err != nil {
+			return err
+		}
+		if err := gitops.SaveWikisTemplate(installPath, wikisTemplate); err != nil {
+			return err
+		}
+		for k, v := range wikisVars {
+			vars[k] = v
+		}
+	}
+
+	// 7. Read admin passwords and add to vars.
 	passwords, err := gitops.ReadAdminPasswords(installPath)
 	if err != nil {
 		logging.Print(fmt.Sprintf("Warning: could not read admin passwords: %v\n", err))
@@ -193,7 +211,7 @@ func runInitBootstrap(installPath, hostName, role, repoURL, keyFile string, forc
 		vars["admin_password_"+wikiID] = password
 	}
 
-	// 7. Create hosts.yaml.
+	// 8. Create hosts.yaml.
 	// Use the Canasta ID from the installation registry if available.
 	canastaID := filepath.Base(installPath)
 	details, detailsErr := config.GetDetails(canastaID)
@@ -214,17 +232,17 @@ func runInitBootstrap(installPath, hostName, role, repoURL, keyFile string, forc
 		return err
 	}
 
-	// 8. Save vars.yaml.
+	// 9. Save vars.yaml.
 	if err := gitops.SaveVars(installPath, hostName, vars); err != nil {
 		return err
 	}
 
-	// 9. Save local host identity.
+	// 10. Save local host identity.
 	if err := gitops.SaveLocalHost(installPath, hostName); err != nil {
 		return err
 	}
 
-	// 10. Convert extensions and skins to submodules.
+	// 11. Convert extensions and skins to submodules.
 	if err := convertToSubmodules(installPath, "extensions"); err != nil {
 		fmt.Printf("Warning: could not convert extensions to submodules: %v\n", err)
 	}
@@ -232,7 +250,7 @@ func runInitBootstrap(installPath, hostName, role, repoURL, keyFile string, forc
 		fmt.Printf("Warning: could not convert skins to submodules: %v\n", err)
 	}
 
-	// 11. Initial commit.
+	// 12. Initial commit.
 	if err := gitops.AddAll(installPath); err != nil {
 		return err
 	}
@@ -241,7 +259,7 @@ func runInitBootstrap(installPath, hostName, role, repoURL, keyFile string, forc
 		return err
 	}
 
-	// 12. Add remote and push.
+	// 13. Add remote and push.
 	if err := gitops.AddRemote(installPath, "origin", repoURL); err != nil {
 		return err
 	}
@@ -495,6 +513,7 @@ var requiredGitignoreEntries = []struct {
 	comment string
 }{
 	{"config/backup/", "# Database dumps created by canasta backup"},
+	{"config/wikis.yaml", "# Rendered from wikis.yaml.template — host-specific URLs"},
 }
 
 // ensureGitignoreEntries appends any missing required entries to the repo's

--- a/cmd/gitops/join.go
+++ b/cmd/gitops/join.go
@@ -133,6 +133,21 @@ func runInitJoin(installPath, hostName, role, repoURL, keyFile string) error {
 			strings.Join(missing, "=... ")+"=...")
 	}
 
+	// Extract wiki URLs from the local wikis.yaml into vars.
+	wikisContent, err := gitops.LoadWikisYAML(installPath)
+	if err != nil {
+		return err
+	}
+	if wikisContent != "" {
+		_, wikisVars, err := gitops.ExtractWikisTemplate(wikisContent)
+		if err != nil {
+			return err
+		}
+		for k, v := range wikisVars {
+			vars[k] = v
+		}
+	}
+
 	passwords, err := gitops.ReadAdminPasswords(installPath)
 	if err != nil {
 		logging.Print(fmt.Sprintf("Warning: could not read admin passwords: %v\n", err))
@@ -149,7 +164,7 @@ func runInitJoin(installPath, hostName, role, repoURL, keyFile string) error {
 		return err
 	}
 
-	// 6. Render .env in memory (written to disk after push succeeds).
+	// 6. Render .env and wikis.yaml in memory (written to disk after push succeeds).
 	tmpl, err := gitops.LoadEnvTemplate(installPath)
 	if err != nil {
 		return err
@@ -157,6 +172,18 @@ func runInitJoin(installPath, hostName, role, repoURL, keyFile string) error {
 	newEnv, err := gitops.RenderTemplate(tmpl, vars)
 	if err != nil {
 		return fmt.Errorf("rendering env.template: %w", err)
+	}
+
+	var newWikis string
+	wikisTmpl, err := gitops.LoadWikisTemplate(installPath)
+	if err != nil {
+		return err
+	}
+	if wikisTmpl != "" {
+		newWikis, err = gitops.RenderWikisTemplate(wikisTmpl, vars)
+		if err != nil {
+			return fmt.Errorf("rendering wikis.yaml.template: %w", err)
+		}
 	}
 
 	// 7. Update submodules.
@@ -212,9 +239,15 @@ func runInitJoin(installPath, hostName, role, repoURL, keyFile string) error {
 		}
 	}
 
-	// 9. Write .env and admin passwords now that the push succeeded.
+	// 9. Write .env, wikis.yaml, and admin passwords now that the push succeeded.
 	if err := os.WriteFile(envPath, []byte(newEnv), permissions.SecretFilePermission); err != nil {
 		return fmt.Errorf("writing .env: %w", err)
+	}
+	if newWikis != "" {
+		wikisPath := filepath.Join(installPath, "config", "wikis.yaml")
+		if err := os.WriteFile(wikisPath, []byte(newWikis), permissions.FilePermission); err != nil {
+			return fmt.Errorf("writing wikis.yaml: %w", err)
+		}
 	}
 	if err := gitops.WriteAdminPasswords(installPath, vars); err != nil {
 		return err

--- a/cmd/gitops/pull.go
+++ b/cmd/gitops/pull.go
@@ -122,12 +122,31 @@ func runPull(installPath string) (*gitops.PullResult, error) {
 		return nil, fmt.Errorf("writing .env: %w", err)
 	}
 
-	// 6. Write admin password files.
+	// 6. Render wikis.yaml from template if it exists.
+	var wikisChanged bool
+	wikisTmpl, err := gitops.LoadWikisTemplate(installPath)
+	if err != nil {
+		return nil, err
+	}
+	if wikisTmpl != "" {
+		newWikis, err := gitops.RenderWikisTemplate(wikisTmpl, vars)
+		if err != nil {
+			return nil, fmt.Errorf("rendering wikis.yaml.template: %w", err)
+		}
+		wikisPath := filepath.Join(installPath, "config", "wikis.yaml")
+		oldWikis, _ := os.ReadFile(wikisPath)
+		if err := os.WriteFile(wikisPath, []byte(newWikis), permissions.FilePermission); err != nil {
+			return nil, fmt.Errorf("writing wikis.yaml: %w", err)
+		}
+		wikisChanged = strings.TrimSpace(string(oldWikis)) != strings.TrimSpace(newWikis)
+	}
+
+	// 7. Write admin password files.
 	if err := gitops.WriteAdminPasswords(installPath, vars); err != nil {
 		return nil, err
 	}
 
-	// 7. Determine what changed.
+	// 8. Determine what changed.
 	changedFiles, err := gitops.DiffNameOnly(installPath, prevCommit)
 	if err != nil {
 		// Non-fatal: we can still report success without the diff.
@@ -136,12 +155,15 @@ func runPull(installPath string) (*gitops.PullResult, error) {
 
 	needsRestart, needsMaintenance, submodulesUpdated := gitops.AnalyzeChanges(changedFiles)
 
-	// Also check if .env content actually changed.
+	// Also check if .env or wikis.yaml content actually changed.
 	if strings.TrimSpace(string(oldEnv)) != strings.TrimSpace(newEnvContent) {
 		needsRestart = true
 	}
+	if wikisChanged {
+		needsRestart = true
+	}
 
-	// 8. Save the applied commit.
+	// 9. Save the applied commit.
 	if err := gitops.SaveAppliedCommit(installPath, newCommit); err != nil {
 		logging.Print(fmt.Sprintf("Warning: could not save applied commit: %v\n", err))
 	}

--- a/docs/guide/gitops.md
+++ b/docs/guide/gitops.md
@@ -27,8 +27,9 @@ The following tools must be installed:
 
 The git repository contains:
 
-- **Configuration files** — `config/` directory (wikis.yaml, Caddyfile customizations, PHP settings)
+- **Configuration files** — `config/` directory (Caddyfile customizations, PHP settings)
 - **Environment template** — `env.template` with `{{placeholders}}` for host-specific values
+- **Wiki farm template** — `wikis.yaml.template` with `{{wiki_url_<id>}}` placeholders for host-specific wiki URLs
 - **Per-host variables** — `hosts/{name}/vars.yaml` with secrets and host-specific values (encrypted by git-crypt)
 - **Host inventory** — `hosts.yaml` defining all servers and their roles
 - **Extensions and skins** — tracked as git submodules pinned to specific versions, or as regular files for custom extensions without their own repository
@@ -38,7 +39,8 @@ The git repository contains:
 
 ### What is NOT tracked (gitignored)
 
-- `.env` — generated from template + vars at deploy time
+- `.env` — generated from `env.template` + vars at deploy time
+- `config/wikis.yaml` — generated from `wikis.yaml.template` + vars at deploy time
 - `config/admin-password_*` — generated from vars at deploy time
 - `docker-compose.yml` — managed by the Canasta CLI
 - `config/Caddyfile` — auto-generated from wikis.yaml on restart
@@ -53,8 +55,8 @@ canasta-config/
 ├── .gitignore
 ├── custom-keys.yaml            # user-defined host-specific .env keys (optional)
 ├── env.template                # shared .env template with {{placeholders}}
+├── wikis.yaml.template         # shared wikis.yaml template with {{wiki_url_<id>}} placeholders
 ├── config/
-│   ├── wikis.yaml
 │   ├── Caddyfile.site
 │   ├── Caddyfile.global
 │   └── settings/
@@ -136,11 +138,12 @@ This bootstraps a new gitops repository from the existing installation:
 2. Sets up `.gitignore` and `.gitattributes`
 3. Initializes git-crypt and exports the symmetric key
 4. Creates `env.template` by extracting the current `.env` and replacing host-specific values with `{{placeholders}}`
-5. Creates `hosts.yaml` with this server as the first entry
-6. Creates `hosts/myserver/vars.yaml` with the actual values extracted from `.env` and admin password files
-7. Converts user-installed extensions and skins to git submodules
-8. Makes an initial commit
-9. Pushes to the remote
+5. Creates `wikis.yaml.template` by extracting wiki URLs from `config/wikis.yaml` and replacing them with `{{wiki_url_<id>}}` placeholders
+6. Creates `hosts.yaml` with this server as the first entry
+7. Creates `hosts/myserver/vars.yaml` with the actual values extracted from `.env`, wiki URLs, and admin password files
+8. Converts user-installed extensions and skins to git submodules
+9. Makes an initial commit
+10. Pushes to the remote
 
 **Store the exported git-crypt key securely** — it is needed to unlock the repo on other servers and must never be committed to the repo.
 
@@ -183,6 +186,40 @@ At deploy time, `canasta gitops pull` renders the template with the host's vars 
 
 !!! warning "Do not edit `.env` directly"
     The `.env` file is regenerated from `env.template` + `vars.yaml` on every pull. Manual edits to `.env` will be overwritten. To change a host-specific value, update `hosts/{name}/vars.yaml`. To change the structure of the `.env` (add or remove keys), edit `env.template`.
+
+## Wiki URL template
+
+For wiki farms, `config/wikis.yaml` contains per-wiki URLs that differ between hosts (e.g., `production.example.com` vs `localhost`). The `wikis.yaml.template` works the same way as `env.template` — wiki URLs are replaced with `{{wiki_url_<id>}}` placeholders:
+
+```yaml
+# wikis.yaml.template
+wikis:
+- id: main
+  url: "{{wiki_url_main}}"
+  name: Main Wiki
+- id: docs
+  url: "{{wiki_url_docs}}"
+  name: Documentation
+```
+
+Each host's `vars.yaml` supplies the actual URLs:
+
+```yaml
+# hosts/production/vars.yaml (in addition to .env vars)
+wiki_url_main: production.example.com
+wiki_url_docs: production.example.com/docs
+```
+
+```yaml
+# hosts/devbox/vars.yaml
+wiki_url_main: localhost
+wiki_url_docs: localhost/docs
+```
+
+At deploy time, `canasta gitops pull` renders `wikis.yaml.template` with the host's vars to produce `config/wikis.yaml`. This prevents local development from accidentally overwriting production URLs when pushing configuration changes.
+
+!!! warning "Do not edit `config/wikis.yaml` directly in a gitops-managed installation"
+    Like `.env`, `config/wikis.yaml` is regenerated from `wikis.yaml.template` + `vars.yaml` on every pull. To change a wiki's URL for a specific host, update `hosts/{name}/vars.yaml`. To add or remove wikis, edit `wikis.yaml.template`.
 
 ### Built-in placeholder keys
 
@@ -412,7 +449,7 @@ canasta config set -i mywiki MY_API_KEY=...
 canasta gitops join -i mywiki -n production --repo git@github.com:yourorg/mywiki-config.git --key /path/to/gitops-key
 ```
 
-This clones the repo, unlocks git-crypt, adds the host to `hosts.yaml`, extracts host-specific values into `vars.yaml`, updates submodules, and pushes the new host entry back to the repo.
+This clones the repo, unlocks git-crypt, adds the host to `hosts.yaml`, extracts host-specific values (including wiki URLs) into `vars.yaml`, renders `.env` and `config/wikis.yaml` from templates, updates submodules, and pushes the new host entry back to the repo.
 
 ## Removing a server
 

--- a/internal/gitops/changes.go
+++ b/internal/gitops/changes.go
@@ -16,7 +16,7 @@ func AnalyzeChanges(changedFiles []string) (needsRestart, needsMaintenance bool,
 		switch {
 		case f == "env.template" || f == ".env":
 			needsRestart = true
-		case f == "config/wikis.yaml":
+		case f == "config/wikis.yaml" || f == "wikis.yaml.template":
 			needsRestart = true
 		case f == "config/Caddyfile.site" || f == "config/Caddyfile.global":
 			needsRestart = true

--- a/internal/gitops/config.go
+++ b/internal/gitops/config.go
@@ -12,13 +12,13 @@ import (
 )
 
 const (
-	hostsFile          = "hosts.yaml"
-	customKeysFile     = "custom-keys.yaml"
-	envTemplateFile    = "env.template"
-	wikisTemplateFile  = "wikis.yaml.template"
-	wikisFile          = "config/wikis.yaml"
-	appliedFile        = ".gitops-applied"
-	hostFile           = ".gitops-host"
+	hostsFile         = "hosts.yaml"
+	customKeysFile    = "custom-keys.yaml"
+	envTemplateFile   = "env.template"
+	wikisTemplateFile = "wikis.yaml.template"
+	wikisFile         = "config/wikis.yaml"
+	appliedFile       = ".gitops-applied"
+	hostFile          = ".gitops-host"
 )
 
 // LoadHostsConfig reads and parses hosts.yaml from the installation directory.

--- a/internal/gitops/config.go
+++ b/internal/gitops/config.go
@@ -12,11 +12,13 @@ import (
 )
 
 const (
-	hostsFile       = "hosts.yaml"
-	customKeysFile  = "custom-keys.yaml"
-	envTemplateFile = "env.template"
-	appliedFile     = ".gitops-applied"
-	hostFile        = ".gitops-host"
+	hostsFile          = "hosts.yaml"
+	customKeysFile     = "custom-keys.yaml"
+	envTemplateFile    = "env.template"
+	wikisTemplateFile  = "wikis.yaml.template"
+	wikisFile          = "config/wikis.yaml"
+	appliedFile        = ".gitops-applied"
+	hostFile           = ".gitops-host"
 )
 
 // LoadHostsConfig reads and parses hosts.yaml from the installation directory.
@@ -116,6 +118,39 @@ func LoadEnvTemplate(installPath string) (string, error) {
 // SaveEnvTemplate writes the env.template file to the installation directory.
 func SaveEnvTemplate(installPath, content string) error {
 	return os.WriteFile(filepath.Join(installPath, envTemplateFile), []byte(content), permissions.FilePermission)
+}
+
+// LoadWikisTemplate reads the wikis.yaml.template file from the
+// installation directory. Returns empty string and no error if the file
+// does not exist (for backward compatibility with repos that predate
+// wikis templating).
+func LoadWikisTemplate(installPath string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(installPath, wikisTemplateFile))
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("reading %s: %w", wikisTemplateFile, err)
+	}
+	return string(data), nil
+}
+
+// SaveWikisTemplate writes the wikis.yaml.template file to the
+// installation directory.
+func SaveWikisTemplate(installPath, content string) error {
+	return os.WriteFile(filepath.Join(installPath, wikisTemplateFile), []byte(content), permissions.FilePermission)
+}
+
+// LoadWikisYAML reads the config/wikis.yaml file.
+func LoadWikisYAML(installPath string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(installPath, wikisFile))
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("reading %s: %w", wikisFile, err)
+	}
+	return string(data), nil
 }
 
 // SaveLocalHost writes the .gitops-host file to record which host name

--- a/internal/gitops/defaults/gitignore
+++ b/internal/gitops/defaults/gitignore
@@ -1,5 +1,6 @@
 # Generated at deploy time — do not track
 .env
+config/wikis.yaml
 config/admin-password_*
 
 # Managed by Canasta CLI

--- a/internal/gitops/template.go
+++ b/internal/gitops/template.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"gopkg.in/yaml.v2"
 )
 
 var placeholderRe = regexp.MustCompile(`\{\{(\w+)\}\}`)
@@ -128,4 +130,51 @@ func AllPlaceholderKeys(customKeys []string) []string {
 	keys = append(keys, builtinHostKeys...)
 	keys = append(keys, customKeys...)
 	return keys
+}
+
+// wikiURLKey returns the vars key for a wiki's URL placeholder.
+func wikiURLKey(wikiID string) string {
+	return "wiki_url_" + wikiID
+}
+
+// wikisYAML is a minimal representation of wikis.yaml used only for
+// template extraction and rendering. We intentionally keep this
+// separate from farmsettings.Wikis to avoid a circular import.
+type wikisYAML struct {
+	Wikis []wikiEntry `yaml:"wikis"`
+}
+
+type wikiEntry struct {
+	ID   string `yaml:"id"`
+	URL  string `yaml:"url"`
+	NAME string `yaml:"name"`
+}
+
+// ExtractWikisTemplate converts wikis.yaml content into a template where
+// each wiki's URL is replaced with a {{wiki_url_<id>}} placeholder.
+// Returns the template content and a VarsMap with the original URL values.
+func ExtractWikisTemplate(wikisContent string) (string, VarsMap, error) {
+	var w wikisYAML
+	if err := yaml.Unmarshal([]byte(wikisContent), &w); err != nil {
+		return "", nil, fmt.Errorf("parsing wikis.yaml: %w", err)
+	}
+
+	vars := make(VarsMap, len(w.Wikis))
+	for i, wiki := range w.Wikis {
+		key := wikiURLKey(wiki.ID)
+		vars[key] = wiki.URL
+		w.Wikis[i].URL = "{{" + key + "}}"
+	}
+
+	out, err := yaml.Marshal(&w)
+	if err != nil {
+		return "", nil, fmt.Errorf("marshaling wikis template: %w", err)
+	}
+	return string(out), vars, nil
+}
+
+// RenderWikisTemplate renders a wikis.yaml.template by replacing
+// {{wiki_url_<id>}} placeholders with values from vars.
+func RenderWikisTemplate(templateContent string, vars VarsMap) (string, error) {
+	return RenderTemplate(templateContent, vars)
 }

--- a/internal/gitops/template_test.go
+++ b/internal/gitops/template_test.go
@@ -3,6 +3,8 @@ package gitops
 import (
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v2"
 )
 
 func TestRenderTemplate(t *testing.T) {
@@ -156,6 +158,76 @@ func TestAllPlaceholderKeys(t *testing.T) {
 	expected := len(builtinSecretKeys) + len(builtinHostKeys) + 2
 	if len(keys) != expected {
 		t.Errorf("got %d keys, want %d", len(keys), expected)
+	}
+}
+
+func TestExtractWikisTemplate(t *testing.T) {
+	input := `wikis:
+- id: wiki1
+  url: example.com
+  name: Main Wiki
+- id: wiki2
+  url: example.com/docs
+  name: Documentation
+`
+	tmpl, vars, err := ExtractWikisTemplate(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Check that URLs were replaced with placeholders.
+	if vars["wiki_url_wiki1"] != "example.com" {
+		t.Errorf("wiki_url_wiki1 = %q, want %q", vars["wiki_url_wiki1"], "example.com")
+	}
+	if vars["wiki_url_wiki2"] != "example.com/docs" {
+		t.Errorf("wiki_url_wiki2 = %q, want %q", vars["wiki_url_wiki2"], "example.com/docs")
+	}
+
+	// Template should contain placeholders, not literal URLs.
+	if strings.Contains(tmpl, "example.com") && !strings.Contains(tmpl, "{{wiki_url_") {
+		t.Error("template should contain placeholders instead of literal URLs")
+	}
+
+	// Round-trip: render the template back with the vars.
+	rendered, err := RenderWikisTemplate(tmpl, vars)
+	if err != nil {
+		t.Fatalf("render error: %v", err)
+	}
+
+	// Parse both to compare semantically (YAML formatting may differ).
+	var original, roundTripped wikisYAML
+	if err := yaml.Unmarshal([]byte(input), &original); err != nil {
+		t.Fatalf("parse original: %v", err)
+	}
+	if err := yaml.Unmarshal([]byte(rendered), &roundTripped); err != nil {
+		t.Fatalf("parse rendered: %v", err)
+	}
+
+	if len(roundTripped.Wikis) != len(original.Wikis) {
+		t.Fatalf("got %d wikis, want %d", len(roundTripped.Wikis), len(original.Wikis))
+	}
+	for i, w := range roundTripped.Wikis {
+		if w.URL != original.Wikis[i].URL {
+			t.Errorf("wiki[%d].URL = %q, want %q", i, w.URL, original.Wikis[i].URL)
+		}
+		if w.ID != original.Wikis[i].ID {
+			t.Errorf("wiki[%d].ID = %q, want %q", i, w.ID, original.Wikis[i].ID)
+		}
+	}
+}
+
+func TestExtractWikisTemplateEmpty(t *testing.T) {
+	// Empty wikis list should still work.
+	input := "wikis: []\n"
+	tmpl, vars, err := ExtractWikisTemplate(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vars) != 0 {
+		t.Errorf("expected no vars, got %d", len(vars))
+	}
+	if tmpl == "" {
+		t.Error("expected non-empty template")
 	}
 }
 

--- a/tests/integration/gitops_test.go
+++ b/tests/integration/gitops_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"gopkg.in/yaml.v2"
 )
 
 // TestGitops_InitAndPush creates an instance, initializes gitops with a local
@@ -66,9 +68,56 @@ func TestGitops_InitAndPush(t *testing.T) {
 		t.Fatalf("hosts.yaml not found: %v", err)
 	}
 
-	// Verify wikis.yaml.template was created
-	if _, err := os.Stat(filepath.Join(installDir, "wikis.yaml.template")); err != nil {
+	// Verify wikis.yaml.template was created and contains placeholders,
+	// that vars.yaml captured the original URL, and that rendering the
+	// template produces the original wikis.yaml content.
+	wikisTemplatePath := filepath.Join(installDir, "wikis.yaml.template")
+	wikisTemplateData, err := os.ReadFile(wikisTemplatePath)
+	if err != nil {
 		t.Fatalf("wikis.yaml.template not found after gitops init: %v", err)
+	}
+	wikisTemplate := string(wikisTemplateData)
+
+	// Template should contain a placeholder, not the literal URL.
+	if !strings.Contains(wikisTemplate, "{{wiki_url_") {
+		t.Errorf("wikis.yaml.template should contain {{wiki_url_*}} placeholders, got:\n%s", wikisTemplate)
+	}
+	if strings.Contains(wikisTemplate, "localhost") {
+		t.Errorf("wikis.yaml.template should not contain literal 'localhost', got:\n%s", wikisTemplate)
+	}
+
+	// vars.yaml should contain the wiki URL value.
+	varsData, err := os.ReadFile(filepath.Join(installDir, "hosts", "testhost", "vars.yaml"))
+	if err != nil {
+		t.Fatalf("vars.yaml not found: %v", err)
+	}
+	var vars map[string]string
+	if err := yaml.Unmarshal(varsData, &vars); err != nil {
+		t.Fatalf("failed to parse vars.yaml: %v", err)
+	}
+	// The wiki created by "canasta create -w main" gets ID "main".
+	wikiURL, ok := vars["wiki_url_main"]
+	if !ok {
+		t.Fatalf("vars.yaml missing wiki_url_main key, keys: %v", keysOf(vars))
+	}
+	if wikiURL != "localhost" {
+		t.Errorf("wiki_url_main = %q, want %q", wikiURL, "localhost")
+	}
+
+	// Verify config/wikis.yaml is gitignored (not tracked in the bare repo).
+	showWikis := exec.Command("git", "--git-dir", bareRepo, "show", "HEAD:config/wikis.yaml")
+	if showOut, err := showWikis.CombinedOutput(); err == nil {
+		t.Errorf("config/wikis.yaml should be gitignored but was found in bare repo:\n%s", showOut)
+	}
+
+	// Verify wikis.yaml.template IS tracked in the bare repo.
+	showTmpl := exec.Command("git", "--git-dir", bareRepo, "show", "HEAD:wikis.yaml.template")
+	showTmplOut, err := showTmpl.CombinedOutput()
+	if err != nil {
+		t.Fatalf("wikis.yaml.template not found in bare repo: %v\n%s", err, showTmplOut)
+	}
+	if !strings.Contains(string(showTmplOut), "{{wiki_url_") {
+		t.Errorf("wikis.yaml.template in bare repo should contain placeholders, got:\n%s", showTmplOut)
 	}
 
 	// Verify the initial commit was pushed to the bare repo
@@ -125,4 +174,13 @@ func TestGitops_InitAndPush(t *testing.T) {
 	if !strings.Contains(string(showOut), "gitops integration test") {
 		t.Errorf("unexpected file content in bare repo: %s", string(showOut))
 	}
+}
+
+// keysOf returns the keys of a string map for diagnostic output.
+func keysOf(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }

--- a/tests/integration/gitops_test.go
+++ b/tests/integration/gitops_test.go
@@ -66,6 +66,11 @@ func TestGitops_InitAndPush(t *testing.T) {
 		t.Fatalf("hosts.yaml not found: %v", err)
 	}
 
+	// Verify wikis.yaml.template was created
+	if _, err := os.Stat(filepath.Join(installDir, "wikis.yaml.template")); err != nil {
+		t.Fatalf("wikis.yaml.template not found after gitops init: %v", err)
+	}
+
 	// Verify the initial commit was pushed to the bare repo
 	logCmd := exec.Command("git", "--git-dir", bareRepo, "log", "--oneline", "-1")
 	logOut, err := logCmd.CombinedOutput()


### PR DESCRIPTION
## Summary

- During `gitops init`, extract host-specific wiki URLs from `config/wikis.yaml` into `wikis.yaml.template` with `{{wiki_url_<id>}}` placeholders
- The actual `config/wikis.yaml` is gitignored and rendered from the template + per-host vars on `gitops join` and `gitops pull`
- Follows the same pattern already used for `.env` / `env.template`
- Existing repos get `config/wikis.yaml` added to `.gitignore` automatically on next push (backfill via `requiredGitignoreEntries`)
- Updated gitops documentation to cover wiki URL templating
- Added integration test verifying template round-trip (placeholders in template, URLs in vars, gitignore, tracking)

This prevents `gitops push` from overwriting production wiki URLs when developing locally against a restored backup.

Fixes #642

## Test plan

- [x] Unit tests pass (`go test ./internal/gitops/...`) — round-trip extraction + rendering, empty wikis edge case
- [x] Full test suite passes (`go test ./...`)
- [x] Integration test verifies `wikis.yaml.template` is created during `gitops init`, contains placeholders, vars capture URLs, gitignore works
- [x] Manual: `gitops init` on a wiki farm creates `wikis.yaml.template` with placeholders and adds URL vars to `hosts/<name>/vars.yaml`
- [x] Manual: `gitops join` on a second host renders `config/wikis.yaml` with the local host's URLs from vars
- [x] Manual: `gitops pull` re-renders `config/wikis.yaml` from template, flags restart if content changed
- [x] Backward compatible: repos without `wikis.yaml.template` continue to work (graceful no-op)