### PR TITLE
Fix upgrade removing .git directory used by gitops

### DIFF
--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -621,12 +621,19 @@ func removeSkipBinaryAsHex(installPath string, dryRun bool) (bool, error) {
 // removeLegacyGitDir removes the .git directory from installations that were
 // previously cloned from the Canasta-DockerCompose repo. Stack files are now
 // embedded in the CLI binary, so installations are no longer git repos.
+// Skips removal if gitops is active (indicated by a .gitops-host file).
 func removeLegacyGitDir(installPath string, dryRun bool) (bool, error) {
 	gitDir := filepath.Join(installPath, ".git")
 	if _, err := os.Stat(gitDir); os.IsNotExist(err) {
 		return false, nil
 	} else if err != nil {
 		return false, err
+	}
+
+	// Do not remove .git if gitops is using it.
+	gitopsHost := filepath.Join(installPath, ".gitops-host")
+	if _, err := os.Stat(gitopsHost); err == nil {
+		return false, nil
 	}
 
 	if dryRun {

--- a/internal/gitops/defaults/gitignore
+++ b/internal/gitops/defaults/gitignore
@@ -5,6 +5,10 @@ config/admin-password_*
 
 # Managed by Canasta CLI
 docker-compose.yml
+docker-compose.override.yml.example
+config/default.vcl
+config/settings/global/README
+config/settings/wikis/*/README
 
 # Auto-generated from wikis.yaml on restart
 config/Caddyfile


### PR DESCRIPTION
## Summary

- The `removeLegacyGitDir` migration in `canasta upgrade` unconditionally deleted `.git`, destroying the repository created by `canasta gitops init`
- Now checks for a `.gitops-host` file before removing; if present, the `.git` directory is preserved
- Adds CLI-managed files to the gitops `.gitignore` template so they are not tracked: `docker-compose.override.yml.example`, `config/default.vcl`, READMEs in `config/settings/`

Fixes #670

## Test plan

- [x] Run `canasta upgrade` on an installation with gitops active: `.git` directory should be preserved
- [x] Run `canasta upgrade` on a legacy installation (no gitops): `.git` directory should still be removed
- [x] Run `canasta upgrade` on a normal installation (no `.git`): no change, no error