### PR TITLE
Show local vs remote changes separately in gitops diff

### DIFF
--- a/cmd/gitops/diff.go
+++ b/cmd/gitops/diff.go
@@ -48,33 +48,7 @@ func runDiff(installPath string) error {
 		return nil
 	}
 
-	// Build sets for conflict detection.
-	localSet := make(map[string]bool, len(localFiles))
-	for _, f := range localFiles {
-		localSet[f] = true
-	}
-	remoteSet := make(map[string]bool, len(remoteFiles))
-	for _, f := range remoteFiles {
-		remoteSet[f] = true
-	}
-
-	var conflicts, localOnly, remoteOnly []string
-	for _, f := range localFiles {
-		if remoteSet[f] {
-			conflicts = append(conflicts, f)
-		} else {
-			localOnly = append(localOnly, f)
-		}
-	}
-	for _, f := range remoteFiles {
-		if !localSet[f] {
-			remoteOnly = append(remoteOnly, f)
-		}
-	}
-
-	sort.Strings(localOnly)
-	sort.Strings(remoteOnly)
-	sort.Strings(conflicts)
+	localOnly, remoteOnly, conflicts := classifyChanges(localFiles, remoteFiles)
 
 	if len(localOnly) > 0 {
 		fmt.Printf("Local changes (not yet pushed): %d file(s)\n", len(localOnly))
@@ -123,4 +97,36 @@ func runDiff(installPath string) error {
 	}
 
 	return nil
+}
+
+// classifyChanges partitions local and remote file lists into three sorted
+// slices: files changed only locally, files changed only on the remote,
+// and files changed in both (potential conflicts).
+func classifyChanges(localFiles, remoteFiles []string) (localOnly, remoteOnly, conflicts []string) {
+	localSet := make(map[string]bool, len(localFiles))
+	for _, f := range localFiles {
+		localSet[f] = true
+	}
+	remoteSet := make(map[string]bool, len(remoteFiles))
+	for _, f := range remoteFiles {
+		remoteSet[f] = true
+	}
+
+	for _, f := range localFiles {
+		if remoteSet[f] {
+			conflicts = append(conflicts, f)
+		} else {
+			localOnly = append(localOnly, f)
+		}
+	}
+	for _, f := range remoteFiles {
+		if !localSet[f] {
+			remoteOnly = append(remoteOnly, f)
+		}
+	}
+
+	sort.Strings(localOnly)
+	sort.Strings(remoteOnly)
+	sort.Strings(conflicts)
+	return
 }

--- a/cmd/gitops/diff.go
+++ b/cmd/gitops/diff.go
@@ -2,6 +2,7 @@ package gitops
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/spf13/cobra"
 
@@ -12,9 +13,11 @@ import (
 func newDiffCmd(instance *config.Installation) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "diff",
-		Short: "Show what would change on pull (dry run)",
-		Long:  `Fetch the latest changes from the remote and show what files would be updated without actually applying them.`,
-		Args:  cobra.NoArgs,
+		Short: "Show local and remote changes since the branches diverged",
+		Long: `Fetch the latest changes from the remote and show what files have
+changed locally, what files have changed on the remote, and which
+files have changed in both (potential merge conflicts).`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runDiff(instance.Path)
 		},
@@ -28,36 +31,95 @@ func runDiff(installPath string) error {
 		return err
 	}
 
-	// Compare HEAD to the upstream tracking branch.
-	files, err := gitops.DiffNameOnly(installPath, "@{upstream}")
+	// Files changed locally since the fork point.
+	localFiles, err := gitops.DiffThreeDot(installPath, "@{upstream}", "HEAD")
 	if err != nil {
 		return err
 	}
 
