### PR TITLE
Remove unused _initdb volume mount from stack files

### DIFF
--- a/internal/orchestrators/compose/files/docker-compose.yml
+++ b/internal/orchestrators/compose/files/docker-compose.yml
@@ -37,7 +37,6 @@ services:
       retries: 30
       start_period: 60s
     volumes:
-      - ./_initdb:/docker-entrypoint-initdb.d
       - mysql-data-volume:/var/lib/mysql
       - ./my.cnf:/etc/my.cnf
       - mysql-logs:/var/log/mysql

--- a/internal/orchestrators/kubernetes/files/kubernetes/db.yaml
+++ b/internal/orchestrators/kubernetes/files/kubernetes/db.yaml
@@ -80,18 +80,12 @@ spec:
           periodSeconds: 30
           timeoutSeconds: 5
         volumeMounts:
-        - name: initdb-volume
-          mountPath: /docker-entrypoint-initdb.d
         - name: my-cnf-config
           mountPath: /etc/my.cnf
           subPath: my.cnf
         - name: mysql-data
           mountPath: /var/lib/mysql
       volumes:
-      - name: initdb-volume
-        hostPath:
-          path: /canasta/config-data/_initdb
-          type: DirectoryOrCreate
       - name: my-cnf-config
         configMap:
           name: canasta-config


### PR DESCRIPTION
## Summary
- Remove `_initdb` volume mount from Docker Compose and Kubernetes stack files
- The directory was mounted to MariaDB's `/docker-entrypoint-initdb.d` but nothing in the CLI ever writes to it
- Database imports during `canasta create` use exec piping instead

Fixes #666