### PR TITLE
Move submodule repair to canasta gitops fix-submodules

### DIFF
--- a/cmd/gitops/fix_submodules.go
+++ b/cmd/gitops/fix_submodules.go
@@ -1,0 +1,28 @@
+package gitops
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/CanastaWiki/Canasta-CLI/internal/config"
+)
+
+func newFixSubmodulesCmd(instance *config.Installation) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "fix-submodules",
+		Short: "Convert extensions and skins to proper git submodules",
+		Long: `Fix submodule registration in an existing gitops repository.
+
+This handles two cases:
+  1. Extensions or skins that were added after gitops init and need to be
+     converted from standalone git repositories to submodules.
+  2. Submodules listed in .gitmodules that were accidentally committed as
+     regular directories instead of gitlinks.
+
+After fixing, run "canasta gitops push" to push the changes.`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runRepairSubmodules(instance.Path)
+		},
+	}
+	return cmd
+}

--- a/cmd/gitops/fix_submodules_test.go
+++ b/cmd/gitops/fix_submodules_test.go
@@ -20,8 +20,8 @@ func TestRunRepairSubmodules_ConvertsStandaloneExtension(t *testing.T) {
 	runGit(t, repoPath, "commit", "-m", "initial")
 
 	// Create a standalone extension git repo inside extensions/.
-	extRemote := createGitRepoWithCommit(t, t.TempDir(), "wanda")
-	extPath := filepath.Join(repoPath, "extensions", "Wanda")
+	extRemote := createGitRepoWithCommit(t, t.TempDir(), "test-ext")
+	extPath := filepath.Join(repoPath, "extensions", "TestExtension")
 	runGit(t, repoPath, "clone", extRemote, extPath)
 	commitHash := runGit(t, extPath, "rev-parse", "HEAD")
 
@@ -31,7 +31,7 @@ func TestRunRepairSubmodules_ConvertsStandaloneExtension(t *testing.T) {
 	}
 
 	// Verify it was converted to a submodule.
-	staged := runGit(t, repoPath, "ls-files", "--stage", "extensions/Wanda")
+	staged := runGit(t, repoPath, "ls-files", "--stage", "extensions/TestExtension")
 	if !strings.HasPrefix(staged, "160000") {
 		t.Fatalf("expected submodule gitlink (160000), got: %q", staged)
 	}

--- a/cmd/gitops/fix_submodules_test.go
+++ b/cmd/gitops/fix_submodules_test.go
@@ -13,7 +13,9 @@ func TestRunRepairSubmodules_ConvertsStandaloneExtension(t *testing.T) {
 	// Set up a gitops repo with an initial commit.
 	repoPath := t.TempDir()
 	initGitRepo(t, repoPath)
-	os.WriteFile(filepath.Join(repoPath, ".gitignore"), []byte(".env\n"), 0644)
+	if err := os.WriteFile(filepath.Join(repoPath, ".gitignore"), []byte(".env\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 	runGit(t, repoPath, "add", "-A")
 	runGit(t, repoPath, "commit", "-m", "initial")
 
@@ -58,7 +60,9 @@ func TestRunRepairSubmodules_NoExtensions(t *testing.T) {
 	// A gitops repo with no extensions — should be a no-op.
 	repoPath := t.TempDir()
 	initGitRepo(t, repoPath)
-	os.WriteFile(filepath.Join(repoPath, ".gitignore"), []byte(".env\n"), 0644)
+	if err := os.WriteFile(filepath.Join(repoPath, ".gitignore"), []byte(".env\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 	runGit(t, repoPath, "add", "-A")
 	runGit(t, repoPath, "commit", "-m", "initial")
 

--- a/cmd/gitops/fix_submodules_test.go
+++ b/cmd/gitops/fix_submodules_test.go
@@ -1,0 +1,68 @@
+package gitops
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunRepairSubmodules_ConvertsStandaloneExtension(t *testing.T) {
+	t.Setenv("GIT_ALLOW_PROTOCOL", "file")
+
+	// Set up a gitops repo with an initial commit.
+	repoPath := t.TempDir()
+	initGitRepo(t, repoPath)
+	os.WriteFile(filepath.Join(repoPath, ".gitignore"), []byte(".env\n"), 0644)
+	runGit(t, repoPath, "add", "-A")
+	runGit(t, repoPath, "commit", "-m", "initial")
+
+	// Create a standalone extension git repo inside extensions/.
+	extRemote := createGitRepoWithCommit(t, t.TempDir(), "wanda")
+	extPath := filepath.Join(repoPath, "extensions", "Wanda")
+	runGit(t, repoPath, "clone", extRemote, extPath)
+	commitHash := runGit(t, extPath, "rev-parse", "HEAD")
+
+	// Run fix-submodules.
+	if err := runRepairSubmodules(repoPath); err != nil {
+		t.Fatalf("runRepairSubmodules returned error: %v", err)
+	}
+
+	// Verify it was converted to a submodule.
+	staged := runGit(t, repoPath, "ls-files", "--stage", "extensions/Wanda")
+	if !strings.HasPrefix(staged, "160000") {
+		t.Fatalf("expected submodule gitlink (160000), got: %q", staged)
+	}
+
+	// Verify the submodule is pinned to the same commit.
+	subCommit := runGit(t, extPath, "rev-parse", "HEAD")
+	if subCommit != commitHash {
+		t.Errorf("expected submodule at %s, got %s", commitHash, subCommit)
+	}
+}
+
+func TestRunRepairSubmodules_NoGitRepo(t *testing.T) {
+	repoPath := t.TempDir()
+
+	// No .git directory — should error.
+	err := runRepairSubmodules(repoPath)
+	if err == nil {
+		t.Fatal("expected error for non-git directory")
+	}
+	if !strings.Contains(err.Error(), "not a git repository") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunRepairSubmodules_NoExtensions(t *testing.T) {
+	// A gitops repo with no extensions — should be a no-op.
+	repoPath := t.TempDir()
+	initGitRepo(t, repoPath)
+	os.WriteFile(filepath.Join(repoPath, ".gitignore"), []byte(".env\n"), 0644)
+	runGit(t, repoPath, "add", "-A")
+	runGit(t, repoPath, "commit", "-m", "initial")
+
+	if err := runRepairSubmodules(repoPath); err != nil {
+		t.Fatalf("runRepairSubmodules returned error: %v", err)
+	}
+}

--- a/cmd/gitops/gitops.go
+++ b/cmd/gitops/gitops.go
@@ -41,6 +41,7 @@ git-crypt, and multi-server deployments with push/pull workflows.`,
 	gitopsCmd.AddCommand(newPullCmd(&instance))
 	gitopsCmd.AddCommand(newStatusCmd(&instance))
 	gitopsCmd.AddCommand(newDiffCmd(&instance))
+	gitopsCmd.AddCommand(newFixSubmodulesCmd(&instance))
 
 	gitopsCmd.PersistentFlags().StringVarP(&instance.ID, "id", "i", "", "Canasta instance ID (defaults to instance associated with current directory)")
 	return gitopsCmd

--- a/cmd/gitops/init.go
+++ b/cmd/gitops/init.go
@@ -34,7 +34,6 @@ func newInitCmd(instance *config.Installation) *cobra.Command {
 		keyFile      string
 		force        bool
 		pullRequests bool
-		repair       bool
 	)
 
 	cmd := &cobra.Command{
@@ -53,16 +52,10 @@ Use --pull-requests to require changes to go through pull requests instead of
 pushing directly to main. This enables review workflows for multi-server
 deployments.
 
-Use --repair to fix submodule registration in an existing gitops repository
-without re-initializing. This re-converts extensions/skins that were
-committed as regular directories instead of submodules.
-
-To join an existing gitops repository instead, use "canasta gitops join".`,
+To join an existing gitops repository instead, use "canasta gitops join".
+To fix submodule registration after adding extensions, use "canasta gitops fix-submodules".`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if repair {
-				return runRepairSubmodules(instance.Path)
-			}
 			if err := validateInitFlags(hostName); err != nil {
 				return err
 			}
@@ -79,7 +72,6 @@ To join an existing gitops repository instead, use "canasta gitops join".`,
 	cmd.Flags().StringVar(&keyFile, "key", "", "Path to export the git-crypt key")
 	cmd.Flags().BoolVar(&force, "force", false, "Force push to a non-empty remote repository")
 	cmd.Flags().BoolVar(&pullRequests, "pull-requests", false, "Require pull requests instead of pushing directly to main")
-	cmd.Flags().BoolVar(&repair, "repair", false, "Re-register extensions/skins as proper submodules")
 
 	_ = cmd.MarkFlagRequired("name")
 	_ = cmd.MarkFlagRequired("repo")


### PR DESCRIPTION
## Summary

- `canasta gitops init --repair` failed with `required flag(s) "key", "name", "repo" not set` because Cobra validated required flags before `RunE` could check the repair flag
- Extracted the submodule fix into a standalone `canasta gitops fix-submodules` command instead of overloading `init` with a flag
- Restores `MarkFlagRequired` on `init` (no longer needs the workaround)

Fixes #675

## Test plan

- [x] `canasta gitops fix-submodules` works on a gitops repo with a new extension
- [x] `canasta gitops init` without required flags still errors correctly
- [x] `canasta gitops init --name ... --repo ... --key ...` still works for full bootstrap