-	if len(files) == 0 {
-		fmt.Println("No changes to pull — already up to date.")
+	// Files changed on the remote since the fork point.
+	remoteFiles, err := gitops.DiffThreeDot(installPath, "HEAD", "@{upstream}")
+	if err != nil {
+		return err
+	}
+
+	if len(localFiles) == 0 && len(remoteFiles) == 0 {
+		fmt.Println("No changes — local and remote are in sync.")
 		return nil
 	}
 
-	fmt.Printf("%d file(s) would change on pull:\n", len(files))
-	for _, f := range files {
-		fmt.Printf("  %s\n", f)
+	// Build sets for conflict detection.
+	localSet := make(map[string]bool, len(localFiles))
+	for _, f := range localFiles {
+		localSet[f] = true
+	}
+	remoteSet := make(map[string]bool, len(remoteFiles))
+	for _, f := range remoteFiles {
+		remoteSet[f] = true
 	}
 
-	needsRestart, needsMaintenance, submodulesUpdated := gitops.AnalyzeChanges(files)
-
-	if len(submodulesUpdated) > 0 {
-		fmt.Println("\nSubmodules that would be updated:")
-		for _, s := range submodulesUpdated {
-			fmt.Printf("  %s\n", s)
+	var conflicts, localOnly, remoteOnly []string
+	for _, f := range localFiles {
+		if remoteSet[f] {
+			conflicts = append(conflicts, f)
+		} else {
+			localOnly = append(localOnly, f)
+		}
+	}
+	for _, f := range remoteFiles {
+		if !localSet[f] {
+			remoteOnly = append(remoteOnly, f)
 		}
 	}
 
-	if needsRestart {
-		fmt.Println("\nA restart would be needed after pulling.")
+	sort.Strings(localOnly)
+	sort.Strings(remoteOnly)
+	sort.Strings(conflicts)
+
+	if len(localOnly) > 0 {
+		fmt.Printf("Local changes (not yet pushed): %d file(s)\n", len(localOnly))
+		for _, f := range localOnly {
+			fmt.Printf("  %s\n", f)
+		}
 	}
-	if needsMaintenance {
-		fmt.Println("A maintenance update may be needed after pulling.")
+
+	if len(remoteOnly) > 0 {
+		if len(localOnly) > 0 {
+			fmt.Println()
+		}
+		fmt.Printf("Remote changes (would be applied on pull): %d file(s)\n", len(remoteOnly))
+		for _, f := range remoteOnly {
+			fmt.Printf("  %s\n", f)
+		}
+	}
+
+	if len(conflicts) > 0 {
+		fmt.Printf("\nPotential conflicts (changed in both): %d file(s)\n", len(conflicts))
+		for _, f := range conflicts {
+			fmt.Printf("  %s\n", f)
+		}
+	}
+
+	// Analyze remote changes for restart/maintenance hints.
+	allRemote := make([]string, 0, len(remoteOnly)+len(conflicts))
+	allRemote = append(allRemote, remoteOnly...)
+	allRemote = append(allRemote, conflicts...)
+	if len(allRemote) > 0 {
+		needsRestart, needsMaintenance, submodulesUpdated := gitops.AnalyzeChanges(allRemote)
+
+		if len(submodulesUpdated) > 0 {
+			fmt.Println("\nSubmodules that would be updated:")
+			for _, s := range submodulesUpdated {
+				fmt.Printf("  %s\n", s)
+			}
+		}
+
+		if needsRestart {
+			fmt.Println("\nA restart would be needed after pulling.")
+		}
+		if needsMaintenance {
+			fmt.Println("A maintenance update may be needed after pulling.")
+		}
 	}
 
 	return nil

--- a/cmd/gitops/diff.go
+++ b/cmd/gitops/diff.go
@@ -14,9 +14,10 @@ func newDiffCmd(instance *config.Installation) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "diff",
 		Short: "Show local and remote changes since the branches diverged",
-		Long: `Fetch the latest changes from the remote and show what files have
-changed locally, what files have changed on the remote, and which
-files have changed in both (potential merge conflicts).`,
+		Long: `Show uncommitted working tree changes, then fetch the latest from
+the remote and show what files have changed locally, what files have
+changed on the remote, and which files have changed in both
+(potential merge conflicts).`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runDiff(instance.Path)
@@ -26,6 +27,12 @@ files have changed in both (potential merge conflicts).`,
 }
 
 func runDiff(installPath string) error {
+	// Check for uncommitted working tree changes first.
+	hasUncommitted, uncommittedFiles, err := gitops.HasUncommittedChanges(installPath)
+	if err != nil {
+		return err
+	}
+
 	// Fetch without merging.
 	if err := gitops.Fetch(installPath); err != nil {
 		return err
@@ -43,9 +50,17 @@ func runDiff(installPath string) error {
 		return err
 	}
 
-	if len(localFiles) == 0 && len(remoteFiles) == 0 {
+	if !hasUncommitted && len(localFiles) == 0 && len(remoteFiles) == 0 {
 		fmt.Println("No changes — local and remote are in sync.")
 		return nil
+	}
+
+	if hasUncommitted {
+		fmt.Printf("Uncommitted changes: %d file(s)\n", len(uncommittedFiles))
+		for _, f := range uncommittedFiles {
+			fmt.Printf("  %s\n", f)
+		}
+		fmt.Println()
 	}
 
 	localOnly, remoteOnly, conflicts := classifyChanges(localFiles, remoteFiles)

--- a/cmd/gitops/diff_test.go
+++ b/cmd/gitops/diff_test.go
@@ -1,0 +1,81 @@
+package gitops
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestClassifyChanges(t *testing.T) {
+	tests := []struct {
+		name       string
+		local      []string
+		remote     []string
+		wantLocal  []string
+		wantRemote []string
+		wantConfl  []string
+	}{
+		{
+			name:       "local only",
+			local:      []string{"a.php", "b.php"},
+			remote:     nil,
+			wantLocal:  []string{"a.php", "b.php"},
+			wantRemote: nil,
+			wantConfl:  nil,
+		},
+		{
+			name:       "remote only",
+			local:      nil,
+			remote:     []string{"c.php", "d.php"},
+			wantLocal:  nil,
+			wantRemote: []string{"c.php", "d.php"},
+			wantConfl:  nil,
+		},
+		{
+			name:       "no overlap",
+			local:      []string{"a.php"},
+			remote:     []string{"b.php"},
+			wantLocal:  []string{"a.php"},
+			wantRemote: []string{"b.php"},
+			wantConfl:  nil,
+		},
+		{
+			name:       "all conflict",
+			local:      []string{"a.php", "b.php"},
+			remote:     []string{"b.php", "a.php"},
+			wantLocal:  nil,
+			wantRemote: nil,
+			wantConfl:  []string{"a.php", "b.php"},
+		},
+		{
+			name:       "mixed",
+			local:      []string{"config/LocalSettings.php", "docker-compose.yml", ".env"},
+			remote:     []string{"config/LocalSettings.php", "config/wikis.yaml"},
+			wantLocal:  []string{".env", "docker-compose.yml"},
+			wantRemote: []string{"config/wikis.yaml"},
+			wantConfl:  []string{"config/LocalSettings.php"},
+		},
+		{
+			name:       "both empty",
+			local:      nil,
+			remote:     nil,
+			wantLocal:  nil,
+			wantRemote: nil,
+			wantConfl:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			localOnly, remoteOnly, conflicts := classifyChanges(tt.local, tt.remote)
+			if !reflect.DeepEqual(localOnly, tt.wantLocal) {
+				t.Errorf("localOnly = %v, want %v", localOnly, tt.wantLocal)
+			}
+			if !reflect.DeepEqual(remoteOnly, tt.wantRemote) {
+				t.Errorf("remoteOnly = %v, want %v", remoteOnly, tt.wantRemote)
+			}
+			if !reflect.DeepEqual(conflicts, tt.wantConfl) {
+				t.Errorf("conflicts = %v, want %v", conflicts, tt.wantConfl)
+			}
+		})
+	}
+}

--- a/cmd/gitops/status.go
+++ b/cmd/gitops/status.go
@@ -50,24 +50,22 @@ func runStatus(installPath string) error {
 		fmt.Printf("Last applied:   %s\n", gitops.ShortHash(applied))
 	}
 
-	// Staged changes.
-	hasStaged, stagedFiles, err := gitops.HasStagedChanges(installPath)
-	if err == nil && hasStaged {
-		fmt.Printf("\nStaged for push (%d files):\n", len(stagedFiles))
-		for _, f := range stagedFiles {
-			fmt.Printf("  %s\n", f)
-		}
-	}
-
-	// Uncommitted changes.
-	hasChanges, files, err := gitops.HasUncommittedChanges(installPath)
+	// Working tree status.
+	stagedFiles, unstagedFiles, err := gitops.WorkingTreeStatus(installPath)
 	if err == nil {
-		if hasChanges {
-			fmt.Printf("\nUnstaged changes (%d files):\n", len(files))
-			for _, f := range files {
+		if len(stagedFiles) > 0 {
+			fmt.Printf("\nStaged for push (%d files):\n", len(stagedFiles))
+			for _, f := range stagedFiles {
 				fmt.Printf("  %s\n", f)
 			}
-		} else if !hasStaged {
+		}
+		if len(unstagedFiles) > 0 {
+			fmt.Printf("\nUnstaged changes (%d files):\n", len(unstagedFiles))
+			for _, f := range unstagedFiles {
+				fmt.Printf("  %s\n", f)
+			}
+		}
+		if len(stagedFiles) == 0 && len(unstagedFiles) == 0 {
 			fmt.Println("\nNo changes.")
 		}
 	}

--- a/internal/gitops/git.go
+++ b/internal/gitops/git.go
@@ -171,32 +171,62 @@ func SubmoduleAdd(repoPath, submoduleURL, relativePath string) error {
 	return nil
 }
 
-// HasUncommittedChanges checks whether the working tree has uncommitted
-// changes. Returns true if there are changes, along with a list of
-// modified file paths.
-func HasUncommittedChanges(path string) (bool, []string, error) {
+// WorkingTreeStatus returns files grouped by their git status: staged
+// (index changes only) and unstaged (working tree modifications,
+// including untracked files). A file that is both staged and has
+// further working tree changes appears in both lists.
+func WorkingTreeStatus(path string) (staged, unstaged []string, err error) {
 	output, err := execute.Run(path, "git", "status", "--porcelain")
 	if err != nil {
-		return false, nil, fmt.Errorf("git status: %w", err)
+		return nil, nil, fmt.Errorf("git status: %w", err)
 	}
 	// Trim only trailing whitespace — leading spaces are significant
 	// in porcelain format (e.g. " M file" means unstaged modification).
 	output = strings.TrimRight(output, " \t\n\r")
 	if output == "" {
-		return false, nil, nil
+		return nil, nil, nil
 	}
-	var files []string
 	for _, line := range strings.Split(output, "\n") {
 		if len(line) < 4 {
 			continue
 		}
-		// porcelain format: "XY filename" where XY is a 2-char
-		// status code followed by a space — always 3 characters.
-		// Do not trim leading spaces: the first status character
-		// may itself be a space (e.g. " M file").
-		files = append(files, line[3:])
+		// porcelain format: "XY filename"
+		// X = index status, Y = working tree status
+		x, y := line[0], line[1]
+		file := line[3:]
+		if x != ' ' && x != '?' {
+			staged = append(staged, file)
+		}
+		if y != ' ' || x == '?' {
+			unstaged = append(unstaged, file)
+		}
 	}
-	return true, files, nil
+	return staged, unstaged, nil
+}
+
+// HasUncommittedChanges checks whether the working tree has uncommitted
+// changes (staged or unstaged). Returns true if there are changes, along
+// with a combined list of all modified file paths.
+func HasUncommittedChanges(path string) (bool, []string, error) {
+	staged, unstaged, err := WorkingTreeStatus(path)
+	if err != nil {
+		return false, nil, err
+	}
+	seen := make(map[string]bool)
+	var files []string
+	for _, f := range staged {
+		if !seen[f] {
+			seen[f] = true
+			files = append(files, f)
+		}
+	}
+	for _, f := range unstaged {
+		if !seen[f] {
+			seen[f] = true
+			files = append(files, f)
+		}
+	}
+	return len(files) > 0, files, nil
 }
 
 // CurrentCommitHash returns the full commit hash of HEAD.

--- a/internal/gitops/git.go
+++ b/internal/gitops/git.go
@@ -245,6 +245,20 @@ func DiffNameOnly(path, ref string) ([]string, error) {
 	return strings.Split(output, "\n"), nil
 }
 
+// DiffThreeDot returns files changed on refB since its merge base with refA.
+// This is equivalent to `git diff --name-only refA...refB`.
+func DiffThreeDot(path, refA, refB string) ([]string, error) {
+	output, err := execute.Run(path, "git", "diff", "--name-only", refA+"..."+refB)
+	if err != nil {
+		return nil, fmt.Errorf("git diff --name-only %s...%s: %w", refA, refB, err)
+	}
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return nil, nil
+	}
+	return strings.Split(output, "\n"), nil
+}
+
 // CheckoutHead checks out all tracked files from HEAD into the working tree
 // without overwriting untracked files.
 func CheckoutHead(path string) error {


### PR DESCRIPTION
## Summary

- `canasta gitops diff` now shows three sections instead of a flat list:
  - **Local changes** (not yet pushed)
  - **Remote changes** (would be applied on pull)
  - **Potential conflicts** (changed in both local and remote)
- Shows uncommitted working tree changes (untracked, staged, unstaged) before the branch comparison, so users see all local changes without needing to commit first
- Fixes `canasta gitops status` incorrectly listing staged-only files under "Unstaged changes" by adding `WorkingTreeStatus()` that correctly parses porcelain XY codes
- Adds `DiffThreeDot` helper to compare changes since the fork point
- Extracts `classifyChanges` function with table-driven unit tests
- Restart/maintenance hints are based on remote changes only

Fixes #677
Fixes #691

## Test plan

- [x] With only local changes: shows "Local changes" section, no remote section
- [x] With only remote changes: shows "Remote changes" section, no local section
- [x] With both: shows all three sections, conflicts listed separately
- [x] Fully synced: shows "No changes" message
- [x] Uncommitted file (not staged or committed): diff shows "Uncommitted changes"
- [x] Staged-only file: `gitops status` shows it under "Staged for push" only, not "Unstaged changes"