### PR TITLE
Clarify gitops-specific files in repo structure diagram

### DIFF
--- a/docs/guide/gitops.md
+++ b/docs/guide/gitops.md
@@ -60,9 +60,9 @@ canasta-config/
 ├── env.template †              # shared .env template with {{placeholders}}
 ├── wikis.yaml.template †       # shared wikis.yaml template (wiki farms only)
 ├── hosts.yaml †                # host inventory and settings
-├── hosts/ †                    # per-host variables (encrypted by git-crypt)
-│   └── myserver/
-│       └── vars.yaml
+├── hosts/ †                    # per-host variables
+│   └── myserver/ †
+│       └── vars.yaml †         # encrypted by git-crypt
 ├── config/
 │   ├── wikis.yaml ‡
 │   ├── admin-password_* ‡

--- a/docs/guide/gitops.md
+++ b/docs/guide/gitops.md
@@ -49,14 +49,24 @@ The git repository contains:
 
 ## Repository structure
 
+The tree below shows the full directory layout of a gitops-managed installation. Most files and directories are part of every Canasta installation. Files marked `†` are created by `gitops init` and only exist when gitops is in use. Files marked `‡` are generated at deploy time from templates and are not tracked in git.
+
 ```
 canasta-config/
-├── .gitattributes              # git-crypt filter rules
-├── .gitignore
-├── custom-keys.yaml            # user-defined host-specific .env keys (optional)
-├── env.template                # shared .env template with {{placeholders}}
-├── wikis.yaml.template         # shared wikis.yaml template with {{wiki_url_<id>}} placeholders
+├── .gitattributes †
+├── .gitignore †
+├── .env ‡
+├── custom-keys.yaml †          # user-defined host-specific .env keys (optional)
+├── env.template †              # shared .env template with {{placeholders}}
+├── wikis.yaml.template †       # shared wikis.yaml template (wiki farms only)
+├── hosts.yaml †                # host inventory and settings
+├── hosts/ †                    # per-host variables (encrypted by git-crypt)
+│   └── myserver/
+│       └── vars.yaml
 ├── config/
+│   ├── wikis.yaml ‡
+│   ├── admin-password_* ‡
+│   ├── Caddyfile               # auto-generated on restart
 │   ├── Caddyfile.site
 │   ├── Caddyfile.global
 │   └── settings/
@@ -69,11 +79,8 @@ canasta-config/
 ├── extensions/                 # git submodules (or regular files for custom extensions)
 ├── skins/                      # git submodules (or regular files for custom skins)
 ├── public_assets/
-├── docker-compose.override.yml # if used
-├── hosts/                      # per-host variables (encrypted by git-crypt)
-│   └── myserver/
-│       └── vars.yaml
-└── hosts.yaml                  # host inventory and settings
+├── docker-compose.yml ‡        # managed by the Canasta CLI
+└── docker-compose.override.yml # if used
 ```
 
 ## Initial setup

--- a/docs/guide/gitops.md
+++ b/docs/guide/gitops.md
@@ -425,6 +425,8 @@ Since they are regular files in the repo, they are automatically synced to all s
 
 ## Adding a server
 
+Backup and gitops are complementary systems. **Backup** (`canasta backup`) captures everything — databases, uploaded files, and configuration. **Gitops** tracks configuration only — settings files, extensions, skins, environment template, and wiki farm structure. When adding a server (whether a production replica or a local dev copy), you need both: the backup provides the database and files, while gitops gives you the shared configuration repo.
+
 To add a new server to an existing managed wiki farm:
 
 ### 1. Back up the existing wiki farm
@@ -459,6 +461,37 @@ canasta gitops join -i mywiki -n production --repo git@github.com:yourorg/mywiki
 ```
 
 This clones the repo, unlocks git-crypt, adds the host to `hosts.yaml`, extracts host-specific values (including wiki URLs) into `vars.yaml`, renders `.env` and `config/wikis.yaml` from templates, updates submodules, and pushes the new host entry back to the repo.
+
+### Setting up a local dev copy
+
+The steps above also apply when setting up a local development copy of a production wiki. The key differences are:
+
+1. **Restore from a remote backup** instead of copying a file. Add the production server's backup credentials (`RESTIC_REPOSITORY`, `RESTIC_PASSWORD`, and any `AWS_*`/`AZURE_*`/`B2_*` keys) to your local instance's `.env`, then:
+
+    ```bash
+    canasta backup list -i mywiki
+    canasta backup restore -i mywiki -s <snapshot-id>
+    ```
+
+2. **Edit `config/wikis.yaml` before joining** to replace production URLs with local addresses (e.g., `localhost`). The join command captures these URLs into your host's `vars.yaml`, so they must be correct before you run it.
+
+3. **Use `--role source`** (or `--role both`) so you can push changes back to the repo:
+
+    ```bash
+    canasta gitops join -i mywiki -n devbox --role source \
+      --repo git@github.com:yourorg/mywiki-config.git --key /path/to/gitops-key
+    ```
+
+After making and testing changes locally, push them to the repo and pull on the production server:
+
+```bash
+# Local
+canasta gitops add -i mywiki config/settings/global/MyChange.php
+canasta gitops push -i mywiki -m "Description of change"
+
+# Production
+canasta gitops pull -i mywiki
+```
 
 ## Removing a server
 

--- a/docs/guide/gitops.md
+++ b/docs/guide/gitops.md
@@ -49,13 +49,13 @@ The git repository contains:
 
 ## Repository structure
 
-The tree below shows the full directory layout of a gitops-managed installation. Most files and directories are part of every Canasta installation. Files marked `†` are created by `gitops init` and only exist when gitops is in use. Files marked `‡` are generated at deploy time from templates and are not tracked in git.
+The tree below shows the full directory layout of a gitops-managed installation. Most files and directories are part of every Canasta installation. Files marked `†` are created by `gitops init` and only exist when gitops is in use. Files marked `‡` are not pushed to the gitops repository — they are either generated locally from templates, managed by the CLI, or excluded because they contain host-specific data.
 
 ```
 canasta-config/
 ├── .gitattributes †
 ├── .gitignore †
