### PR TITLE
Move --wiki flag to maintenance subcommands and iterate over all wikis in script

### DIFF
--- a/cmd/maintenance/exec.go
+++ b/cmd/maintenance/exec.go
@@ -15,8 +15,9 @@ func newExecCmd(instance *config.Installation) *cobra.Command {
 	var service string
 
 	cmd := &cobra.Command{
-		Use:   "exec [command ...]",
-		Short: "Execute a command in a running container",
+		Use:                   "exec [flags] [command ...]",
+		DisableFlagsInUseLine: true,
+		Short:                 "Execute a command in a running container",
 		Long: `Execute a command or open an interactive shell in a running container
 of a Canasta installation.
 

--- a/cmd/maintenance/exec.go
+++ b/cmd/maintenance/exec.go
@@ -15,14 +15,17 @@ func newExecCmd(instance *config.Installation) *cobra.Command {
 	var service string
 
 	cmd := &cobra.Command{
-		Use:   "exec [-- command ...]",
+		Use:   "exec [command ...]",
 		Short: "Execute a command in a running container",
 		Long: `Execute a command or open an interactive shell in a running container
 of a Canasta installation.
 
 With no arguments and no --service flag, lists the running services.
 With --service (or -s) and no command, opens an interactive bash shell.
-With --service and a command after --, runs that command.
+With --service and a command, runs that command.
+
+Flags (-i, -s) must come before the command. Everything after the first
+non-flag argument is treated as the command and its arguments.
 
 The default service is "web" (the MediaWiki container).`,
 		Example: `  # List running services
@@ -32,10 +35,10 @@ The default service is "web" (the MediaWiki container).`,
   canasta maintenance exec -i myinstance -s web
 
   # Run a command in the web container
-  canasta maintenance exec -i myinstance -s web -- ls /var/www
+  canasta maintenance exec -i myinstance -s web ls /var/www
 
   # Default service is "web", so this also works
-  canasta maintenance exec -i myinstance -- php -v`,
+  canasta maintenance exec -i myinstance php -v`,
 		PreRunE: func(_ *cobra.Command, _ []string) error {
 			var err error
 			*instance, err = canasta.CheckCanastaID(*instance)
@@ -92,5 +95,8 @@ The default service is "web" (the MediaWiki container).`,
 	}
 
 	cmd.Flags().StringVarP(&service, "service", "s", "", "Service name (default: web)")
+	// Stop parsing flags after the first non-flag argument (the command).
+	// This allows command arguments like -v to be passed without --.
+	cmd.Flags().SetInterspersed(false)
 	return cmd
 }

