### PR TITLE
Sync wikis.yaml.template when adding or removing wikis

### DIFF
--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -11,6 +11,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
 	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
+	"github.com/CanastaWiki/Canasta-CLI/internal/gitops"
 	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI/internal/mediawiki"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
@@ -256,6 +257,11 @@ func AddWiki(opts AddWikiOptions) error {
 	// Add the wiki in farmsettings (only after successful installation)
 	err = farmsettings.AddWiki(opts.WikiID, opts.Instance.Path, opts.Domain, opts.WikiPath, opts.SiteName)
 	if err != nil {
+		return err
+	}
+
+	// Update wikis.yaml.template if gitops is active.
+	if err := gitops.SyncWikisTemplate(opts.Instance.Path); err != nil {
 		return err
 	}
 

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -10,6 +10,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/canasta"
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
 	"github.com/CanastaWiki/Canasta-CLI/internal/farmsettings"
+	"github.com/CanastaWiki/Canasta-CLI/internal/gitops"
 	"github.com/CanastaWiki/Canasta-CLI/internal/logging"
 	"github.com/CanastaWiki/Canasta-CLI/internal/mediawiki"
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
@@ -104,6 +105,11 @@ func RemoveWiki(instance config.Installation, wikiID string, yes bool) error {
 	// Remove the wiki
 	err = farmsettings.RemoveWiki(wikiID, instance.Path)
 	if err != nil {
+		return err
+	}
+
+	// Update wikis.yaml.template if gitops is active.
+	if err := gitops.SyncWikisTemplate(instance.Path); err != nil {
 		return err
 	}
 

--- a/internal/gitops/template.go
+++ b/internal/gitops/template.go
@@ -178,3 +178,66 @@ func ExtractWikisTemplate(wikisContent string) (string, VarsMap, error) {
 func RenderWikisTemplate(templateContent string, vars VarsMap) (string, error) {
 	return RenderTemplate(templateContent, vars)
 }
+
+// SyncWikisTemplate regenerates wikis.yaml.template from the current
+// config/wikis.yaml and updates the current host's vars with any new or
+// removed wiki_url_* entries. This is a no-op if gitops is not active
+// (i.e., wikis.yaml.template does not exist).
+func SyncWikisTemplate(installPath string) error {
+	// Check if gitops is active by looking for the template file.
+	existingTemplate, err := LoadWikisTemplate(installPath)
+	if err != nil {
+		return err
+	}
+	if existingTemplate == "" {
+		return nil
+	}
+
+	// Read the current wikis.yaml.
+	wikisContent, err := LoadWikisYAML(installPath)
+	if err != nil {
+		return err
+	}
+	if wikisContent == "" {
+		return nil
+	}
+
+	// Regenerate the template.
+	newTemplate, newVars, err := ExtractWikisTemplate(wikisContent)
+	if err != nil {
+		return err
+	}
+	if err := SaveWikisTemplate(installPath, newTemplate); err != nil {
+		return err
+	}
+
+	// Update the current host's vars with the new wiki URL entries.
+	hostName, err := LoadLocalHost(installPath)
+	if err != nil || hostName == "" {
+		// No host configured — nothing more to do.
+		return nil
+	}
+
+	vars, err := LoadVars(installPath, hostName)
+	if err != nil {
+		return err
+	}
+
+	// Remove old wiki_url_* entries that are no longer in the template.
+	for key := range vars {
+		if strings.HasPrefix(key, "wiki_url_") {
+			if _, ok := newVars[key]; !ok {
+				delete(vars, key)
+			}
+		}
+	}
+
+	// Add new wiki_url_* entries that are not yet in the vars.
+	for key, value := range newVars {
+		if _, ok := vars[key]; !ok {
+			vars[key] = value
+		}
+	}
+
+	return SaveVars(installPath, hostName, vars)
+}

--- a/internal/gitops/template_test.go
+++ b/internal/gitops/template_test.go
@@ -1,6 +1,7 @@
 package gitops
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -229,6 +230,119 @@ func TestExtractWikisTemplateEmpty(t *testing.T) {
 	if tmpl == "" {
 		t.Error("expected non-empty template")
 	}
+}
+
+func TestSyncWikisTemplate_AddsNewWiki(t *testing.T) {
+	dir := t.TempDir()
+
+	// Set up an existing template with one wiki.
+	oldTemplate := "wikis:\n- id: wiki1\n  url: '{{wiki_url_wiki1}}'\n  name: Main Wiki\n"
+	if err := SaveWikisTemplate(dir, oldTemplate); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up host config.
+	if err := SaveLocalHost(dir, "server1"); err != nil {
+		t.Fatal(err)
+	}
+	oldVars := VarsMap{"wiki_url_wiki1": "example.com", "mysql_password": "secret"}
+	if err := SaveVars(dir, "server1", oldVars); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write an updated wikis.yaml with two wikis.
+	wikisContent := "wikis:\n- id: wiki1\n  url: example.com\n  name: Main Wiki\n- id: wiki2\n  url: example.com/docs\n  name: Docs\n"
+	if err := saveWikisYAML(dir, wikisContent); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SyncWikisTemplate(dir); err != nil {
+		t.Fatalf("SyncWikisTemplate: %v", err)
+	}
+
+	// Verify template was updated.
+	tmpl, err := LoadWikisTemplate(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(tmpl, "{{wiki_url_wiki2}}") {
+		t.Error("template should contain {{wiki_url_wiki2}}")
+	}
+
+	// Verify vars were updated.
+	vars, err := LoadVars(dir, "server1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vars["wiki_url_wiki2"] != "example.com/docs" {
+		t.Errorf("wiki_url_wiki2 = %q, want %q", vars["wiki_url_wiki2"], "example.com/docs")
+	}
+	// Existing non-wiki vars should be preserved.
+	if vars["mysql_password"] != "secret" {
+		t.Errorf("mysql_password = %q, want %q", vars["mysql_password"], "secret")
+	}
+}
+
+func TestSyncWikisTemplate_RemovesWiki(t *testing.T) {
+	dir := t.TempDir()
+
+	// Set up template with two wikis.
+	oldTemplate := "wikis:\n- id: wiki1\n  url: '{{wiki_url_wiki1}}'\n  name: Main\n- id: wiki2\n  url: '{{wiki_url_wiki2}}'\n  name: Docs\n"
+	if err := SaveWikisTemplate(dir, oldTemplate); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SaveLocalHost(dir, "server1"); err != nil {
+		t.Fatal(err)
+	}
+	oldVars := VarsMap{"wiki_url_wiki1": "example.com", "wiki_url_wiki2": "example.com/docs", "mysql_password": "secret"}
+	if err := SaveVars(dir, "server1", oldVars); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write wikis.yaml with only one wiki (wiki2 removed).
+	wikisContent := "wikis:\n- id: wiki1\n  url: example.com\n  name: Main\n"
+	if err := saveWikisYAML(dir, wikisContent); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SyncWikisTemplate(dir); err != nil {
+		t.Fatalf("SyncWikisTemplate: %v", err)
+	}
+
+	// Verify wiki2 var was removed.
+	vars, err := LoadVars(dir, "server1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := vars["wiki_url_wiki2"]; ok {
+		t.Error("wiki_url_wiki2 should have been removed from vars")
+	}
+	if vars["wiki_url_wiki1"] != "example.com" {
+		t.Errorf("wiki_url_wiki1 = %q, want %q", vars["wiki_url_wiki1"], "example.com")
+	}
+	if vars["mysql_password"] != "secret" {
+		t.Errorf("mysql_password should be preserved")
+	}
+}
+
+func TestSyncWikisTemplate_NoopWithoutGitops(t *testing.T) {
+	dir := t.TempDir()
+
+	// No wikis.yaml.template — SyncWikisTemplate should be a no-op.
+	err := SyncWikisTemplate(dir)
+	if err != nil {
+		t.Fatalf("expected no error when gitops is not active, got: %v", err)
+	}
+}
+
+// saveWikisYAML is a test helper that writes config/wikis.yaml.
+func saveWikisYAML(installPath, content string) error {
+	dir := installPath + "/config"
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(dir+"/wikis.yaml", []byte(content), 0o644)
 }
 
 func TestFindMissingCustomKeys(t *testing.T) {


### PR DESCRIPTION
## Summary
- When gitops is active, `canasta add` and `canasta remove` now regenerate `wikis.yaml.template` from the updated `config/wikis.yaml`
- Also updates the current host's vars with any new or removed `wiki_url_*` entries
- No-op when gitops is not configured (template file doesn't exist)

Previously only `config/wikis.yaml` was updated, but that file is gitignored. New wikis added after `gitops init` were not tracked in the repo and could be lost on `git reset` or pull.

Closes #681

## Test plan
- [x] Set up gitops, run `canasta add` for a second wiki, verify `wikis.yaml.template` and host vars are updated
- [x] Run `canasta remove` for the second wiki, verify template and vars no longer include it
- [x] Run `canasta add` on a non-gitops instance, verify no errors (no-op)
- [x] Unit tests pass for SyncWikisTemplate (add, remove, no-op cases)
- [x] Lint passes