-├── .env ‡
+├── .env ‡                      # generated from env.template + vars
 ├── custom-keys.yaml †          # user-defined host-specific .env keys (optional)
 ├── env.template †              # shared .env template with {{placeholders}}
 ├── wikis.yaml.template †       # shared wikis.yaml template (wiki farms only)
@@ -64,9 +64,10 @@ canasta-config/
 │   └── myserver/ †
 │       └── vars.yaml †         # encrypted by git-crypt
 ├── config/
-│   ├── wikis.yaml ‡
-│   ├── admin-password_* ‡
-│   ├── Caddyfile               # auto-generated on restart
+│   ├── wikis.yaml ‡            # generated from wikis.yaml.template + vars
+│   ├── admin-password_* ‡      # generated from vars
+│   ├── Caddyfile ‡             # auto-generated on restart
+│   ├── backup/ ‡               # database dumps from canasta backup
 │   ├── Caddyfile.site
 │   ├── Caddyfile.global
 │   └── settings/
@@ -79,6 +80,7 @@ canasta-config/
 ├── extensions/                 # git submodules (or regular files for custom extensions)
 ├── skins/                      # git submodules (or regular files for custom skins)
 ├── public_assets/
+├── images/ ‡                   # uploaded files (covered by canasta backup)
 ├── docker-compose.yml ‡        # managed by the Canasta CLI
 └── docker-compose.override.yml # if used
 ```

--- a/docs/guide/gitops.md
+++ b/docs/guide/gitops.md
@@ -55,19 +55,19 @@ The tree below shows the full directory layout of a gitops-managed installation.
 canasta-config/
 ├── .gitattributes †
 ├── .gitignore †
-├── .env ‡                      # generated from env.template + vars
-├── custom-keys.yaml †          # user-defined host-specific .env keys (optional)
-├── env.template †              # shared .env template with {{placeholders}}
-├── wikis.yaml.template †       # shared wikis.yaml template (wiki farms only)
+├── .env ‡                      # rendered from env.template + vars
+├── custom-keys.yaml †          # host-specific .env keys (optional)
+├── env.template †              # .env template with {{placeholders}}
+├── wikis.yaml.template †       # wikis.yaml template (wiki farms only)
 ├── hosts.yaml †                # host inventory and settings
 ├── hosts/ †                    # per-host variables
 │   └── myserver/ †
 │       └── vars.yaml †         # encrypted by git-crypt
 ├── config/
-│   ├── wikis.yaml ‡            # generated from wikis.yaml.template + vars
-│   ├── admin-password_* ‡      # generated from vars
-│   ├── Caddyfile ‡             # auto-generated on restart
-│   ├── backup/ ‡               # database dumps from canasta backup
+│   ├── wikis.yaml ‡            # rendered from template + vars
+│   ├── admin-password_* ‡      # rendered from vars
+│   ├── Caddyfile ‡             # generated on restart
+│   ├── backup/ ‡               # database dumps
 │   ├── Caddyfile.site
 │   ├── Caddyfile.global
 │   └── settings/
@@ -80,8 +80,8 @@ canasta-config/
 ├── extensions/                 # git submodules (or regular files for custom extensions)
 ├── skins/                      # git submodules (or regular files for custom skins)
 ├── public_assets/
-├── images/ ‡                   # uploaded files (covered by canasta backup)
-├── docker-compose.yml ‡        # managed by the Canasta CLI
+├── images/ ‡                   # uploaded files
+├── docker-compose.yml ‡        # managed by CLI
 └── docker-compose.override.yml # if used
 ```
 


### PR DESCRIPTION
Closes #646

## Summary

- Add markers to the repository structure tree: `†` for gitops-only files, `‡` for files not pushed to the gitops repo
- Include generated/gitignored files (`.env`, `config/wikis.yaml`, `admin-password_*`, `docker-compose.yml`, etc.) in the tree with inline descriptions
- Add introductory paragraph explaining the two markers
- Add overview paragraph to "Adding a server" explaining how backup and gitops complement each other
- Add "Setting up a local dev copy" subsection with step-by-step guide for restoring a remote backup and joining a gitops repo for local development

## Test plan

- [ ] Verify rendered docs look correct on MkDocs