### PR TITLE
Standardize required flag marking and add --id default description

### DIFF
--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -157,7 +157,7 @@ an existing database dump instead of running the installer.`,
 	addCmd.Flags().StringVarP(&wikiID, "wiki", "w", "", "ID of the new wiki")
 	addCmd.Flags().StringVarP(&url, "url", "u", "", "URL of the new wiki (domain/path format, e.g., 'localhost/wiki2' or 'example.com/mywiki'; do not include protocol/scheme)")
 	addCmd.Flags().StringVarP(&siteName, "site-name", "t", "", "Display name of the wiki (optional, defaults to wiki ID)")
-	addCmd.Flags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
+	addCmd.Flags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID (defaults to instance associated with current directory)")
 	addCmd.Flags().StringVarP(&databasePath, "database", "d", "", "Path to existing database dump (.sql or .sql.gz) to import instead of running install.php")
 	addCmd.Flags().StringVarP(&wikiSettingsPath, "wiki-settings", "l", "", "Path to per-wiki settings file to copy to config/settings/wikis/<wiki_id>/ (filename preserved)")
 	addCmd.Flags().StringVarP(&admin, "admin", "a", "WikiSysop", "Admin name of the new wiki (default: \"WikiSysop\")")

--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -85,10 +85,8 @@ an existing database dump instead of running the installer.`,
 
   # Add a wiki with an existing database dump
   canasta add -i myinstance -w docs -u localhost/docs -d /path/to/dump.sql`,
-		RunE: func(_ *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				return fmt.Errorf("unknown argument %q; use flags to specify options (e.g. canasta add --wiki <wiki> --url <url>)", args[0])
-			}
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
 			var err error
 
 			// Validate wiki ID

--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -70,7 +70,7 @@ and RESTIC_PASSWORD to be configured in the installation's .env file.`,
 	backupCmd.AddCommand(newPurgeCmd(&orch, &instance, &envPath, &repoURL))
 	backupCmd.AddCommand(newScheduleCmd(&instance))
 
-	backupCmd.PersistentFlags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
+	backupCmd.PersistentFlags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID (defaults to instance associated with current directory)")
 	return backupCmd
 
 }

