### PR TITLE
Test(gitops): Add unit test coverage for convertToSubmodules (closes #606)

### DIFF
--- a/cmd/gitops/init_test.go
+++ b/cmd/gitops/init_test.go
@@ -156,3 +156,243 @@ func TestRepairBrokenSubmodules(t *testing.T) {
 		}
 	})
 }
+
+func TestConvertToSubmodulesStandaloneRepoConverted(t *testing.T) {
+	t.Setenv("GIT_ALLOW_PROTOCOL", "file")
+
+	installPath := t.TempDir()
+	dirName := "extensions"
+
+	if err := os.MkdirAll(filepath.Join(installPath, dirName), 0755); err != nil {
+		t.Fatalf("creating extensions dir: %v", err)
+	}
+	initGitRepo(t, installPath)
+
+	remote := createGitRepoWithCommit(t, t.TempDir(), "module")
+	subDir := filepath.Join(installPath, dirName, "MyModule")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatalf("creating subdir: %v", err)
+	}
+	initGitRepo(t, subDir)
+	runGit(t, subDir, "remote", "add", "origin", remote)
+	if err := os.WriteFile(filepath.Join(subDir, "plugin.php"), []byte("<?php\n"), 0644); err != nil {
+		t.Fatalf("writing plugin file: %v", err)
+	}
+	runGit(t, subDir, "add", "plugin.php")
+	runGit(t, subDir, "commit", "-m", "add plugin")
+
+	err := convertToSubmodules(installPath, dirName)
+	if err != nil {
+		t.Fatalf("convertToSubmodules returned error: %v", err)
+	}
+
+	gitPath := filepath.Join(subDir, ".git")
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		t.Errorf("expected .git to exist after conversion, got error: %v", err)
+	}
+	if !info.IsDir() {
+		moduleContents, _ := os.ReadFile(gitPath)
+		if !strings.Contains(string(moduleContents), "gitdir") {
+			t.Errorf("expected .git to be a gitlink file after conversion")
+		}
+	}
+}
+
+func TestConvertToSubmodulesCommitPreserved(t *testing.T) {
+	t.Setenv("GIT_ALLOW_PROTOCOL", "file")
+
+	installPath := t.TempDir()
+	dirName := "extensions"
+
+	if err := os.MkdirAll(filepath.Join(installPath, dirName), 0755); err != nil {
+		t.Fatalf("creating extensions dir: %v", err)
+	}
+	initGitRepo(t, installPath)
+
+	remotePath := t.TempDir()
+	initGitRepo(t, remotePath)
+	runGit(t, remotePath, "config", "receive.denyCurrentBranch", "ignore")
+
+	subDir := filepath.Join(installPath, dirName, "Pinned")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatalf("creating subdir: %v", err)
+	}
+	initGitRepo(t, subDir)
+	runGit(t, subDir, "remote", "add", "origin", remotePath)
+
+	if err := os.WriteFile(filepath.Join(subDir, "v1.txt"), []byte("version 1\n"), 0644); err != nil {
+		t.Fatalf("writing v1: %v", err)
+	}
+	runGit(t, subDir, "add", "v1.txt")
+	runGit(t, subDir, "commit", "-m", "version 1")
+
+	if err := os.WriteFile(filepath.Join(subDir, "v2.txt"), []byte("version 2\n"), 0644); err != nil {
+		t.Fatalf("writing v2: %v", err)
+	}
+	runGit(t, subDir, "add", "v2.txt")
+	runGit(t, subDir, "commit", "-m", "version 2")
+	headBeforeConvert := runGit(t, subDir, "rev-parse", "HEAD")
+
+	runGit(t, subDir, "push", "-u", "origin", "main")
+
+	err := convertToSubmodules(installPath, dirName)
+	if err != nil {
+		t.Fatalf("convertToSubmodules returned error: %v", err)
+	}
+
+	gitPath := filepath.Join(subDir, ".git")
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		t.Fatalf("expected .git to exist after conversion, got error: %v", err)
+	}
+
+	if !info.IsDir() {
+		gitContent, _ := os.ReadFile(gitPath)
+		if !strings.Contains(string(gitContent), "gitdir") {
+			t.Fatalf("expected .git to be a gitlink file after conversion")
+		}
+	}
+
+	currentHead := runGit(t, subDir, "rev-parse", "HEAD")
+	if currentHead != headBeforeConvert {
+		t.Errorf("expected commit to be preserved at %s, but got %s", headBeforeConvert[:8], currentHead[:8])
+	}
+}
+
+func TestConvertToSubmodulesNoRemoteSkipped(t *testing.T) {
+	installPath := t.TempDir()
+	dirName := "extensions"
+
+	if err := os.MkdirAll(filepath.Join(installPath, dirName), 0755); err != nil {
+		t.Fatalf("creating extensions dir: %v", err)
+	}
+	initGitRepo(t, installPath)
+
+	subDir := filepath.Join(installPath, dirName, "NoRemote")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatalf("creating subdir: %v", err)
+	}
+	initGitRepo(t, subDir)
+	if err := os.WriteFile(filepath.Join(subDir, "file.txt"), []byte("content\n"), 0644); err != nil {
+		t.Fatalf("writing file: %v", err)
+	}
+	runGit(t, subDir, "add", "file.txt")
+	runGit(t, subDir, "commit", "-m", "initial")
+
+	err := convertToSubmodules(installPath, dirName)
+	if err != nil {
+		t.Fatalf("convertToSubmodules returned error: %v", err)
+	}
+
+	_, err = os.Stat(subDir)
+	if os.IsNotExist(err) {
+		t.Errorf("expected subdirectory to be skipped and remain, but it was removed")
+	}
+
+	gitDir := filepath.Join(subDir, ".git")
+	if _, err := os.Stat(gitDir); os.IsNotExist(err) {
+		t.Errorf("expected .git directory to be preserved")
+	}
+}
+
+func TestConvertToSubmodulesNonGitDirectorySkipped(t *testing.T) {
+	installPath := t.TempDir()
+	dirName := "extensions"
+
+	if err := os.MkdirAll(filepath.Join(installPath, dirName), 0755); err != nil {
+		t.Fatalf("creating extensions dir: %v", err)
+	}
+	initGitRepo(t, installPath)
+
+	subDir := filepath.Join(installPath, dirName, "NotGit")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatalf("creating subdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "readme.txt"), []byte("not a git repo\n"), 0644); err != nil {
+		t.Fatalf("writing file: %v", err)
+	}
+
+	err := convertToSubmodules(installPath, dirName)
+	if err != nil {
+		t.Fatalf("convertToSubmodules returned error: %v", err)
+	}
+
+	_, err = os.Stat(subDir)
+	if os.IsNotExist(err) {
+		t.Errorf("expected non-git directory to be skipped and remain")
+	}
+
+	gitDir := filepath.Join(subDir, ".git")
+	if _, err := os.Stat(gitDir); err == nil {
+		t.Errorf("expected .git not to exist in non-git directory")
+	}
+}
+
+func TestConvertToSubmodulesGitlinkFileSkipped(t *testing.T) {
+	installPath := t.TempDir()
+	dirName := "extensions"
+
+	if err := os.MkdirAll(filepath.Join(installPath, dirName), 0755); err != nil {
+		t.Fatalf("creating extensions dir: %v", err)
+	}
+	initGitRepo(t, installPath)
+
+	subDir := filepath.Join(installPath, dirName, "GitLink")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatalf("creating subdir: %v", err)
+	}
+	gitFile := filepath.Join(subDir, ".git")
+	if err := os.WriteFile(gitFile, []byte("gitdir: /some/path\n"), 0644); err != nil {
+		t.Fatalf("writing .git file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "marker.txt"), []byte("already a submodule\n"), 0644); err != nil {
+		t.Fatalf("writing marker: %v", err)
+	}
+
+	err := convertToSubmodules(installPath, dirName)
+	if err != nil {
+		t.Fatalf("convertToSubmodules returned error: %v", err)
+	}
+
+	_, err = os.Stat(subDir)
+	if os.IsNotExist(err) {
+		t.Errorf("expected subdirectory with .git file to be skipped and remain")
+	}
+
+	content, _ := os.ReadFile(gitFile)
+	expected := string(content)
+	if !strings.Contains(expected, "gitdir") {
+		t.Errorf("expected .git file to be preserved")
+	}
+}
+
+func TestConvertToSubmodulesEmptyDirectory(t *testing.T) {
+	installPath := t.TempDir()
+	dirName := "extensions"
+
+	if err := os.MkdirAll(filepath.Join(installPath, dirName), 0755); err != nil {
+		t.Fatalf("creating extensions dir: %v", err)
+	}
+	initGitRepo(t, installPath)
+
+	err := convertToSubmodules(installPath, dirName)
+	if err != nil {
+		t.Fatalf("convertToSubmodules should handle empty directory without error, got: %v", err)
+	}
+
+	_, err = os.Stat(filepath.Join(installPath, dirName))
+	if os.IsNotExist(err) {
+		t.Errorf("expected extensions directory to still exist")
+	}
+}
+
+func TestConvertToSubmodulesMissingDirectory(t *testing.T) {
+	installPath := t.TempDir()
+	dirName := "nonexistent"
+
+	err := convertToSubmodules(installPath, dirName)
+	if err != nil {
+		t.Fatalf("convertToSubmodules should handle missing directory without error, got: %v", err)
+	}
+}

