### PR TITLE
wiki-publish: use syntaxhighlight with copy button for examples

### DIFF
--- a/tools/wiki-publish/main.go
+++ b/tools/wiki-publish/main.go
@@ -226,9 +226,13 @@ func genWikitext(c *cobra.Command) string {
 
 	if len(c.Example) > 0 {
 		b.WriteString("=== Examples ===\n\n")
-		b.WriteString("<pre>\n")
+		if hasPlaceholder(c.Example) {
+			b.WriteString("<syntaxhighlight lang=\"bash\">\n")
+		} else {
+			b.WriteString("<syntaxhighlight lang=\"bash\" copy=1>\n")
+		}
 		b.WriteString(c.Example + "\n")
-		b.WriteString("</pre>\n\n")
+		b.WriteString("</syntaxhighlight>\n\n")
 	}
 
 	// Combined flags
@@ -264,6 +268,16 @@ func hasAnyFlags(c *cobra.Command) bool {
 func isFlagRequired(f *pflag.Flag) bool {
 	ann, ok := f.Annotations[cobra.BashCompOneRequiredFlag]
 	return ok && len(ann) > 0 && ann[0] == "true"
+}
+
+// rePlaceholder matches bracket/angle-bracket placeholders like [flags], [args...],
+// <path>, etc. that indicate the example is not fully concrete.
+var rePlaceholder = regexp.MustCompile(`\[.*?\]|<.*?>`)
+
+// hasPlaceholder reports whether text contains placeholder patterns such as
+// [flags], [args...], or <path> that indicate incomplete examples.
+func hasPlaceholder(text string) bool {
+	return rePlaceholder.MatchString(text)
 }
 
 // reParenDefault matches "(default: ...)" or "(defaults to ...)" or "(optional, defaults to ...)"

--- a/tools/wiki-publish/main.go
+++ b/tools/wiki-publish/main.go
@@ -200,9 +200,9 @@ func genWikitext(c *cobra.Command) string {
 	}
 
 	if c.Runnable() {
-		b.WriteString("<pre>\n")
+		b.WriteString("<syntaxhighlight lang=\"bash\">\n")
 		b.WriteString(c.UseLine() + "\n")
-		b.WriteString("</pre>\n\n")
+		b.WriteString("</syntaxhighlight>\n\n")
 	}
 
 	// Subcommands section for non-runnable commands


### PR DESCRIPTION
## Summary
- Render CLI example blocks using `<syntaxhighlight lang="bash" copy=1>` when they contain no placeholder patterns (`[flags]`, `[args]`, etc.), giving users a one-click copy button on the wiki
- Examples with placeholders use `<syntaxhighlight lang="bash">` without the copy attribute since copying incomplete commands isn't useful
- Usage line blocks switched from `<pre>` to `<syntaxhighlight lang="bash">` (without copy) for visual consistency

Fixes #689

## Test plan
- [x] Run `go run tools/wiki-publish/main.go -dry-run` and verify concrete examples get `copy=1`, placeholder examples do not
- [x] Verify usage lines render as `<syntaxhighlight lang="bash">` without copy
- [ ] Publish to wiki and confirm copy buttons appear on concrete example blocks