--- a/cmd/backup/check.go
+++ b/cmd/backup/check.go
@@ -17,7 +17,7 @@ func newCheckCmd(orch *orchestrators.Orchestrator, instance *config.Installation
 		Long: `Verify the integrity of the backup repository and its data. This
 checks for errors in the repository structure and snapshot data.`,
 		Example: `  canasta backup check -i myinstance`,
-		Args: cobra.NoArgs,
+		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			output, err := runBackup(*orch, instance.Path, *envPath, nil, "-r", *repoURL, "check")
 			if err != nil {

--- a/cmd/backup/check.go
+++ b/cmd/backup/check.go
@@ -17,6 +17,7 @@ func newCheckCmd(orch *orchestrators.Orchestrator, instance *config.Installation
 		Long: `Verify the integrity of the backup repository and its data. This
 checks for errors in the repository structure and snapshot data.`,
 		Example: `  canasta backup check -i myinstance`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			output, err := runBackup(*orch, instance.Path, *envPath, nil, "-r", *repoURL, "check")
 			if err != nil {

--- a/cmd/backup/create.go
+++ b/cmd/backup/create.go
@@ -36,7 +36,7 @@ uploads the snapshot to the backup repository with the specified tag.`,
 		},
 	}
 
-	createBackupCmd.Flags().StringVarP(&tag, "tag", "t", "", "Backup tag (required)")
+	createBackupCmd.Flags().StringVarP(&tag, "tag", "t", "", "Backup tag")
 	_ = createBackupCmd.MarkFlagRequired("tag")
 	return createBackupCmd
 }

--- a/cmd/backup/create.go
+++ b/cmd/backup/create.go
@@ -27,6 +27,7 @@ with .env, docker-compose.override.yml, and my.cnf (if present), then
 uploads the snapshot to the backup repository with the specified tag.`,
 		Example: `  # Create a backup with a descriptive tag
   canasta backup create -i myinstance -t before-upgrade`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := takeSnapshot(*orch, *instance, *envPath, *repoURL, tag); err != nil {
 				return err

--- a/cmd/backup/delete.go
+++ b/cmd/backup/delete.go
@@ -18,6 +18,7 @@ func newDeleteCmd(orch *orchestrators.Orchestrator, instance *config.Installatio
 		Long: `Remove a snapshot from the backup repository by its ID. The snapshot data
 may still exist until a prune is run on the repository.`,
 		Example: `  canasta backup delete -i myinstance -s abc123`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			output, err := runBackup(*orch, instance.Path, *envPath, nil, "-r", *repoURL, "forget", snapshot)
 			if err != nil {

--- a/cmd/backup/delete.go
+++ b/cmd/backup/delete.go
@@ -28,7 +28,7 @@ may still exist until a prune is run on the repository.`,
 		},
 	}
 
-	deleteCmd.Flags().StringVarP(&snapshot, "snapshot", "s", "", "Snapshot ID (required)")
+	deleteCmd.Flags().StringVarP(&snapshot, "snapshot", "s", "", "Snapshot ID")
 	_ = deleteCmd.MarkFlagRequired("snapshot")
 	return deleteCmd
 }

--- a/cmd/backup/delete.go
+++ b/cmd/backup/delete.go
@@ -18,7 +18,7 @@ func newDeleteCmd(orch *orchestrators.Orchestrator, instance *config.Installatio
 		Long: `Remove a snapshot from the backup repository by its ID. The snapshot data
 may still exist until a prune is run on the repository.`,
 		Example: `  canasta backup delete -i myinstance -s abc123`,
-		Args: cobra.NoArgs,
+		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			output, err := runBackup(*orch, instance.Path, *envPath, nil, "-r", *repoURL, "forget", snapshot)
 			if err != nil {

--- a/cmd/backup/diff.go
+++ b/cmd/backup/diff.go
@@ -19,7 +19,7 @@ func newDiffCmd(orch *orchestrators.Orchestrator, instance *config.Installation,
 contents and metadata of both snapshots, displaying added, removed, and
 modified files.`,
 		Example: `  canasta backup diff -i myinstance --snapshot1 abc123 --snapshot2 def456`,
-		Args: cobra.NoArgs,
+		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			output, err := runBackup(*orch, instance.Path, *envPath, nil, "-r", *repoURL, "diff", snapshot1, snapshot2)
 			if err != nil {

--- a/cmd/backup/diff.go
+++ b/cmd/backup/diff.go
@@ -19,6 +19,7 @@ func newDiffCmd(orch *orchestrators.Orchestrator, instance *config.Installation,
 contents and metadata of both snapshots, displaying added, removed, and
 modified files.`,
 		Example: `  canasta backup diff -i myinstance --snapshot1 abc123 --snapshot2 def456`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			output, err := runBackup(*orch, instance.Path, *envPath, nil, "-r", *repoURL, "diff", snapshot1, snapshot2)
 			if err != nil {

--- a/cmd/backup/diff.go
+++ b/cmd/backup/diff.go
@@ -28,8 +28,8 @@ modified files.`,
 			return nil
 		},
 	}
-	diffCmd.Flags().StringVar(&snapshot1, "snapshot1", "", "First snapshot ID (required)")
-	diffCmd.Flags().StringVar(&snapshot2, "snapshot2", "", "Second snapshot ID (required)")
+	diffCmd.Flags().StringVar(&snapshot1, "snapshot1", "", "First snapshot ID")
+	diffCmd.Flags().StringVar(&snapshot2, "snapshot2", "", "Second snapshot ID")
 	_ = diffCmd.MarkFlagRequired("snapshot1")
 	_ = diffCmd.MarkFlagRequired("snapshot2")
 	return diffCmd

--- a/cmd/backup/files.go
+++ b/cmd/backup/files.go
@@ -18,6 +18,7 @@ func newFilesCmd(orch *orchestrators.Orchestrator, instance *config.Installation
 		Long: `List all files contained in a specific backup snapshot. This is useful
 for inspecting what was backed up before performing a restore.`,
 		Example: `  canasta backup files -i myinstance -s abc123`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			output, err := runBackup(*orch, instance.Path, *envPath, nil, "-r", *repoURL, "ls", snapshot)
 			if err != nil {

--- a/cmd/backup/files.go
+++ b/cmd/backup/files.go
@@ -27,7 +27,7 @@ for inspecting what was backed up before performing a restore.`,
 			return nil
 		},
 	}
-	filesCmd.Flags().StringVarP(&snapshot, "snapshot", "s", "", "Snapshot ID (required)")
+	filesCmd.Flags().StringVarP(&snapshot, "snapshot", "s", "", "Snapshot ID")
 	_ = filesCmd.MarkFlagRequired("snapshot")
 	return filesCmd
 }

--- a/cmd/backup/files.go
+++ b/cmd/backup/files.go
@@ -18,7 +18,7 @@ func newFilesCmd(orch *orchestrators.Orchestrator, instance *config.Installation
 		Long: `List all files contained in a specific backup snapshot. This is useful
 for inspecting what was backed up before performing a restore.`,
 		Example: `  canasta backup files -i myinstance -s abc123`,
-		Args: cobra.NoArgs,
+		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			output, err := runBackup(*orch, instance.Path, *envPath, nil, "-r", *repoURL, "ls", snapshot)
 			if err != nil {

--- a/cmd/backup/init.go
+++ b/cmd/backup/init.go
@@ -18,6 +18,7 @@ func newInitCmd(orch *orchestrators.Orchestrator, instance *config.Installation,
 creating any backups. The repository location is read from the
 RESTIC_REPOSITORY variable (or AWS S3 settings) in the installation's .env file.`,
 		Example: `  canasta backup init -i myinstance`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			fmt.Println("Initializing backup repository")
 			output, err := runBackup(*orch, instance.Path, *envPath, nil, "-r", *repoURL, "init")

--- a/cmd/backup/init.go
+++ b/cmd/backup/init.go
@@ -18,7 +18,7 @@ func newInitCmd(orch *orchestrators.Orchestrator, instance *config.Installation,
 creating any backups. The repository location is read from the
 RESTIC_REPOSITORY variable (or AWS S3 settings) in the installation's .env file.`,
 		Example: `  canasta backup init -i myinstance`,
-		Args: cobra.NoArgs,
+		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			fmt.Println("Initializing backup repository")
 			output, err := runBackup(*orch, instance.Path, *envPath, nil, "-r", *repoURL, "init")

--- a/cmd/backup/list.go
+++ b/cmd/backup/list.go
@@ -17,6 +17,7 @@ func newListCmd(orch *orchestrators.Orchestrator, instance *config.Installation,
 		Long: `List all snapshots stored in the backup repository. Displays
 each snapshot's ID, timestamp, hostname, and tags.`,
 		Example: `  canasta backup list -i myinstance`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			output, err := runBackup(*orch, instance.Path, *envPath, nil, "-r", *repoURL, "snapshots")
 			if err != nil {

--- a/cmd/backup/list.go
+++ b/cmd/backup/list.go
@@ -17,7 +17,7 @@ func newListCmd(orch *orchestrators.Orchestrator, instance *config.Installation,
 		Long: `List all snapshots stored in the backup repository. Displays
 each snapshot's ID, timestamp, hostname, and tags.`,
 		Example: `  canasta backup list -i myinstance`,
-		Args: cobra.NoArgs,
+		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			output, err := runBackup(*orch, instance.Path, *envPath, nil, "-r", *repoURL, "snapshots")
 			if err != nil {

--- a/cmd/backup/purge.go
+++ b/cmd/backup/purge.go
@@ -33,6 +33,7 @@ is required.`,
 
   # Preview what would be removed
   canasta backup purge -i myinstance --older-than 30d --dry-run`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if olderThan == "" && keepLast == 0 {
 				return fmt.Errorf("at least one of --older-than or --keep-last is required")

--- a/cmd/backup/restore.go
+++ b/cmd/backup/restore.go
@@ -45,7 +45,7 @@ images, and public assets from the backup, leaving shared files untouched.`,
 		},
 	}
 
-	restoreCmd.Flags().StringVarP(&snapshotID, "snapshot", "s", "", "Snapshot ID (required)")
+	restoreCmd.Flags().StringVarP(&snapshotID, "snapshot", "s", "", "Snapshot ID")
 	restoreCmd.Flags().BoolVar(&skipBeforeSnapshot, "skip-safety-backup", false, "Skip taking a safety backup before restore")
 	restoreCmd.Flags().StringVarP(&wikiID, "wiki", "w", "", "Restore only this wiki's database and per-wiki files")
 	_ = restoreCmd.MarkFlagRequired("snapshot")

--- a/cmd/backup/restore.go
+++ b/cmd/backup/restore.go
@@ -40,6 +40,7 @@ images, and public assets from the backup, leaving shared files untouched.`,
 
   # Restore only a single wiki's database
   canasta backup restore -i myinstance -s abc123 -w wiki2`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return restoreSnapshot(*orch, *instance, *envPath, *repoURL, snapshotID, skipBeforeSnapshot, wikiID)
 		},

--- a/cmd/backup/unlock.go
+++ b/cmd/backup/unlock.go
@@ -17,6 +17,7 @@ func newUnlockCmd(orch *orchestrators.Orchestrator, instance *config.Installatio
 		Long: `Remove stale lock files from the backup repository. Use this if a previous
 backup operation was interrupted and left the repository in a locked state.`,
 		Example: `  canasta backup unlock -i myinstance`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			output, err := runBackup(*orch, instance.Path, *envPath, nil, "-r", *repoURL, "unlock")
 			if err != nil {

--- a/cmd/backup/unlock.go
+++ b/cmd/backup/unlock.go
@@ -17,7 +17,7 @@ func newUnlockCmd(orch *orchestrators.Orchestrator, instance *config.Installatio
 		Long: `Remove stale lock files from the backup repository. Use this if a previous
 backup operation was interrupted and left the repository in a locked state.`,
 		Example: `  canasta backup unlock -i myinstance`,
-		Args: cobra.NoArgs,
+		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			output, err := runBackup(*orch, instance.Path, *envPath, nil, "-r", *repoURL, "unlock")
 			if err != nil {

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -90,7 +90,7 @@ To change the domain, first edit config/wikis.yaml, then use
 		},
 	}
 
-	configCmd.PersistentFlags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
+	configCmd.PersistentFlags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID (defaults to instance associated with current directory)")
 
 	configCmd.AddCommand(newGetCmd(&instance))
 	configCmd.AddCommand(newSetCmd(&instance, &orch))

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -54,6 +54,7 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
 
   # Create with an existing database dump
   canasta create -i myinstance -w main -d /path/to/dump.sql -n example.com`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Check if the system has at least 4GB of memory
 			if err := system.CheckMemoryInGB(4); err != nil {

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -36,10 +36,8 @@ prompted for confirmation before any data is deleted.`,
 
   # Delete without confirmation prompt
   canasta delete -i myinstance -y`,
-		RunE: func(_ *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				return fmt.Errorf("unknown argument %q; use --id to specify the instance ID (e.g. canasta delete --id %s)", args[0], args[0])
-			}
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
 			var err error
 			instance, err = canasta.CheckCanastaID(instance)
 			if err != nil {

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -57,7 +57,7 @@ prompted for confirmation before any data is deleted.`,
 			return nil
 		},
 	}
-	deleteCmd.Flags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
+	deleteCmd.Flags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID (defaults to instance associated with current directory)")
 	deleteCmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompt")
 	return deleteCmd
 }

--- a/cmd/devmode/devmode.go
+++ b/cmd/devmode/devmode.go
@@ -47,7 +47,7 @@ debugging. This is only supported with Docker Compose.`,
 		},
 	}
 
-	devmodeCmd.PersistentFlags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
+	devmodeCmd.PersistentFlags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID (defaults to instance associated with current directory)")
 
 	devmodeCmd.AddCommand(newEnableCmd(&instance, &orch))
 	devmodeCmd.AddCommand(newDisableCmd(&instance, &orch))

--- a/cmd/devmode/disable.go
+++ b/cmd/devmode/disable.go
@@ -21,6 +21,7 @@ directory is preserved so you can re-enable dev mode later without
 re-extracting code.`,
 		Example: `  # Disable dev mode on an installation
   canasta devmode disable -i myinstance`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			fmt.Printf("Disabling development mode on '%s'...\n", instance.ID)
 

--- a/cmd/devmode/enable.go
+++ b/cmd/devmode/enable.go
@@ -21,6 +21,7 @@ MediaWiki code for live editing, builds an Xdebug-enabled image, and restarts
 the instance with dev mode compose files. Only supported with Docker Compose.`,
 		Example: `  # Enable dev mode on an installation
   canasta devmode enable -i myinstance`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			fmt.Printf("Enabling development mode on '%s'...\n", instance.ID)
 

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -81,7 +81,7 @@ Use a .gz extension on the output path to get a gzip-compressed dump.`,
 	}
 	instance.Path = workingDir
 
-	exportCmd.Flags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
+	exportCmd.Flags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID (defaults to instance associated with current directory)")
 	exportCmd.Flags().StringVarP(&wikiID, "wiki", "w", "", "ID of the wiki to export")
 	exportCmd.Flags().StringVarP(&outputPath, "file", "f", "", "Output file path (default: <wikiID>.sql)")
 

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -34,6 +34,7 @@ Use a .gz extension on the output path to get a gzip-compressed dump.`,
 
   # Export as gzipped SQL
   canasta export -i myinstance -w main -f /backups/main-backup.sql.gz`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			var err error
 

--- a/cmd/gitops/diff.go
+++ b/cmd/gitops/diff.go
@@ -14,6 +14,7 @@ func newDiffCmd(instance *config.Installation) *cobra.Command {
 		Use:   "diff",
 		Short: "Show what would change on pull (dry run)",
 		Long:  `Fetch the latest changes from the remote and show what files would be updated without actually applying them.`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runDiff(instance.Path)
 		},

--- a/cmd/gitops/diff.go
+++ b/cmd/gitops/diff.go
@@ -14,7 +14,7 @@ func newDiffCmd(instance *config.Installation) *cobra.Command {
 		Use:   "diff",
 		Short: "Show what would change on pull (dry run)",
 		Long:  `Fetch the latest changes from the remote and show what files would be updated without actually applying them.`,
-		Args: cobra.NoArgs,
+		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runDiff(instance.Path)
 		},

--- a/cmd/gitops/gitops.go
+++ b/cmd/gitops/gitops.go
@@ -42,6 +42,6 @@ git-crypt, and multi-server deployments with push/pull workflows.`,
 	gitopsCmd.AddCommand(newStatusCmd(&instance))
 	gitopsCmd.AddCommand(newDiffCmd(&instance))
 
-	gitopsCmd.PersistentFlags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
+	gitopsCmd.PersistentFlags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID (defaults to instance associated with current directory)")
 	return gitopsCmd
 }

--- a/cmd/gitops/init.go
+++ b/cmd/gitops/init.go
@@ -58,6 +58,7 @@ without re-initializing. This re-converts extensions/skins that were
 committed as regular directories instead of submodules.
 
 To join an existing gitops repository instead, use "canasta gitops join".`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if repair {
 				return runRepairSubmodules(instance.Path)

--- a/cmd/gitops/init.go
+++ b/cmd/gitops/init.go
@@ -19,7 +19,7 @@ import (
 
 var validHostName = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9_-]*[a-zA-Z0-9])?$`)
 
-func validateInitFlags(hostName, repoURL, keyFile string) error {
+func validateInitFlags(hostName string) error {
 	if !validHostName.MatchString(hostName) {
 		return fmt.Errorf("invalid host name %q: must contain only alphanumeric characters, hyphens, and underscores", hostName)
 	}
@@ -62,7 +62,7 @@ To join an existing gitops repository instead, use "canasta gitops join".`,
 			if repair {
 				return runRepairSubmodules(instance.Path)
 			}
-			if err := validateInitFlags(hostName, repoURL, keyFile); err != nil {
+			if err := validateInitFlags(hostName); err != nil {
 				return err
 			}
 			if err := gitops.ValidateRole(role); err != nil {

--- a/cmd/gitops/init.go
+++ b/cmd/gitops/init.go
@@ -20,17 +20,8 @@ import (
 var validHostName = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9_-]*[a-zA-Z0-9])?$`)
 
 func validateInitFlags(hostName, repoURL, keyFile string) error {
-	if hostName == "" {
-		return fmt.Errorf("--name is required")
-	}
 	if !validHostName.MatchString(hostName) {
 		return fmt.Errorf("invalid host name %q: must contain only alphanumeric characters, hyphens, and underscores", hostName)
-	}
-	if repoURL == "" {
-		return fmt.Errorf("--repo is required")
-	}
-	if keyFile == "" {
-		return fmt.Errorf("--key is required")
 	}
 	return nil
 }
@@ -81,13 +72,18 @@ To join an existing gitops repository instead, use "canasta gitops join".`,
 		},
 	}
 
-	cmd.Flags().StringVarP(&hostName, "name", "n", "", "Name for this host in hosts.yaml (required)")
+	cmd.Flags().StringVarP(&hostName, "name", "n", "", "Name for this host in hosts.yaml")
 	cmd.Flags().StringVar(&role, "role", gitops.RoleBoth, "Host role: source, sink, or both")
-	cmd.Flags().StringVar(&repoURL, "repo", "", "Git repository URL (required)")
-	cmd.Flags().StringVar(&keyFile, "key", "", "Path to export the git-crypt key (required)")
+	cmd.Flags().StringVar(&repoURL, "repo", "", "Git repository URL")
+	cmd.Flags().StringVar(&keyFile, "key", "", "Path to export the git-crypt key")
 	cmd.Flags().BoolVar(&force, "force", false, "Force push to a non-empty remote repository")
 	cmd.Flags().BoolVar(&pullRequests, "pull-requests", false, "Require pull requests instead of pushing directly to main")
 	cmd.Flags().BoolVar(&repair, "repair", false, "Re-register extensions/skins as proper submodules")
+
+	_ = cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("repo")
+	_ = cmd.MarkFlagRequired("key")
+
 	return cmd
 }
 

--- a/cmd/gitops/join.go
+++ b/cmd/gitops/join.go
@@ -34,7 +34,7 @@ pushes the new host entry back to the repo.
 The installation must already exist and have a working .env file. Use
 "canasta gitops init" to bootstrap a new gitops repository instead.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if err := validateInitFlags(hostName, repoURL, keyFile); err != nil {
+			if err := validateInitFlags(hostName); err != nil {
 				return err
 			}
 			if err := gitops.ValidateRole(role); err != nil {

--- a/cmd/gitops/join.go
+++ b/cmd/gitops/join.go
@@ -44,10 +44,15 @@ The installation must already exist and have a working .env file. Use
 		},
 	}
 
-	cmd.Flags().StringVarP(&hostName, "name", "n", "", "Name for this host in hosts.yaml (required)")
+	cmd.Flags().StringVarP(&hostName, "name", "n", "", "Name for this host in hosts.yaml")
 	cmd.Flags().StringVar(&role, "role", gitops.RoleBoth, "Host role: source, sink, or both")
-	cmd.Flags().StringVar(&repoURL, "repo", "", "Git repository URL (required)")
-	cmd.Flags().StringVar(&keyFile, "key", "", "Path to the git-crypt key file (required)")
+	cmd.Flags().StringVar(&repoURL, "repo", "", "Git repository URL")
+	cmd.Flags().StringVar(&keyFile, "key", "", "Path to the git-crypt key file")
+
+	_ = cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("repo")
+	_ = cmd.MarkFlagRequired("key")
+
 	return cmd
 }
 

--- a/cmd/gitops/join.go
+++ b/cmd/gitops/join.go
@@ -33,6 +33,7 @@ pushes the new host entry back to the repo.
 
 The installation must already exist and have a working .env file. Use
 "canasta gitops init" to bootstrap a new gitops repository instead.`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := validateInitFlags(hostName); err != nil {
 				return err

--- a/cmd/gitops/pull.go
+++ b/cmd/gitops/pull.go
@@ -21,6 +21,7 @@ func newPullCmd(instance *config.Installation) *cobra.Command {
 		Long: `Pull the latest configuration from the remote repository, update submodules,
 render .env and admin password files from the template and host vars, and
 report what changed and whether a restart is needed.`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			result, err := runPull(instance.Path)
 			if err != nil {

--- a/cmd/gitops/push.go
+++ b/cmd/gitops/push.go
@@ -23,6 +23,7 @@ func newPushCmd(instance *config.Installation) *cobra.Command {
 staged first using "canasta gitops add". When pull_requests is enabled in
 hosts.yaml, creates a branch and opens a pull request instead of pushing
 directly to main.`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			result, err := runPush(instance.Path, message)
 			if err != nil {

--- a/cmd/gitops/status.go
+++ b/cmd/gitops/status.go
@@ -14,7 +14,7 @@ func newStatusCmd(instance *config.Installation) *cobra.Command {
 		Use:   "status",
 		Short: "Show gitops status for the installation",
 		Long:  `Show the current host, role, uncommitted changes, and ahead/behind status relative to the remote.`,
-		Args: cobra.NoArgs,
+		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runStatus(instance.Path)
 		},

--- a/cmd/gitops/status.go
+++ b/cmd/gitops/status.go
@@ -14,6 +14,7 @@ func newStatusCmd(instance *config.Installation) *cobra.Command {
 		Use:   "status",
 		Short: "Show gitops status for the installation",
 		Long:  `Show the current host, role, uncommitted changes, and ahead/behind status relative to the remote.`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runStatus(instance.Path)
 		},

--- a/cmd/import/import.go
+++ b/cmd/import/import.go
@@ -36,6 +36,7 @@ To create a new wiki from a database dump, use the --database flag with
 
   # Import a gzipped dump and replace the wiki's Settings.php
   canasta import -i myinstance -w main -d /path/to/dump.sql.gz -l /path/to/Settings.php`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			var err error
 

--- a/cmd/import/import.go
+++ b/cmd/import/import.go
@@ -91,7 +91,7 @@ To create a new wiki from a database dump, use the --database flag with
 	}
 	instance.Path = workingDir
 
-	importCmd.Flags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
+	importCmd.Flags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID (defaults to instance associated with current directory)")
 	importCmd.Flags().StringVarP(&wikiID, "wiki", "w", "", "ID of the wiki to import into")
 	importCmd.Flags().StringVarP(&databasePath, "database", "d", "", "Path to SQL dump file (.sql or .sql.gz)")
 	importCmd.Flags().StringVarP(&settingsPath, "wiki-settings", "l", "", "Path to per-wiki Settings.php to replace the existing one")

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -23,6 +23,7 @@ ID, path, and orchestrator as recorded in the Canasta configuration file.
 Use --cleanup to remove stale entries whose installation directories no longer exist.`,
 		Example: `  canasta list
   canasta list --cleanup`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return List(instance, cleanup)
 		},

--- a/cmd/maintenance/maintenance.go
+++ b/cmd/maintenance/maintenance.go
@@ -34,7 +34,7 @@ arbitrary core maintenance scripts, or run extension-specific maintenance script
 	maintenanceCmd.AddCommand(newExtensionCmd(&instance, &wiki))
 	maintenanceCmd.AddCommand(newExecCmd(&instance))
 
-	maintenanceCmd.PersistentFlags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
+	maintenanceCmd.PersistentFlags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID (defaults to instance associated with current directory)")
 	maintenanceCmd.PersistentFlags().StringVarP(&wiki, "wiki", "w", "", "Wiki ID to run maintenance on (default: all wikis)")
 	return maintenanceCmd
 }

--- a/cmd/maintenance/maintenanceUpdate.go
+++ b/cmd/maintenance/maintenanceUpdate.go
@@ -34,6 +34,7 @@ specific wiki.`,
 		Example: `  canasta maintenance update -i myinstance
   canasta maintenance update -i myinstance --wiki=docs
   canasta maintenance update -i myinstance --skip-jobs --skip-smw`,
+		Args: cobra.NoArgs,
 		PreRunE: func(_ *cobra.Command, _ []string) error {
 			var err error
 			*instance, err = canasta.CheckCanastaID(*instance)

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -38,11 +38,8 @@ for confirmation before any data is deleted.`,
 
   # Remove without confirmation prompt
   canasta remove -i myinstance -w docs -y`,
-		RunE: func(_ *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				return fmt.Errorf("unknown argument %q; use --wiki to specify the wiki ID (e.g. canasta remove --wiki %s)", args[0], args[0])
-			}
-
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
 			instance, err = canasta.CheckCanastaID(instance)
 			if err != nil {
 				return err

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -39,11 +39,8 @@ for confirmation before any data is deleted.`,
   # Remove without confirmation prompt
   canasta remove -i myinstance -w docs -y`,
 		RunE: func(_ *cobra.Command, args []string) error {
-			if wikiID == "" {
-				if len(args) > 0 {
-					return fmt.Errorf("unknown argument %q; use --wiki to specify the wiki ID (e.g. canasta remove --wiki %s)", args[0], args[0])
-				}
-				return fmt.Errorf("--wiki flag is required")
+			if len(args) > 0 {
+				return fmt.Errorf("unknown argument %q; use --wiki to specify the wiki ID (e.g. canasta remove --wiki %s)", args[0], args[0])
 			}
 
 			instance, err = canasta.CheckCanastaID(instance)
@@ -61,8 +58,11 @@ for confirmation before any data is deleted.`,
 	}
 
 	addCmd.Flags().StringVarP(&wikiID, "wiki", "w", "", "ID of the wiki")
-	addCmd.Flags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
+	addCmd.Flags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID (defaults to instance associated with current directory)")
 	addCmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompt")
+
+	_ = addCmd.MarkFlagRequired("wiki")
+
 	return addCmd
 }
 

--- a/cmd/restart/restart.go
+++ b/cmd/restart/restart.go
@@ -30,10 +30,8 @@ restart. Use 'canasta devmode enable' or 'canasta devmode disable' to
 change the development mode setting.`,
 		Example: `  # Restart an installation by ID
   canasta restart -i myinstance`,
-		RunE: func(_ *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				return fmt.Errorf("unknown argument %q; use --id to specify the instance ID (e.g. canasta restart --id %s)", args[0], args[0])
-			}
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
 			resolvedInstance, err := canasta.CheckCanastaID(instance)
 			if err != nil {
 				return err

--- a/cmd/restart/restart.go
+++ b/cmd/restart/restart.go
@@ -46,7 +46,7 @@ change the development mode setting.`,
 			return nil
 		},
 	}
-	restartCmd.Flags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
+	restartCmd.Flags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID (defaults to instance associated with current directory)")
 	return restartCmd
 }
 

--- a/cmd/sitemap/generate.go
+++ b/cmd/sitemap/generate.go
@@ -27,6 +27,7 @@ generator will automatically refresh them.`,
 
   # Generate sitemaps for all wikis
   canasta sitemap generate -i myinstance`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runGenerate(*instance, *orch, wikiID)
 		},

--- a/cmd/sitemap/remove.go
+++ b/cmd/sitemap/remove.go
@@ -32,6 +32,7 @@ for all wikis. Once removed, the background generator will skip those wikis.`,
 
   # Remove sitemaps for all wikis without prompting
   canasta sitemap remove -i myinstance -y`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runRemove(*instance, *orch, wikiID, yes)
 		},

--- a/cmd/sitemap/sitemap.go
+++ b/cmd/sitemap/sitemap.go
@@ -47,7 +47,7 @@ to delete them.`,
 	sitemapCmd.AddCommand(newGenerateCmd(&instance, &orch))
 	sitemapCmd.AddCommand(newRemoveCmd(&instance, &orch))
 
-	sitemapCmd.PersistentFlags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
+	sitemapCmd.PersistentFlags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID (defaults to instance associated with current directory)")
 
 	return sitemapCmd
 }

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -29,10 +29,8 @@ has development mode enabled, it starts with Xdebug automatically. Use
 development mode setting.`,
 		Example: `  # Start an installation by ID
   canasta start -i myinstance`,
-		RunE: func(_ *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				return fmt.Errorf("unknown argument %q; use --id to specify the instance ID (e.g. canasta start --id %s)", args[0], args[0])
-			}
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
 			resolvedInstance, err := canasta.CheckCanastaID(instance)
 			if err != nil {
 				return err

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -45,7 +45,7 @@ development mode setting.`,
 			return nil
 		},
 	}
-	startCmd.Flags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
+	startCmd.Flags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID (defaults to instance associated with current directory)")
 	return startCmd
 }
 

--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -27,10 +27,8 @@ func NewCmd() *cobra.Command {
 are stopped gracefully, preserving all data in Docker volumes.`,
 		Example: `  # Stop an installation by ID
   canasta stop -i myinstance`,
-		RunE: func(_ *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				return fmt.Errorf("unknown argument %q; use --id to specify the instance ID (e.g. canasta stop --id %s)", args[0], args[0])
-			}
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
 			resolvedInstance, err := canasta.CheckCanastaID(instance)
 			if err != nil {
 				return err

--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -43,7 +43,7 @@ are stopped gracefully, preserving all data in Docker volumes.`,
 			return nil
 		},
 	}
-	stopCmd.Flags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
+	stopCmd.Flags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID (defaults to instance associated with current directory)")
 	return stopCmd
 }
 

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -51,6 +51,7 @@ distributed using the stored configuration.`,
 
   # Preview what would change without applying
   canasta upgrade --dry-run`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			// Check for CLI updates first (skipped automatically for dev builds and dry-run)
 			if !dryRun {

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -28,7 +28,7 @@ func NewCmd() *cobra.Command {
 		Long: `Display the Canasta CLI version, git commit hash, and build timestamp.
 Shows "dev" if the binary was built without version information.`,
 		Example: `  canasta version`,
-		Args: cobra.NoArgs,
+		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			fmt.Println(displayVersion())
 			return nil

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -28,6 +28,7 @@ func NewCmd() *cobra.Command {
 		Long: `Display the Canasta CLI version, git commit hash, and build timestamp.
 Shows "dev" if the binary was built without version information.`,
 		Example: `  canasta version`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			fmt.Println(displayVersion())
 			return nil

--- a/internal/extensionsskins/commands.go
+++ b/internal/extensionsskins/commands.go
@@ -46,7 +46,7 @@ a specific wiki in a farm.`, constants.Plural, constants.Plural),
 		},
 	}
 
-	cmd.PersistentFlags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID")
+	cmd.PersistentFlags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID (defaults to instance associated with current directory)")
 	cmd.PersistentFlags().StringVarP(&wiki, "wiki", "w", "", "ID of the specific wiki within the Canasta farm")
 
 	cmd.AddCommand(newListCmd(&instance, &orch, &wiki, &constants))


### PR DESCRIPTION
## Summary

- Standardize on `MarkFlagRequired` for all required flags, replacing inconsistent mix of `MarkFlagRequired`, `(required)` in description text, and runtime validation
- Add `MarkFlagRequired` to `gitops init` (`--name`, `--repo`, `--key`), `gitops join` (`--name`, `--repo`, `--key`), and `remove` (`--wiki`)
- Remove redundant `(required)` from flag descriptions where `MarkFlagRequired` is already used (backup commands)
- Remove redundant empty-string checks in `validateInitFlags` and `remove`'s `RunE` now that Cobra handles them
- Add `(defaults to instance associated with current directory)` to `--id` description on all commands except `create` (where `--id` is required)
- Add `cobra.NoArgs` to all 32 commands that don't accept positional arguments, ensuring unexpected args produce a clear error instead of being silently ignored
- Remove redundant manual `len(args) > 0` checks in `delete`, `start`, `stop`, `restart`, and `add`

## Test plan

- [x] Verify `go test ./...` passes
- [x] Verify `canasta gitops init` without `--name` shows Cobra's required flag error
- [x] Verify `canasta remove` without `--wiki` shows Cobra's required flag error
- [x] Verify `canasta create` still requires `--id`
- [x] Verify `canasta start` (and similar) still defaults `--id` to current directory
- [x] Verify `canasta start foo` rejects unexpected positional argument

Fixes #650