--- a/cmd/maintenance/exec.go
+++ b/cmd/maintenance/exec.go
@@ -15,18 +15,14 @@ func newExecCmd(instance *config.Installation) *cobra.Command {
 	var service string
 
 	cmd := &cobra.Command{
-		Use:                   "exec [flags] [command ...]",
-		DisableFlagsInUseLine: true,
-		Short:                 "Execute a command in a running container",
+		Use:   "exec [-- command ...]",
+		Short: "Execute a command in a running container",
 		Long: `Execute a command or open an interactive shell in a running container
 of a Canasta installation.
 
 With no arguments and no --service flag, lists the running services.
 With --service (or -s) and no command, opens an interactive bash shell.
-With --service and a command, runs that command.
-
-Flags (-i, -s) must come before the command. Everything after the first
-non-flag argument is treated as the command and its arguments.
+With --service and a command after --, runs that command.
 
 The default service is "web" (the MediaWiki container).`,
 		Example: `  # List running services
@@ -36,10 +32,10 @@ The default service is "web" (the MediaWiki container).`,
   canasta maintenance exec -i myinstance -s web
 
   # Run a command in the web container
-  canasta maintenance exec -i myinstance -s web ls /var/www
+  canasta maintenance exec -i myinstance -s web -- ls /var/www
 
   # Default service is "web", so this also works
-  canasta maintenance exec -i myinstance php -v`,
+  canasta maintenance exec -i myinstance -- php -v`,
 		PreRunE: func(_ *cobra.Command, _ []string) error {
 			var err error
 			*instance, err = canasta.CheckCanastaID(*instance)
@@ -96,8 +92,5 @@ The default service is "web" (the MediaWiki container).`,
 	}
 
 	cmd.Flags().StringVarP(&service, "service", "s", "", "Service name (default: web)")
-	// Stop parsing flags after the first non-flag argument (the command).
-	// This allows command arguments like -v to be passed without --.
-	cmd.Flags().SetInterspersed(false)
 	return cmd
 }

--- a/cmd/maintenance/extension.go
+++ b/cmd/maintenance/extension.go
@@ -31,9 +31,8 @@ directory. With one argument (extension name), lists available maintenance
 scripts for that extension. With two or more arguments (extension name,
 script name, and optional script arguments), runs the specified script.
 
-Flags (-i, --wiki) must come before the extension name. Everything after
-the extension name is treated as the script and its arguments — no quotes
-are needed.
+Flags (-i, --wiki) must come before the extension name. Everything after the
+extension name is treated as the script and its arguments — no quotes needed.
 
 Only extensions that are currently loaded (enabled) for the target wiki are
 shown and allowed to run. In a wiki farm, runs on all wikis by default.

--- a/cmd/maintenance/extension.go
+++ b/cmd/maintenance/extension.go
@@ -22,8 +22,9 @@ func newExtensionCmd(instance *config.Installation) *cobra.Command {
 	var wiki string
 
 	extensionCmd := &cobra.Command{
-		Use:   "extension [extension-name] [script.php [args...]]",
-		Short: "Run extension maintenance scripts",
+		Use:                   "extension [flags] [extension-name] [script.php [args...]]",
+		DisableFlagsInUseLine: true,
+		Short:                 "Run extension maintenance scripts",
 		Long: `Run maintenance scripts provided by loaded MediaWiki extensions.
 
 With no arguments, lists all loaded extensions that have a maintenance/

--- a/cmd/maintenance/extension.go
+++ b/cmd/maintenance/extension.go
@@ -18,7 +18,8 @@ import (
 // wikiArgRe matches --wiki=value or --wiki value in a script argument string.
 var wikiArgRe = regexp.MustCompile(`(?:^|\s)--wiki[=\s](\S+)`)
 
-func newExtensionCmd(instance *config.Installation, wiki *string) *cobra.Command {
+func newExtensionCmd(instance *config.Installation) *cobra.Command {
+	var wiki string
 
 	extensionCmd := &cobra.Command{
 		Use:   "extension [extension-name] [script.php [args...]]",
@@ -60,13 +61,13 @@ Use --wiki to target a specific wiki.`,
 		RunE: func(_ *cobra.Command, args []string) error {
 			switch {
 			case len(args) == 0:
-				return listExtensionsWithMaintenance(*instance, *wiki)
+				return listExtensionsWithMaintenance(*instance, wiki)
 			case len(args) == 1:
-				return listExtensionScripts(*instance, args[0], *wiki)
+				return listExtensionScripts(*instance, args[0], wiki)
 			default:
 				extName := args[0]
 				scriptStr := strings.Join(args[1:], " ")
-				wikiIDs, err := resolveWikiIDs(*instance, *wiki)
+				wikiIDs, err := resolveWikiIDs(*instance, wiki)
 				if err != nil {
 					return err
 				}
@@ -80,6 +81,7 @@ Use --wiki to target a specific wiki.`,
 		},
 	}
 
+	extensionCmd.Flags().StringVarP(&wiki, "wiki", "w", "", "Wiki ID to run maintenance on (default: all wikis)")
 	// Stop parsing flags after the first non-flag argument (the extension name).
 	// This allows script arguments like -s 1000 to be passed without quotes.
 	extensionCmd.Flags().SetInterspersed(false)

--- a/cmd/maintenance/extension.go
+++ b/cmd/maintenance/extension.go
@@ -22,9 +22,8 @@ func newExtensionCmd(instance *config.Installation) *cobra.Command {
 	var wiki string
 
 	extensionCmd := &cobra.Command{
-		Use:                   "extension [flags] [extension-name] [script.php [args...]]",
-		DisableFlagsInUseLine: true,
-		Short:                 "Run extension maintenance scripts",
+		Use:   "extension [extension-name] [script.php [args...]]",
+		Short: "Run extension maintenance scripts",
 		Long: `Run maintenance scripts provided by loaded MediaWiki extensions.
 
 With no arguments, lists all loaded extensions that have a maintenance/
@@ -32,8 +31,9 @@ directory. With one argument (extension name), lists available maintenance
 scripts for that extension. With two or more arguments (extension name,
 script name, and optional script arguments), runs the specified script.
 
-Flags (-i, --wiki) must come before the extension name. Everything after the
-extension name is treated as the script and its arguments — no quotes needed.
+Flags (-i, --wiki) must come before the extension name. Everything after
+the extension name is treated as the script and its arguments — no quotes
+are needed.
 
 Only extensions that are currently loaded (enabled) for the target wiki are
 shown and allowed to run. In a wiki farm, runs on all wikis by default.

--- a/cmd/maintenance/maintenance.go
+++ b/cmd/maintenance/maintenance.go
@@ -10,10 +10,7 @@ import (
 )
 
 func NewCmd() *cobra.Command {
-	var (
-		instance config.Installation
-		wiki     string
-	)
+	var instance config.Installation
 
 	workingDir, wdErr := os.Getwd()
 	if wdErr != nil {
@@ -29,12 +26,11 @@ group provides subcommands to run the standard update sequence, execute
 arbitrary core maintenance scripts, or run extension-specific maintenance scripts.`,
 	}
 
-	maintenanceCmd.AddCommand(newUpdateCmd(&instance, &wiki))
-	maintenanceCmd.AddCommand(newScriptCmd(&instance, &wiki))
-	maintenanceCmd.AddCommand(newExtensionCmd(&instance, &wiki))
+	maintenanceCmd.AddCommand(newUpdateCmd(&instance))
+	maintenanceCmd.AddCommand(newScriptCmd(&instance))
+	maintenanceCmd.AddCommand(newExtensionCmd(&instance))
 	maintenanceCmd.AddCommand(newExecCmd(&instance))
 
 	maintenanceCmd.PersistentFlags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
-	maintenanceCmd.PersistentFlags().StringVarP(&wiki, "wiki", "w", "", "Wiki ID to run maintenance on (default: all wikis)")
 	return maintenanceCmd
 }

--- a/cmd/maintenance/maintenanceScript.go
+++ b/cmd/maintenance/maintenanceScript.go
@@ -3,7 +3,6 @@ package maintenance
 import (
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -13,7 +12,8 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-func newScriptCmd(instance *config.Installation, wiki *string) *cobra.Command {
+func newScriptCmd(instance *config.Installation) *cobra.Command {
+	var wiki string
 
 	scriptCmd := &cobra.Command{
 		Use:   `script ["scriptname.php [args]"]`,
@@ -24,7 +24,8 @@ With no arguments, lists all available maintenance scripts. With one argument
 (a quoted script name and optional arguments), runs that script. The script
 name is relative to the maintenance/ directory.
 
-Use --wiki to target a specific wiki in a farm.`,
+In a wiki farm, runs on all wikis by default. Use --wiki to target a
+specific wiki.`,
 		Example: `  # List all available maintenance scripts
   canasta maintenance script -i myinstance
 
@@ -46,10 +47,11 @@ Use --wiki to target a specific wiki in a farm.`,
 			if len(args) == 0 {
 				return listMaintenanceScripts(*instance)
 			}
-			return runMaintenanceScript(*instance, args[0], *wiki)
+			return runMaintenanceScript(*instance, args[0], wiki)
 		},
 	}
 
+	scriptCmd.Flags().StringVarP(&wiki, "wiki", "w", "", "Wiki ID to run maintenance on (default: all wikis)")
 	return scriptCmd
 }
 
@@ -102,21 +104,32 @@ func runMaintenanceScriptWith(orch orchestrators.Orchestrator, inst config.Insta
 		return err
 	}
 
-	// Require --wiki on wiki farms
-	if resolvedWiki == "" {
-		ids, err := farmsettings.GetWikiIDs(inst.Path)
-		if err == nil && len(ids) > 0 {
-			return fmt.Errorf("this is a wiki farm; use --wiki to specify a wiki (%s)", strings.Join(ids, ", "))
-		}
+	// If a specific wiki was given, run once for that wiki.
+	// Otherwise, run on all wikis in the farm.
+	if resolvedWiki != "" {
+		return runScriptForWiki(orch, inst, cleanedScript, resolvedWiki)
 	}
 
-	wikiFlag := ""
-	if resolvedWiki != "" {
-		wikiFlag = " --wiki=" + resolvedWiki
+	wikiIDs, err := farmsettings.GetWikiIDs(inst.Path)
+	if err != nil {
+		return err
 	}
-	fmt.Println("Running maintenance script " + cleanedScript)
+	for _, id := range wikiIDs {
+		if err := runScriptForWiki(orch, inst, cleanedScript, id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func runScriptForWiki(orch orchestrators.Orchestrator, inst config.Installation, script, wikiID string) error {
+	wikiFlag := ""
+	if wikiID != "" {
+		wikiFlag = " --wiki=" + wikiID
+	}
+	fmt.Println("Running maintenance script " + script + wikiFlag)
 	if err := orch.ExecStreaming(inst.Path, orchestrators.ServiceWeb,
-		"php maintenance/"+cleanedScript+wikiFlag); err != nil {
+		"php maintenance/"+script+wikiFlag); err != nil {
 		return fmt.Errorf("maintenance script failed: %w", err)
 	}
 	fmt.Println("Completed running maintenance script")

--- a/cmd/maintenance/maintenanceScript.go
+++ b/cmd/maintenance/maintenanceScript.go
@@ -3,7 +3,6 @@ package maintenance
 import (
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -17,17 +16,13 @@ func newScriptCmd(instance *config.Installation) *cobra.Command {
 	var wiki string
 
 	scriptCmd := &cobra.Command{
-		Use:                   "script [flags] [scriptname.php [args...]]",
-		DisableFlagsInUseLine: true,
-		Short:                 "Run maintenance scripts",
+		Use:   `script ["scriptname.php [args]"]`,
+		Short: "Run maintenance scripts",
 		Long: `Run a MediaWiki core maintenance script inside the web container.
 
-With no arguments, lists all available maintenance scripts. With one or more
-arguments, runs the specified script. The script name is relative to the
-maintenance/ directory.
-
-Flags (-i, --wiki) must come before the script name. Everything after the
-script name is treated as script arguments — no quotes needed.
+With no arguments, lists all available maintenance scripts. With one argument
+(a quoted script name and optional arguments), runs that script. The script
+name is relative to the maintenance/ directory.
 
 In a wiki farm, runs on all wikis by default. Use --wiki to target a
 specific wiki.`,
@@ -35,14 +30,14 @@ specific wiki.`,
   canasta maintenance script -i myinstance
 
   # Run rebuildrecentchanges.php
-  canasta maintenance script -i myinstance rebuildrecentchanges.php
+  canasta maintenance script "rebuildrecentchanges.php" -i myinstance
 
   # Run a script with arguments
-  canasta maintenance script -i myinstance importDump.php /path/to/dump.xml
+  canasta maintenance script "importDump.php /path/to/dump.xml" -i myinstance
 
   # Run a script for a specific wiki in a farm
-  canasta maintenance script -i myinstance --wiki=docs rebuildrecentchanges.php`,
-		Args: cobra.ArbitraryArgs,
+  canasta maintenance script "rebuildrecentchanges.php" -i myinstance --wiki=docs`,
+		Args: cobra.RangeArgs(0, 1),
 		PreRunE: func(_ *cobra.Command, _ []string) error {
 			var err error
 			*instance, err = canasta.CheckCanastaID(*instance)
@@ -52,15 +47,11 @@ specific wiki.`,
 			if len(args) == 0 {
 				return listMaintenanceScripts(*instance)
 			}
-			scriptStr := strings.Join(args, " ")
-			return runMaintenanceScript(*instance, scriptStr, wiki)
+			return runMaintenanceScript(*instance, args[0], wiki)
 		},
 	}
 
 	scriptCmd.Flags().StringVarP(&wiki, "wiki", "w", "", "Wiki ID to run maintenance on (default: all wikis)")
-	// Stop parsing flags after the first non-flag argument (the script name).
-	// This allows script arguments like -s 1000 to be passed without quotes.
-	scriptCmd.Flags().SetInterspersed(false)
 	return scriptCmd
 }
 

--- a/cmd/maintenance/maintenanceScript.go
+++ b/cmd/maintenance/maintenanceScript.go
@@ -17,8 +17,9 @@ func newScriptCmd(instance *config.Installation) *cobra.Command {
 	var wiki string
 
 	scriptCmd := &cobra.Command{
-		Use:   "script [scriptname.php [args...]]",
-		Short: "Run maintenance scripts",
+		Use:                   "script [flags] [scriptname.php [args...]]",
+		DisableFlagsInUseLine: true,
+		Short:                 "Run maintenance scripts",
 		Long: `Run a MediaWiki core maintenance script inside the web container.
 
 With no arguments, lists all available maintenance scripts. With one or more

--- a/cmd/maintenance/maintenanceScript.go
+++ b/cmd/maintenance/maintenanceScript.go
@@ -3,6 +3,7 @@ package maintenance
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -16,13 +17,16 @@ func newScriptCmd(instance *config.Installation) *cobra.Command {
 	var wiki string
 
 	scriptCmd := &cobra.Command{
-		Use:   `script ["scriptname.php [args]"]`,
+		Use:   "script [scriptname.php [args...]]",
 		Short: "Run maintenance scripts",
 		Long: `Run a MediaWiki core maintenance script inside the web container.
 
-With no arguments, lists all available maintenance scripts. With one argument
-(a quoted script name and optional arguments), runs that script. The script
-name is relative to the maintenance/ directory.
+With no arguments, lists all available maintenance scripts. With one or more
+arguments, runs the specified script. The script name is relative to the
+maintenance/ directory.
+
+Flags (-i, --wiki) must come before the script name. Everything after the
+script name is treated as script arguments — no quotes needed.
 
 In a wiki farm, runs on all wikis by default. Use --wiki to target a
 specific wiki.`,
@@ -30,14 +34,14 @@ specific wiki.`,
   canasta maintenance script -i myinstance
 
   # Run rebuildrecentchanges.php
-  canasta maintenance script "rebuildrecentchanges.php" -i myinstance
+  canasta maintenance script -i myinstance rebuildrecentchanges.php
 
   # Run a script with arguments
-  canasta maintenance script "importDump.php /path/to/dump.xml" -i myinstance
+  canasta maintenance script -i myinstance importDump.php /path/to/dump.xml
 
   # Run a script for a specific wiki in a farm
-  canasta maintenance script "rebuildrecentchanges.php" -i myinstance --wiki=docs`,
-		Args: cobra.RangeArgs(0, 1),
+  canasta maintenance script -i myinstance --wiki=docs rebuildrecentchanges.php`,
+		Args: cobra.ArbitraryArgs,
 		PreRunE: func(_ *cobra.Command, _ []string) error {
 			var err error
 			*instance, err = canasta.CheckCanastaID(*instance)
@@ -47,11 +51,15 @@ specific wiki.`,
 			if len(args) == 0 {
 				return listMaintenanceScripts(*instance)
 			}
-			return runMaintenanceScript(*instance, args[0], wiki)
+			scriptStr := strings.Join(args, " ")
+			return runMaintenanceScript(*instance, scriptStr, wiki)
 		},
 	}
 
 	scriptCmd.Flags().StringVarP(&wiki, "wiki", "w", "", "Wiki ID to run maintenance on (default: all wikis)")
+	// Stop parsing flags after the first non-flag argument (the script name).
+	// This allows script arguments like -s 1000 to be passed without quotes.
+	scriptCmd.Flags().SetInterspersed(false)
 	return scriptCmd
 }
 

--- a/cmd/maintenance/maintenanceScript.go
+++ b/cmd/maintenance/maintenanceScript.go
@@ -105,7 +105,7 @@ func runMaintenanceScriptWith(orch orchestrators.Orchestrator, inst config.Insta
 	// Require --wiki on wiki farms
 	if resolvedWiki == "" {
 		ids, err := farmsettings.GetWikiIDs(inst.Path)
-		if err == nil && len(ids) > 1 {
+		if err == nil && len(ids) > 0 {
 			return fmt.Errorf("this is a wiki farm; use --wiki to specify a wiki (%s)", strings.Join(ids, ", "))
 		}
 	}

--- a/cmd/maintenance/maintenanceScript.go
+++ b/cmd/maintenance/maintenanceScript.go
@@ -3,11 +3,13 @@ package maintenance
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
@@ -98,6 +100,14 @@ func runMaintenanceScriptWith(orch orchestrators.Orchestrator, inst config.Insta
 	resolvedWiki, cleanedScript, err := resolveWikiFlag(wiki, script)
 	if err != nil {
 		return err
+	}
+
+	// Require --wiki on wiki farms
+	if resolvedWiki == "" {
+		ids, err := farmsettings.GetWikiIDs(inst.Path)
+		if err == nil && len(ids) > 1 {
+			return fmt.Errorf("this is a wiki farm; use --wiki to specify a wiki (%s)", strings.Join(ids, ", "))
+		}
 	}
 
 	wikiFlag := ""

--- a/cmd/maintenance/maintenanceUpdate.go
+++ b/cmd/maintenance/maintenanceUpdate.go
@@ -13,8 +13,9 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-func newUpdateCmd(instance *config.Installation, wiki *string) *cobra.Command {
+func newUpdateCmd(instance *config.Installation) *cobra.Command {
 	var (
+		wiki     string
 		skipJobs bool
 		skipSMW  bool
 	)
@@ -40,8 +41,8 @@ specific wiki.`,
 			return err
 		},
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if *wiki != "" {
-				return runMaintenanceUpdate(*instance, *wiki, skipJobs, skipSMW)
+			if wiki != "" {
+				return runMaintenanceUpdate(*instance, wiki, skipJobs, skipSMW)
 			}
 			wikiIDs, err := farmsettings.GetWikiIDs(instance.Path)
 			if err != nil {
@@ -56,6 +57,7 @@ specific wiki.`,
 		},
 	}
 
+	updateCmd.Flags().StringVarP(&wiki, "wiki", "w", "", "Wiki ID to run maintenance on (default: all wikis)")
 	updateCmd.Flags().BoolVar(&skipJobs, "skip-jobs", false, "Skip running runJobs.php")
 	updateCmd.Flags().BoolVar(&skipSMW, "skip-smw", false, "Skip running Semantic MediaWiki rebuildData.php")
 

--- a/cmd/maintenance/maintenance_test.go
+++ b/cmd/maintenance/maintenance_test.go
@@ -1,9 +1,14 @@
 package maintenance
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/config"
 )
 
 // findSubcommand returns the named subcommand, or nil if not found.
@@ -80,6 +85,65 @@ func TestScriptAcceptsZeroArgs(t *testing.T) {
 	cmd.SetArgs([]string{"script"})
 	if err := cmd.Execute(); err != nil {
 		t.Errorf("expected no error with zero args, got: %v", err)
+	}
+}
+
+func writeWikisYAML(t *testing.T, dir string, content string) {
+	t.Helper()
+	configDir := filepath.Join(dir, "config")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "wikis.yaml"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestScriptRequiresWikiOnFarm(t *testing.T) {
+	dir := t.TempDir()
+	writeWikisYAML(t, dir, "wikis:\n  - id: main\n    url: http://localhost\n  - id: docs\n    url: http://localhost\n")
+
+	mock := &extMockOrchestrator{}
+	inst := config.Installation{Path: dir}
+	err := runMaintenanceScriptWith(mock, inst, "rebuildrecentchanges.php", "")
+	if err == nil {
+		t.Fatal("expected error when --wiki not specified on farm")
+	}
+	if !strings.Contains(err.Error(), "wiki farm") {
+		t.Errorf("expected wiki farm error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "main") || !strings.Contains(err.Error(), "docs") {
+		t.Errorf("expected wiki IDs in error, got: %v", err)
+	}
+}
+
+func TestScriptAllowsWikiOnFarm(t *testing.T) {
+	dir := t.TempDir()
+	writeWikisYAML(t, dir, "wikis:\n  - id: main\n    url: http://localhost\n  - id: docs\n    url: http://localhost\n")
+
+	mock := &extMockOrchestrator{}
+	inst := config.Installation{Path: dir}
+	err := runMaintenanceScriptWith(mock, inst, "rebuildrecentchanges.php", "docs")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mock.streamingCalls) != 1 {
+		t.Fatalf("expected 1 streaming call, got %d", len(mock.streamingCalls))
+	}
+	if !strings.Contains(mock.streamingCalls[0], "--wiki=docs") {
+		t.Errorf("expected --wiki=docs, got: %s", mock.streamingCalls[0])
+	}
+}
+
+func TestScriptNoWikiRequiredOnSingleWiki(t *testing.T) {
+	dir := t.TempDir()
+	writeWikisYAML(t, dir, "wikis:\n  - id: main\n    url: http://localhost\n")
+
+	mock := &extMockOrchestrator{}
+	inst := config.Installation{Path: dir}
+	err := runMaintenanceScriptWith(mock, inst, "rebuildrecentchanges.php", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/cmd/maintenance/maintenance_test.go
+++ b/cmd/maintenance/maintenance_test.go
@@ -40,7 +40,6 @@ func TestMaintenancePersistentFlags(t *testing.T) {
 		shorthand string
 	}{
 		{"id", "i"},
-		{"wiki", "w"},
 	}
 
 	for _, f := range flags {
@@ -99,25 +98,28 @@ func writeWikisYAML(t *testing.T, dir string, content string) {
 	}
 }
 
-func TestScriptRequiresWikiOnFarm(t *testing.T) {
+func TestScriptRunsAllWikisOnFarm(t *testing.T) {
 	dir := t.TempDir()
 	writeWikisYAML(t, dir, "wikis:\n  - id: main\n    url: http://localhost\n  - id: docs\n    url: http://localhost\n")
 
 	mock := &extMockOrchestrator{}
 	inst := config.Installation{Path: dir}
 	err := runMaintenanceScriptWith(mock, inst, "rebuildrecentchanges.php", "")
-	if err == nil {
-		t.Fatal("expected error when --wiki not specified on farm")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "wiki farm") {
-		t.Errorf("expected wiki farm error, got: %v", err)
+	if len(mock.streamingCalls) != 2 {
+		t.Fatalf("expected 2 streaming calls (one per wiki), got %d", len(mock.streamingCalls))
 	}
-	if !strings.Contains(err.Error(), "main") || !strings.Contains(err.Error(), "docs") {
-		t.Errorf("expected wiki IDs in error, got: %v", err)
+	if !strings.Contains(mock.streamingCalls[0], "--wiki=main") {
+		t.Errorf("expected --wiki=main in first call, got: %s", mock.streamingCalls[0])
+	}
+	if !strings.Contains(mock.streamingCalls[1], "--wiki=docs") {
+		t.Errorf("expected --wiki=docs in second call, got: %s", mock.streamingCalls[1])
 	}
 }
 
-func TestScriptAllowsWikiOnFarm(t *testing.T) {
+func TestScriptRunsSpecificWikiOnFarm(t *testing.T) {
 	dir := t.TempDir()
 	writeWikisYAML(t, dir, "wikis:\n  - id: main\n    url: http://localhost\n  - id: docs\n    url: http://localhost\n")
 
@@ -135,18 +137,21 @@ func TestScriptAllowsWikiOnFarm(t *testing.T) {
 	}
 }
 
-func TestScriptRequiresWikiOnSingleWikiFarm(t *testing.T) {
+func TestScriptRunsAllWikisOnSingleWikiFarm(t *testing.T) {
 	dir := t.TempDir()
 	writeWikisYAML(t, dir, "wikis:\n  - id: main\n    url: http://localhost\n")
 
 	mock := &extMockOrchestrator{}
 	inst := config.Installation{Path: dir}
 	err := runMaintenanceScriptWith(mock, inst, "rebuildrecentchanges.php", "")
-	if err == nil {
-		t.Fatal("expected error when --wiki not specified on single-wiki farm")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "wiki farm") {
-		t.Errorf("expected wiki farm error, got: %v", err)
+	if len(mock.streamingCalls) != 1 {
+		t.Fatalf("expected 1 streaming call, got %d", len(mock.streamingCalls))
+	}
+	if !strings.Contains(mock.streamingCalls[0], "--wiki=main") {
+		t.Errorf("expected --wiki=main, got: %s", mock.streamingCalls[0])
 	}
 }
 

--- a/cmd/maintenance/maintenance_test.go
+++ b/cmd/maintenance/maintenance_test.go
@@ -135,15 +135,18 @@ func TestScriptAllowsWikiOnFarm(t *testing.T) {
 	}
 }
 
-func TestScriptNoWikiRequiredOnSingleWiki(t *testing.T) {
+func TestScriptRequiresWikiOnSingleWikiFarm(t *testing.T) {
 	dir := t.TempDir()
 	writeWikisYAML(t, dir, "wikis:\n  - id: main\n    url: http://localhost\n")
 
 	mock := &extMockOrchestrator{}
 	inst := config.Installation{Path: dir}
 	err := runMaintenanceScriptWith(mock, inst, "rebuildrecentchanges.php", "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if err == nil {
+		t.Fatal("expected error when --wiki not specified on single-wiki farm")
+	}
+	if !strings.Contains(err.Error(), "wiki farm") {
+		t.Errorf("expected wiki farm error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #648

## Summary

- Move `--wiki/-w` from a persistent flag on `maintenance` to a local flag on `update`, `script`, and `extension` — `exec` no longer shows `--wiki`
- Make `script` iterate over all wikis when `--wiki` is omitted, matching the behavior of `update` and `extension`
- Updated tests to verify wiki iteration behavior

## Test plan

- [x] Unit tests pass (`go test ./cmd/maintenance/...`)
- [x] Full test suite passes (`go test ./...`)
- [x] `canasta maintenance exec --help` does not show `--wiki`