### PR TITLE
Detect and report template file changes during upgrade

### DIFF
--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -129,12 +129,11 @@ func Upgrade(instance config.Installation, dryRun bool) error {
 		return err
 	}
 
-	// Update CLI-managed template files (READMEs, new files added in this CLI version).
-	// User-editable files are only created if missing.
-	if !dryRun {
-		if err := canasta.UpdateInstallationTemplate(instance.Path); err != nil {
-			return err
-		}
+	// Update CLI-managed template files (config files, READMEs, etc.).
+	// User-editable files are skipped. Returns true if any files were updated.
+	templateChanged, err := canasta.UpdateInstallationTemplate(instance.Path, dryRun)
+	if err != nil {
+		return err
 	}
 
 	// Update container images
@@ -229,7 +228,7 @@ func Upgrade(instance config.Installation, dryRun bool) error {
 
 	if dryRun {
 		fmt.Println()
-		if stackChanged || migrationsNeeded || mysqlMigrationNeeded {
+		if stackChanged || templateChanged || migrationsNeeded || mysqlMigrationNeeded {
 			fmt.Println("Run 'canasta upgrade' to apply these changes.")
 		} else {
 			fmt.Println("Installation is up to date. No upgrade needed.")
@@ -238,7 +237,7 @@ func Upgrade(instance config.Installation, dryRun bool) error {
 	}
 
 	// Only restart if something changed
-	if stackChanged || migrationsNeeded || imagesUpdated || mysqlMigrationNeeded {
+	if stackChanged || templateChanged || migrationsNeeded || imagesUpdated || mysqlMigrationNeeded {
 		// Restart the containers
 		fmt.Println("Restarting containers...")
 		if err = orch.Stop(instance); err != nil {

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -2,6 +2,7 @@ package canasta
 
 import (
 	"bufio"
+	"bytes"
 	"crypto/rand"
 	"embed"
 	"encoding/hex"
@@ -79,10 +80,69 @@ func CopyInstallationTemplate(destPath string) error {
 
 // UpdateInstallationTemplate re-applies the embedded template during upgrade.
 // User-editable files are skipped entirely (they may have been intentionally deleted).
-// CLI-managed files (READMEs, etc.) are always updated to match the current CLI version.
-func UpdateInstallationTemplate(destPath string) error {
-	logging.Print("Updating installation template files\n")
-	return copyTemplate(destPath, true)
+// CLI-managed files are updated only when their content differs from the template.
+// Returns true if any files were changed. In dry-run mode, changes are reported
+// but not applied.
+func UpdateInstallationTemplate(destPath string, dryRun bool) (bool, error) {
+	logging.Print("Updating installation template files...\n")
+	changed := false
+	err := fs.WalkDir(installationTemplate, "installation-template", func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		relPath, err := filepath.Rel("installation-template", path)
+		if err != nil {
+			return err
+		}
+		if relPath == "." {
+			return nil
+		}
+
+		targetPath := filepath.Join(destPath, relPath)
+
+		if d.IsDir() {
+			return os.MkdirAll(targetPath, permissions.DirectoryPermission)
+		}
+		if d.Name() == ".gitkeep" {
+			return nil
+		}
+		if userEditablePaths[relPath] {
+			return nil
+		}
+
+		data, err := installationTemplate.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read embedded file %s: %w", path, err)
+		}
+
+		// Compare with existing file — skip if identical
+		existing, readErr := os.ReadFile(targetPath)
+		if readErr == nil && bytes.Equal(existing, data) {
+			return nil
+		}
+
+		changed = true
+		if dryRun {
+			if readErr != nil {
+				fmt.Printf("  Would create %s\n", relPath)
+			} else {
+				fmt.Printf("  Would update %s\n", relPath)
+			}
+			return nil
+		}
+
+		if readErr != nil {
+			fmt.Printf("  Creating %s\n", relPath)
+		} else {
+			fmt.Printf("  Updating %s\n", relPath)
+		}
+		return os.WriteFile(targetPath, data, permissions.FilePermission)
+	})
+	if !changed {
+		fmt.Println("  Template files are up to date.")
+	}
+	return changed, err
 }
 
 // copyTemplate walks the embedded installation template and copies files to destPath.

--- a/internal/canasta/canasta_test.go
+++ b/internal/canasta/canasta_test.go
@@ -913,6 +913,168 @@ func TestResolveFilePaths(t *testing.T) {
 	})
 }
 
+func TestUpdateInstallationTemplate_NoChanges(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a pristine installation
+	if err := CopyInstallationTemplate(dir); err != nil {
+		t.Fatalf("CopyInstallationTemplate() error = %v", err)
+	}
+
+	// Update should report no changes
+	changed, err := UpdateInstallationTemplate(dir, false)
+	if err != nil {
+		t.Fatalf("UpdateInstallationTemplate() error = %v", err)
+	}
+	if changed {
+		t.Error("expected no changes on a freshly created installation")
+	}
+}
+
+func TestUpdateInstallationTemplate_DetectsChange(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a pristine installation
+	if err := CopyInstallationTemplate(dir); err != nil {
+		t.Fatalf("CopyInstallationTemplate() error = %v", err)
+	}
+
+	// Modify a non-user-editable file (README)
+	vclPath := filepath.Join(dir, "config", "settings", "wikis", "README")
+	if err := os.WriteFile(vclPath, []byte("modified content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Update should detect the change
+	changed, err := UpdateInstallationTemplate(dir, false)
+	if err != nil {
+		t.Fatalf("UpdateInstallationTemplate() error = %v", err)
+	}
+	if !changed {
+		t.Error("expected change to be detected after modifying README")
+	}
+
+	// Verify the file was restored to the template version
+	got, err := os.ReadFile(vclPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) == "modified content" {
+		t.Error("expected README to be restored to template version")
+	}
+}
+
+func TestUpdateInstallationTemplate_DryRun(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a pristine installation
+	if err := CopyInstallationTemplate(dir); err != nil {
+		t.Fatalf("CopyInstallationTemplate() error = %v", err)
+	}
+
+	// Modify a non-user-editable file
+	vclPath := filepath.Join(dir, "config", "settings", "wikis", "README")
+	original, err := os.ReadFile(vclPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(vclPath, []byte("modified content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Dry run should report change but not modify the file
+	changed, err := UpdateInstallationTemplate(dir, true)
+	if err != nil {
+		t.Fatalf("UpdateInstallationTemplate() error = %v", err)
+	}
+	if !changed {
+		t.Error("dry run should report changed = true")
+	}
+
+	// File should still have the modified content
+	got, err := os.ReadFile(vclPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "modified content" {
+		t.Error("dry run should not modify files")
+	}
+
+	// Now apply for real
+	changed, err = UpdateInstallationTemplate(dir, false)
+	if err != nil {
+		t.Fatalf("UpdateInstallationTemplate() error = %v", err)
+	}
+	if !changed {
+		t.Error("expected change after dry run")
+	}
+
+	got, err = os.ReadFile(vclPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Error("expected file to be restored to template version after apply")
+	}
+}
+
+func TestUpdateInstallationTemplate_SkipsUserEditable(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a pristine installation
+	if err := CopyInstallationTemplate(dir); err != nil {
+		t.Fatalf("CopyInstallationTemplate() error = %v", err)
+	}
+
+	// Modify a user-editable file (.env)
+	envPath := filepath.Join(dir, ".env")
+	if err := os.WriteFile(envPath, []byte("CUSTOM=value"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Update should not touch user-editable files
+	_, err := UpdateInstallationTemplate(dir, false)
+	if err != nil {
+		t.Fatalf("UpdateInstallationTemplate() error = %v", err)
+	}
+
+	got, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "CUSTOM=value" {
+		t.Error("expected user-editable .env to be preserved")
+	}
+}
+
+func TestUpdateInstallationTemplate_CreatesNewFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a pristine installation
+	if err := CopyInstallationTemplate(dir); err != nil {
+		t.Fatalf("CopyInstallationTemplate() error = %v", err)
+	}
+
+	// Delete a non-user-editable file
+	vclPath := filepath.Join(dir, "config", "settings", "wikis", "README")
+	if err := os.Remove(vclPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// Update should recreate it
+	changed, err := UpdateInstallationTemplate(dir, false)
+	if err != nil {
+		t.Fatalf("UpdateInstallationTemplate() error = %v", err)
+	}
+	if !changed {
+		t.Error("expected change when file is missing")
+	}
+
+	if _, err := os.Stat(vclPath); err != nil {
+		t.Error("expected README to be recreated")
+	}
+}
+
 func TestGetBaseImage(t *testing.T) {
 	defaultImage := GetDefaultImage()
 


### PR DESCRIPTION
## Summary

- `UpdateInstallationTemplate` now compares content before writing and returns `(bool, error)` to signal changes
- Supports `--dry-run` mode — reports which files would be created/updated
- Upgrade function uses the result to trigger container restarts when template files change

## Context

Previously, template file updates during `canasta upgrade` were applied silently with no change detection. This meant config files like `default.vcl` could be updated but containers wouldn't restart, so changes wouldn't take effect until a manual restart. The `--dry-run` flag also skipped template updates entirely, giving no preview of what would change.

Fixes #656

## Test plan

- [x] `canasta upgrade --dry-run` reports template files that would be updated
- [x] `canasta upgrade` restarts containers when template files change
- [x] `canasta upgrade` reports "up to date" when template files are already current (TestUpdateInstallationTemplate_NoChanges)
- [x] `canasta create` still works — CopyInstallationTemplate unchanged, tested via TestUpdateInstallationTemplate_* setup
- [x] All existing tests pass
- [x] New tests: detects changes, dry-run reports without modifying, skips user-editable files, recreates missing files