### PR TITLE
Make informational files no-clobber during upgrade

### DIFF
--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -72,9 +72,8 @@ var userEditablePaths = map[string]bool{
 // during "canasta create" but should not be recreated during upgrade. If a
 // user deletes them, they stay gone.
 var noClobberPaths = map[string]bool{
-	"docker-compose.override.yml.example": true,
-	"config/settings/global/README":       true,
-	"config/settings/wikis/README":        true,
+	"config/settings/global/README": true,
+	"config/settings/wikis/README":  true,
 }
 
 // CopyInstallationTemplate copies the embedded installation template files to the

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -68,6 +68,15 @@ var userEditablePaths = map[string]bool{
 	"config/settings/global/CanastaFooterIcon.php": true,
 }
 
+// noClobberPaths lists informational template files that are created once
+// during "canasta create" but should not be recreated during upgrade. If a
+// user deletes them, they stay gone.
+var noClobberPaths = map[string]bool{
+	"docker-compose.override.yml.example": true,
+	"config/settings/global/README":       true,
+	"config/settings/wikis/README":        true,
+}
+
 // CopyInstallationTemplate copies the embedded installation template files to the
 // destination directory. These are shared files common to all orchestrators.
 // Files are only written if they don't already exist (no-clobber), so orchestrator
@@ -108,6 +117,14 @@ func UpdateInstallationTemplate(destPath string, dryRun bool) (bool, error) {
 		}
 		if userEditablePaths[relPath] {
 			return nil
+		}
+		// No-clobber informational files: create if missing, but don't
+		// recreate if the user deleted them. We detect "user deleted" by
+		// checking whether the file exists on disk.
+		if noClobberPaths[relPath] {
+			if _, err := os.Stat(targetPath); os.IsNotExist(err) {
+				return nil
+			}
 		}
 
 		data, err := installationTemplate.ReadFile(path)
@@ -307,10 +324,12 @@ func CopySettings(installPath string) error {
 			return err
 		}
 
-		// Copy README into the wiki's settings directory
+		// Copy README into the wiki's settings directory (no-clobber)
 		readmePath := filepath.Join(dirPath, "README")
-		if err := os.WriteFile(readmePath, wikiREADME, permissions.FilePermission); err != nil {
-			return fmt.Errorf("failed to write README for %s: %w", id, err)
+		if _, err := os.Stat(readmePath); os.IsNotExist(err) {
+			if err := os.WriteFile(readmePath, wikiREADME, permissions.FilePermission); err != nil {
+				return fmt.Errorf("failed to write README for %s: %w", id, err)
+			}
 		}
 	}
 
@@ -327,14 +346,16 @@ func CopySetting(installPath, id string) error {
 		return err
 	}
 
-	// Copy README into the wiki's settings directory
-	wikiREADME, err := installationTemplate.ReadFile("installation-template/config/settings/wikis/README")
-	if err != nil {
-		return fmt.Errorf("failed to read embedded wiki README: %w", err)
-	}
+	// Copy README into the wiki's settings directory (no-clobber)
 	readmePath := filepath.Join(dirPath, "README")
-	if err := os.WriteFile(readmePath, wikiREADME, permissions.FilePermission); err != nil {
-		return fmt.Errorf("failed to write README: %w", err)
+	if _, err := os.Stat(readmePath); os.IsNotExist(err) {
+		wikiREADME, err := installationTemplate.ReadFile("installation-template/config/settings/wikis/README")
+		if err != nil {
+			return fmt.Errorf("failed to read embedded wiki README: %w", err)
+		}
+		if err := os.WriteFile(readmePath, wikiREADME, permissions.FilePermission); err != nil {
+			return fmt.Errorf("failed to write README: %w", err)
+		}
 	}
 
 	return nil

--- a/internal/canasta/canasta_test.go
+++ b/internal/canasta/canasta_test.go
@@ -939,8 +939,8 @@ func TestUpdateInstallationTemplate_DetectsChange(t *testing.T) {
 		t.Fatalf("CopyInstallationTemplate() error = %v", err)
 	}
 
-	// Modify a non-user-editable file (README)
-	vclPath := filepath.Join(dir, "config", "settings", "wikis", "README")
+	// Modify a non-user-editable file (default.vcl)
+	vclPath := filepath.Join(dir, "config", "default.vcl")
 	if err := os.WriteFile(vclPath, []byte("modified content"), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -951,7 +951,7 @@ func TestUpdateInstallationTemplate_DetectsChange(t *testing.T) {
 		t.Fatalf("UpdateInstallationTemplate() error = %v", err)
 	}
 	if !changed {
-		t.Error("expected change to be detected after modifying README")
+		t.Error("expected change to be detected after modifying default.vcl")
 	}
 
 	// Verify the file was restored to the template version
@@ -960,7 +960,7 @@ func TestUpdateInstallationTemplate_DetectsChange(t *testing.T) {
 		t.Fatal(err)
 	}
 	if string(got) == "modified content" {
-		t.Error("expected README to be restored to template version")
+		t.Error("expected default.vcl to be restored to template version")
 	}
 }
 
@@ -973,7 +973,7 @@ func TestUpdateInstallationTemplate_DryRun(t *testing.T) {
 	}
 
 	// Modify a non-user-editable file
-	vclPath := filepath.Join(dir, "config", "settings", "wikis", "README")
+	vclPath := filepath.Join(dir, "config", "default.vcl")
 	original, err := os.ReadFile(vclPath)
 	if err != nil {
 		t.Fatal(err)
@@ -1055,8 +1055,8 @@ func TestUpdateInstallationTemplate_CreatesNewFile(t *testing.T) {
 		t.Fatalf("CopyInstallationTemplate() error = %v", err)
 	}
 
-	// Delete a non-user-editable file
-	vclPath := filepath.Join(dir, "config", "settings", "wikis", "README")
+	// Delete a non-user-editable, non-noClobber file
+	vclPath := filepath.Join(dir, "config", "default.vcl")
 	if err := os.Remove(vclPath); err != nil {
 		t.Fatal(err)
 	}
@@ -1071,7 +1071,35 @@ func TestUpdateInstallationTemplate_CreatesNewFile(t *testing.T) {
 	}
 
 	if _, err := os.Stat(vclPath); err != nil {
-		t.Error("expected README to be recreated")
+		t.Error("expected default.vcl to be recreated")
+	}
+}
+
+func TestUpdateInstallationTemplate_NoClobberSkipsDeletedFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a pristine installation
+	if err := CopyInstallationTemplate(dir); err != nil {
+		t.Fatalf("CopyInstallationTemplate() error = %v", err)
+	}
+
+	// Delete a noClobber file (informational README)
+	readmePath := filepath.Join(dir, "config", "settings", "wikis", "README")
+	if err := os.Remove(readmePath); err != nil {
+		t.Fatal(err)
+	}
+
+	// Update should NOT recreate it
+	changed, err := UpdateInstallationTemplate(dir, false)
+	if err != nil {
+		t.Fatalf("UpdateInstallationTemplate() error = %v", err)
+	}
+	if changed {
+		t.Error("expected no change when a noClobber file is deleted")
+	}
+
+	if _, err := os.Stat(readmePath); !os.IsNotExist(err) {
+		t.Error("expected deleted README to stay gone")
 	}
 }
 

--- a/internal/orchestrators/stackfiles.go
+++ b/internal/orchestrators/stackfiles.go
@@ -11,6 +11,13 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/permissions"
 )
 
