### PR TITLE
Standardize flags-first argument style in maintenance subcommands

### DIFF
--- a/cmd/maintenance/exec.go
+++ b/cmd/maintenance/exec.go
@@ -15,14 +15,18 @@ func newExecCmd(instance *config.Installation) *cobra.Command {
 	var service string
 
 	cmd := &cobra.Command{
-		Use:   "exec [-- command ...]",
-		Short: "Execute a command in a running container",
+		Use:                   "exec [flags] [command ...]",
+		DisableFlagsInUseLine: true,
+		Short:                 "Execute a command in a running container",
 		Long: `Execute a command or open an interactive shell in a running container
 of a Canasta installation.
 
 With no arguments and no --service flag, lists the running services.
 With --service (or -s) and no command, opens an interactive bash shell.
-With --service and a command after --, runs that command.
+With --service and a command, runs that command.
+
+Flags (-i, -s) must come before the command. Everything after the first
+non-flag argument is treated as the command and its arguments.
 
 The default service is "web" (the MediaWiki container).`,
 		Example: `  # List running services
@@ -32,10 +36,10 @@ The default service is "web" (the MediaWiki container).`,
   canasta maintenance exec -i myinstance -s web
 
   # Run a command in the web container
-  canasta maintenance exec -i myinstance -s web -- ls /var/www
+  canasta maintenance exec -i myinstance -s web ls /var/www
 
   # Default service is "web", so this also works
-  canasta maintenance exec -i myinstance -- php -v`,
+  canasta maintenance exec -i myinstance php -v`,
 		PreRunE: func(_ *cobra.Command, _ []string) error {
 			var err error
 			*instance, err = canasta.CheckCanastaID(*instance)
@@ -92,5 +96,8 @@ The default service is "web" (the MediaWiki container).`,
 	}
 
 	cmd.Flags().StringVarP(&service, "service", "s", "", "Service name (default: web)")
+	// Stop parsing flags after the first non-flag argument (the command).
+	// This allows command arguments like -v to be passed without --.
+	cmd.Flags().SetInterspersed(false)
 	return cmd
 }

--- a/cmd/maintenance/extension.go
+++ b/cmd/maintenance/extension.go
@@ -21,8 +21,9 @@ var wikiArgRe = regexp.MustCompile(`(?:^|\s)--wiki[=\s](\S+)`)
 func newExtensionCmd(instance *config.Installation, wiki *string) *cobra.Command {
 
 	extensionCmd := &cobra.Command{
-		Use:   "extension [extension-name] [script.php [args...]]",
-		Short: "Run extension maintenance scripts",
+		Use:                   "extension [flags] [extension-name] [script.php [args...]]",
+		DisableFlagsInUseLine: true,
+		Short:                 "Run extension maintenance scripts",
 		Long: `Run maintenance scripts provided by loaded MediaWiki extensions.
 
 With no arguments, lists all loaded extensions that have a maintenance/
@@ -30,9 +31,8 @@ directory. With one argument (extension name), lists available maintenance
 scripts for that extension. With two or more arguments (extension name,
 script name, and optional script arguments), runs the specified script.
 
-Flags (-i, --wiki) must come before the extension name. Everything after
-the extension name is treated as the script and its arguments — no quotes
-are needed.
+Flags (-i, --wiki) must come before the extension name. Everything after the
+extension name is treated as the script and its arguments — no quotes needed.
 
 Only extensions that are currently loaded (enabled) for the target wiki are
 shown and allowed to run. In a wiki farm, runs on all wikis by default.

--- a/cmd/maintenance/maintenanceScript.go
+++ b/cmd/maintenance/maintenanceScript.go
@@ -3,6 +3,7 @@ package maintenance
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -14,27 +15,31 @@ import (
 func newScriptCmd(instance *config.Installation, wiki *string) *cobra.Command {
 
 	scriptCmd := &cobra.Command{
-		Use:   `script ["scriptname.php [args]"]`,
-		Short: "Run maintenance scripts",
+		Use:                   "script [flags] [scriptname.php [args...]]",
+		DisableFlagsInUseLine: true,
+		Short:                 "Run maintenance scripts",
 		Long: `Run a MediaWiki core maintenance script inside the web container.
 
-With no arguments, lists all available maintenance scripts. With one argument
-(a quoted script name and optional arguments), runs that script. The script
-name is relative to the maintenance/ directory.
+With no arguments, lists all available maintenance scripts. With one or more
+arguments, runs the specified script. The script name is relative to the
+maintenance/ directory.
+
+Flags (-i, --wiki) must come before the script name. Everything after the
+script name is treated as script arguments — no quotes needed.
 
 Use --wiki to target a specific wiki in a farm.`,
 		Example: `  # List all available maintenance scripts
   canasta maintenance script -i myinstance
 
   # Run rebuildrecentchanges.php
-  canasta maintenance script "rebuildrecentchanges.php" -i myinstance
+  canasta maintenance script -i myinstance rebuildrecentchanges.php
 
   # Run a script with arguments
-  canasta maintenance script "importDump.php /path/to/dump.xml" -i myinstance
+  canasta maintenance script -i myinstance importDump.php /path/to/dump.xml
 
   # Run a script for a specific wiki in a farm
-  canasta maintenance script "rebuildrecentchanges.php" -i myinstance --wiki=docs`,
-		Args: cobra.RangeArgs(0, 1),
+  canasta maintenance script -i myinstance --wiki=docs rebuildrecentchanges.php`,
+		Args: cobra.ArbitraryArgs,
 		PreRunE: func(_ *cobra.Command, _ []string) error {
 			var err error
 			*instance, err = canasta.CheckCanastaID(*instance)
@@ -44,10 +49,14 @@ Use --wiki to target a specific wiki in a farm.`,
 			if len(args) == 0 {
 				return listMaintenanceScripts(*instance)
 			}
-			return runMaintenanceScript(*instance, args[0], *wiki)
+			scriptStr := strings.Join(args, " ")
+			return runMaintenanceScript(*instance, scriptStr, *wiki)
 		},
 	}
 
+	// Stop parsing flags after the first non-flag argument (the script name).
+	// This allows script arguments like -s 1000 to be passed without quotes.
+	scriptCmd.Flags().SetInterspersed(false)
 	return scriptCmd
 }
 


### PR DESCRIPTION
Closes #652

## Summary

- Add `SetInterspersed(false)` to `canasta maintenance script` and `canasta maintenance exec`, matching `canasta maintenance extension`'s existing behavior — flags must come before positional arguments
- Use `DisableFlagsInUseLine` with `[flags]` placed before positional args in the `Use` string for all three `canasta maintenance` subcommands, accurately reflecting the required ordering
- `canasta maintenance script` no longer requires quotes around the script name and arguments (uses `ArbitraryArgs` instead of `RangeArgs(0, 1)`)
- `canasta maintenance exec` no longer requires `--` to separate flags from the container command
- Updated long descriptions and examples for all three subcommands

## Test plan

- [x] Unit tests pass (`go test ./cmd/maintenance/...`)
- [x] Full test suite passes (`go test ./...`)
- [x] Manual: `canasta maintenance script --help` shows `[flags]` before positional args
- [x] Manual: `canasta maintenance exec --help` shows `[flags]` before positional args
- [x] Manual: `canasta maintenance extension --help` shows `[flags]` before positional args