--- a/cmd/gitops/init_test.go
+++ b/cmd/gitops/init_test.go
@@ -160,16 +160,16 @@ func TestRepairBrokenSubmodules(t *testing.T) {
 func TestConvertToSubmodulesStandaloneRepoConverted(t *testing.T) {
 	t.Setenv("GIT_ALLOW_PROTOCOL", "file")
 
-	installPath := t.TempDir()
+	instancePath := t.TempDir()
 	dirName := "extensions"
 
-	if err := os.MkdirAll(filepath.Join(installPath, dirName), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(instancePath, dirName), 0755); err != nil {
 		t.Fatalf("creating extensions dir: %v", err)
 	}
-	initGitRepo(t, installPath)
+	initGitRepo(t, instancePath)
 
 	remote := createGitRepoWithCommit(t, t.TempDir(), "module")
-	subDir := filepath.Join(installPath, dirName, "MyModule")
+	subDir := filepath.Join(instancePath, dirName, "MyModule")
 	if err := os.MkdirAll(subDir, 0755); err != nil {
 		t.Fatalf("creating subdir: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestConvertToSubmodulesStandaloneRepoConverted(t *testing.T) {
 	runGit(t, subDir, "add", "plugin.php")
 	runGit(t, subDir, "commit", "-m", "add plugin")
 
-	err := convertToSubmodules(installPath, dirName)
+	err := convertToSubmodules(instancePath, dirName)
 	if err != nil {
 		t.Fatalf("convertToSubmodules returned error: %v", err)
 	}
@@ -202,19 +202,19 @@ func TestConvertToSubmodulesStandaloneRepoConverted(t *testing.T) {
 func TestConvertToSubmodulesCommitPreserved(t *testing.T) {
 	t.Setenv("GIT_ALLOW_PROTOCOL", "file")
 
-	installPath := t.TempDir()
+	instancePath := t.TempDir()
 	dirName := "extensions"
 
-	if err := os.MkdirAll(filepath.Join(installPath, dirName), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(instancePath, dirName), 0755); err != nil {
 		t.Fatalf("creating extensions dir: %v", err)
 	}
-	initGitRepo(t, installPath)
+	initGitRepo(t, instancePath)
 
 	remotePath := t.TempDir()
 	initGitRepo(t, remotePath)
 	runGit(t, remotePath, "config", "receive.denyCurrentBranch", "ignore")
 
-	subDir := filepath.Join(installPath, dirName, "Pinned")
+	subDir := filepath.Join(instancePath, dirName, "Pinned")
 	if err := os.MkdirAll(subDir, 0755); err != nil {
 		t.Fatalf("creating subdir: %v", err)
 	}
@@ -236,7 +236,7 @@ func TestConvertToSubmodulesCommitPreserved(t *testing.T) {
 
 	runGit(t, subDir, "push", "-u", "origin", "main")
 
-	err := convertToSubmodules(installPath, dirName)
+	err := convertToSubmodules(instancePath, dirName)
 	if err != nil {
 		t.Fatalf("convertToSubmodules returned error: %v", err)
 	}
@@ -261,15 +261,15 @@ func TestConvertToSubmodulesCommitPreserved(t *testing.T) {
 }
 
 func TestConvertToSubmodulesNoRemoteSkipped(t *testing.T) {
-	installPath := t.TempDir()
+	instancePath := t.TempDir()
 	dirName := "extensions"
 
-	if err := os.MkdirAll(filepath.Join(installPath, dirName), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(instancePath, dirName), 0755); err != nil {
 		t.Fatalf("creating extensions dir: %v", err)
 	}
-	initGitRepo(t, installPath)
+	initGitRepo(t, instancePath)
 
-	subDir := filepath.Join(installPath, dirName, "NoRemote")
+	subDir := filepath.Join(instancePath, dirName, "NoRemote")
 	if err := os.MkdirAll(subDir, 0755); err != nil {
 		t.Fatalf("creating subdir: %v", err)
 	}
@@ -280,7 +280,7 @@ func TestConvertToSubmodulesNoRemoteSkipped(t *testing.T) {
 	runGit(t, subDir, "add", "file.txt")
 	runGit(t, subDir, "commit", "-m", "initial")
 
-	err := convertToSubmodules(installPath, dirName)
+	err := convertToSubmodules(instancePath, dirName)
 	if err != nil {
 		t.Fatalf("convertToSubmodules returned error: %v", err)
 	}
@@ -297,15 +297,15 @@ func TestConvertToSubmodulesNoRemoteSkipped(t *testing.T) {
 }
 
 func TestConvertToSubmodulesNonGitDirectorySkipped(t *testing.T) {
-	installPath := t.TempDir()
+	instancePath := t.TempDir()
 	dirName := "extensions"
 
-	if err := os.MkdirAll(filepath.Join(installPath, dirName), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(instancePath, dirName), 0755); err != nil {
 		t.Fatalf("creating extensions dir: %v", err)
 	}
-	initGitRepo(t, installPath)
+	initGitRepo(t, instancePath)
 
-	subDir := filepath.Join(installPath, dirName, "NotGit")
+	subDir := filepath.Join(instancePath, dirName, "NotGit")
 	if err := os.MkdirAll(subDir, 0755); err != nil {
 		t.Fatalf("creating subdir: %v", err)
 	}
@@ -313,7 +313,7 @@ func TestConvertToSubmodulesNonGitDirectorySkipped(t *testing.T) {
 		t.Fatalf("writing file: %v", err)
 	}
 
-	err := convertToSubmodules(installPath, dirName)
+	err := convertToSubmodules(instancePath, dirName)
 	if err != nil {
 		t.Fatalf("convertToSubmodules returned error: %v", err)
 	}
@@ -330,15 +330,15 @@ func TestConvertToSubmodulesNonGitDirectorySkipped(t *testing.T) {
 }
 
 func TestConvertToSubmodulesGitlinkFileSkipped(t *testing.T) {
-	installPath := t.TempDir()
+	instancePath := t.TempDir()
 	dirName := "extensions"
 
-	if err := os.MkdirAll(filepath.Join(installPath, dirName), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(instancePath, dirName), 0755); err != nil {
 		t.Fatalf("creating extensions dir: %v", err)
 	}
-	initGitRepo(t, installPath)
+	initGitRepo(t, instancePath)
 
-	subDir := filepath.Join(installPath, dirName, "GitLink")
+	subDir := filepath.Join(instancePath, dirName, "GitLink")
 	if err := os.MkdirAll(subDir, 0755); err != nil {
 		t.Fatalf("creating subdir: %v", err)
 	}
@@ -350,7 +350,7 @@ func TestConvertToSubmodulesGitlinkFileSkipped(t *testing.T) {
 		t.Fatalf("writing marker: %v", err)
 	}
 
-	err := convertToSubmodules(installPath, dirName)
+	err := convertToSubmodules(instancePath, dirName)
 	if err != nil {
 		t.Fatalf("convertToSubmodules returned error: %v", err)
 	}
@@ -368,30 +368,30 @@ func TestConvertToSubmodulesGitlinkFileSkipped(t *testing.T) {
 }
 
 func TestConvertToSubmodulesEmptyDirectory(t *testing.T) {
-	installPath := t.TempDir()
+	instancePath := t.TempDir()
 	dirName := "extensions"
 
-	if err := os.MkdirAll(filepath.Join(installPath, dirName), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(instancePath, dirName), 0755); err != nil {
 		t.Fatalf("creating extensions dir: %v", err)
 	}
-	initGitRepo(t, installPath)
+	initGitRepo(t, instancePath)
 
-	err := convertToSubmodules(installPath, dirName)
+	err := convertToSubmodules(instancePath, dirName)
 	if err != nil {
 		t.Fatalf("convertToSubmodules should handle empty directory without error, got: %v", err)
 	}
 
-	_, err = os.Stat(filepath.Join(installPath, dirName))
+	_, err = os.Stat(filepath.Join(instancePath, dirName))
 	if os.IsNotExist(err) {
 		t.Errorf("expected extensions directory to still exist")
 	}
 }
 
 func TestConvertToSubmodulesMissingDirectory(t *testing.T) {
-	installPath := t.TempDir()
+	instancePath := t.TempDir()
 	dirName := "nonexistent"
 
-	err := convertToSubmodules(installPath, dirName)
+	err := convertToSubmodules(instancePath, dirName)
 	if err != nil {
 		t.Fatalf("convertToSubmodules should handle missing directory without error, got: %v", err)
 	}


### PR DESCRIPTION
This PR adds unit tests for convertToSubmodules() to validate conversion behavior and edge-case handling when scanning installation subdirectories for standalone git repositories.

What was added:

1. Standalone repo converted to submodule
2. Commit preserved after conversion
3. Repo with no remote is skipped
4. Non-git directory is skipped
5. Directory with .git file (gitlink style) is skipped
6. Empty scanned directory returns no error
7. Missing scanned directory returns no error

Validation:

1. Ran targeted tests repeatedly for stability
2. Ran full package tests to confirm no regressions
3. Ran tests with race detector
4. Verified function-level coverage for convertToSubmodules() is high and behavior is reliable
5. This closes a test gap in gitops init behavior and reduces risk of regressions in submodule migration logic.

Issue:
Closes #606 

Apologies for the multiple edits, seems like I wasn't in the correct head-space for quite some time...