### PR TITLE
Add tests for EnsureRunning function in mockOrchestrator

### DIFF
--- a/internal/orchestrators/orchestrator_test.go
+++ b/internal/orchestrators/orchestrator_test.go
@@ -53,6 +53,7 @@ func (m *mockOrchestrator) ExecStreaming(_, _, _ string) error {
 }
 
 func (m *mockOrchestrator) CheckRunningStatus(_ config.Installation) error {
+	m.calls = append(m.calls, "CheckRunningStatus")
 	return m.checkRunningErr
 }
 
@@ -365,10 +366,8 @@ func TestEnsureRunningAlreadyRunning(t *testing.T) {
 		t.Fatalf("EnsureRunning() error = %v", err)
 	}
 
-	for _, call := range mock.calls {
-		if call == "Start" {
-			t.Error("Start should not be called when containers are already running")
-		}
+	if len(mock.calls) != 1 || mock.calls[0] != "CheckRunningStatus" {
+		t.Errorf("expected [CheckRunningStatus], got %v", mock.calls)
 	}
 }
 
@@ -381,14 +380,8 @@ func TestEnsureRunningNotRunning(t *testing.T) {
 		t.Fatalf("EnsureRunning() error = %v", err)
 	}
 
-	hasStart := false
-	for _, call := range mock.calls {
-		if call == "Start" {
-			hasStart = true
-		}
-	}
-	if !hasStart {
-		t.Error("Start should be called when containers are not running")
+	if len(mock.calls) != 2 || mock.calls[0] != "CheckRunningStatus" || mock.calls[1] != "Start" {
+		t.Errorf("expected [CheckRunningStatus, Start], got %v", mock.calls)
 	}
 }
 

--- a/internal/orchestrators/orchestrator_test.go
+++ b/internal/orchestrators/orchestrator_test.go
@@ -10,12 +10,13 @@ import (
 
 // mockOrchestrator records calls for testing
 type mockOrchestrator struct {
-	calls      []string
-	execOutput string
-	execErr    error
-	copyToErr  error
-	startErr   error
-	stopErr    error
+	calls           []string
+	execOutput      string
+	execErr         error
+	copyToErr       error
+	startErr        error
+	stopErr         error
+	checkRunningErr error
 }
 
 func (m *mockOrchestrator) CheckDependencies() error       { return nil }
@@ -52,7 +53,7 @@ func (m *mockOrchestrator) ExecStreaming(_, _, _ string) error {
 }
 
 func (m *mockOrchestrator) CheckRunningStatus(_ config.Installation) error {
-	return nil
+	return m.checkRunningErr
 }
 
 func (m *mockOrchestrator) CopyFrom(_, service, containerPath, hostPath string) error {
@@ -352,5 +353,57 @@ func TestRunBackupError(t *testing.T) {
 	}
 	if len(mock.calls) != 1 {
 		t.Fatalf("expected 1 call, got %d", len(mock.calls))
+	}
+}
+
+func TestEnsureRunningAlreadyRunning(t *testing.T) {
+	mock := &mockOrchestrator{} // checkRunningErr is nil → containers already running
+	instance := config.Installation{ID: "test", Path: "/tmp/test"}
+
+	err := EnsureRunning(mock, instance)
+	if err != nil {
+		t.Fatalf("EnsureRunning() error = %v", err)
+	}
+
+	for _, call := range mock.calls {
+		if call == "Start" {
+			t.Error("Start should not be called when containers are already running")
+		}
+	}
+}
+
+func TestEnsureRunningNotRunning(t *testing.T) {
+	mock := &mockOrchestrator{checkRunningErr: fmt.Errorf("containers not running")}
+	instance := config.Installation{ID: "test", Path: "/tmp/test"}
+
+	err := EnsureRunning(mock, instance)
+	if err != nil {
+		t.Fatalf("EnsureRunning() error = %v", err)
+	}
+
+	hasStart := false
+	for _, call := range mock.calls {
+		if call == "Start" {
+			hasStart = true
+		}
+	}
+	if !hasStart {
+		t.Error("Start should be called when containers are not running")
+	}
+}
+
+func TestEnsureRunningStartFails(t *testing.T) {
+	mock := &mockOrchestrator{
+		checkRunningErr: fmt.Errorf("containers not running"),
+		startErr:        fmt.Errorf("start failed"),
+	}
+	instance := config.Installation{ID: "test", Path: "/tmp/test"}
+
+	err := EnsureRunning(mock, instance)
+	if err == nil {
+		t.Fatal("expected error when Start fails")
+	}
+	if !strings.Contains(err.Error(), "failed to start containers") {
+		t.Errorf("error should mention 'failed to start containers', got: %v", err)
 	}
 }


### PR DESCRIPTION
This pull request adds and improves tests for the `EnsureRunning` function in the orchestrator package, focusing on verifying its behavior under different container running states. It also updates the `mockOrchestrator` to better support these test scenarios.

**Testing improvements:**

* Added three new tests to `orchestrator_test.go` to verify `EnsureRunning` behavior when containers are already running, not running, and when starting containers fails.

**Test infrastructure updates:**

* Updated the `mockOrchestrator` struct to include a `checkRunningErr` field, allowing tests to simulate different running states. The `CheckRunningStatus` method now returns this error. [[1]](diffhunk://#diff-6d356b25a011945bcba430d963ba8f9428d637885ec25c246dc990d59d750217R19) [[2]](diffhunk://#diff-6d356b25a011945bcba430d963ba8f9428d637885ec25c246dc990d59d750217L55-R56)