+// noClobberStackFiles lists informational files bundled with the stack that
+// are created on first install but should not be recreated if the user
+// deletes them.
+var noClobberStackFiles = map[string]bool{
+	"docker-compose.override.yml.example": true,
+}
+
 // writeStackFiles walks an embedded FS and writes files to installPath.
 // If overwrite is false, existing files are skipped (no-clobber).
 func writeStackFiles(stackFS embed.FS, root, installPath string, overwrite bool) error {
@@ -77,6 +84,10 @@ func updateStackFiles(stackFS embed.FS, root, installPath string, dryRun bool) (
 		existing, readErr := os.ReadFile(targetPath)
 		if readErr == nil && bytes.Equal(existing, embedded) {
 			return nil // unchanged
+		}
+		// No-clobber: if the file was deleted by the user, don't recreate it.
+		if readErr != nil && noClobberStackFiles[relPath] {
+			return nil
 		}
 		changed = true
 		if dryRun {

--- a/internal/orchestrators/stackfiles_test.go
+++ b/internal/orchestrators/stackfiles_test.go
@@ -1,0 +1,99 @@
+package orchestrators
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUpdateStackFiles_NoClobberSkipsDeletedExample(t *testing.T) {
+	dir := t.TempDir()
+	c := &ComposeOrchestrator{}
+
+	// Initial write — creates all stack files including the .example.
+	if err := c.WriteStackFiles(dir); err != nil {
+		t.Fatalf("WriteStackFiles: %v", err)
+	}
+	examplePath := filepath.Join(dir, "docker-compose.override.yml.example")
+	if _, err := os.Stat(examplePath); err != nil {
+		t.Fatalf("example file not created on initial write: %v", err)
+	}
+
+	// Delete the example file (simulates user removing it).
+	if err := os.Remove(examplePath); err != nil {
+		t.Fatalf("failed to remove example file: %v", err)
+	}
+
+	// Update — the example should NOT be recreated (no-clobber).
+	changed, err := c.UpdateStackFiles(dir, false)
+	if err != nil {
+		t.Fatalf("UpdateStackFiles: %v", err)
+	}
+	if _, err := os.Stat(examplePath); err == nil {
+		t.Error("noClobber file was recreated after deletion, expected it to stay gone")
+	}
+	if changed {
+		t.Error("expected changed=false when only a noClobber file is missing")
+	}
+}
+
+func TestUpdateStackFiles_RecreatesDeletedComposeFile(t *testing.T) {
+	dir := t.TempDir()
+	c := &ComposeOrchestrator{}
+
+	// Initial write.
+	if err := c.WriteStackFiles(dir); err != nil {
+		t.Fatalf("WriteStackFiles: %v", err)
+	}
+
+	composePath := filepath.Join(dir, "docker-compose.yml")
+	if err := os.Remove(composePath); err != nil {
+		t.Fatalf("failed to remove compose file: %v", err)
+	}
+
+	// Update — non-noClobber file should be recreated.
+	changed, err := c.UpdateStackFiles(dir, false)
+	if err != nil {
+		t.Fatalf("UpdateStackFiles: %v", err)
+	}
+	if _, err := os.Stat(composePath); err != nil {
+		t.Error("docker-compose.yml was not recreated after deletion")
+	}
+	if !changed {
+		t.Error("expected changed=true when docker-compose.yml is missing")
+	}
+}
+
+func TestUpdateStackFiles_NoClobberModifiedExampleIsRestored(t *testing.T) {
+	dir := t.TempDir()
+	c := &ComposeOrchestrator{}
+
+	// Initial write.
+	if err := c.WriteStackFiles(dir); err != nil {
+		t.Fatalf("WriteStackFiles: %v", err)
+	}
+
+	examplePath := filepath.Join(dir, "docker-compose.override.yml.example")
+	original, err := os.ReadFile(examplePath)
+	if err != nil {
+		t.Fatalf("failed to read original: %v", err)
+	}
+
+	// Modify the file (user edited it, not deleted).
+	if err := os.WriteFile(examplePath, []byte("user modified\n"), 0644); err != nil {
+		t.Fatalf("failed to modify: %v", err)
+	}
+
+	// Update — file exists but differs, so it should be restored.
+	changed, err := c.UpdateStackFiles(dir, false)
+	if err != nil {
+		t.Fatalf("UpdateStackFiles: %v", err)
+	}
+	if !changed {
+		t.Error("expected changed=true when noClobber file was modified")
+	}
+	got, _ := os.ReadFile(examplePath)
+	if string(got) != string(original) {
+		t.Errorf("expected file to be restored to embedded content, got %q", string(got))
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a `noClobberPaths` set for informational template files (READMEs) that are created once during `canasta create` but not recreated during upgrade if the user has deleted them
- Adds `noClobberStackFiles` in `stackfiles.go` for `docker-compose.override.yml.example` (which is deployed via stack files, not the installation template)
- Makes per-wiki README writes in `CopySettings`/`CopySetting` no-clobber as well
- Updates existing tests to use `default.vcl` (a CLI-managed file) instead of README for upgrade behavior tests
- Adds new tests for both installation-template and stack-file noClobber behavior

Fixes #672

## Test plan

- [x] Fresh `canasta create`: verify READMEs and override example are created
- [x] `canasta upgrade` with READMEs present: no change (files already match template)
- [x] Delete a README, then `canasta upgrade`: verify it is NOT recreated
- [x] Delete `default.vcl`, then `canasta upgrade`: verify it IS recreated (non-noClobber file)
- [x] Delete `docker-compose.override.yml.example`, then `canasta upgrade`: verify it is NOT recreated
- [x] Modify a noClobber file, then `canasta upgrade`: verify it IS restored (file exists, just changed)