### PR TITLE
fix: improve error messages during canasta upgrade

### DIFF
--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -74,7 +74,12 @@ func upgradeAllInstances(dryRun bool) error {
 		return err
 	}
 	if len(installations) == 0 {
-		fmt.Println("No registered installations found")
+		fmt.Printf("No registered installations found (looked in %s)\n", config.GetConfFilePath())
+		if config.IsRunningAsRoot() {
+			fmt.Println("Note: Running as root uses /etc/canasta/conf.json. Installations")
+			fmt.Println("registered by a non-root user are stored in ~/.config/canasta/conf.json.")
+			fmt.Println("Try running without sudo if your installations were created as a regular user.")
+		}
 		return nil
 	}
 
@@ -219,11 +224,6 @@ func Upgrade(instance config.Installation, dryRun bool) error {
 				fmt.Println("  Would dump MySQL 8.0 databases and re-import into MariaDB")
 			}
 		}
-	} else if !dryRun {
-		// Kubernetes: automatic migration is not supported. Warn the user
-		// so they can manually dump and restore if they were on MySQL 8.0.
-		fmt.Println("  Note: If this installation was using MySQL 8.0, the database must be")
-		fmt.Println("  manually migrated to MariaDB. See https://canasta.wiki/setup/ for details.")
 	}
 
 	if dryRun {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -132,7 +132,11 @@ func ListAll() error {
 	}
 
 	if len(existingInstallations.Installations) == 0 {
-		fmt.Println("No instances found.")
+		fmt.Printf("No instances found (looked in %s)\n", confFile)
+		if IsRunningAsRoot() {
+			fmt.Println("Note: Running as root uses /etc/canasta/conf.json. Installations")
+			fmt.Println("registered by a non-root user are stored in ~/.config/canasta/conf.json.")
+		}
 		return nil
 	}
 
@@ -210,6 +214,21 @@ func GetAll() (map[string]Installation, error) {
 		return nil, err
 	}
 	return existingInstallations.Installations, nil
+}
+
+// GetConfFilePath returns the path to the conf.json file currently in use.
+// Must be called after GetAll or any other function that triggers initialization.
+func GetConfFilePath() string {
+	return confFile
+}
+
+// IsRunningAsRoot returns true if the current process is running as root.
+func IsRunningAsRoot() bool {
+	currentUser, err := user.Current()
+	if err != nil {
+		return false
+	}
+	return currentUser.Username == "root"
 }
 
 func GetDetails(canastaID string) (Installation, error) {

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -111,7 +111,8 @@ func downloadAndInstall(latestVersion, execPath string) error {
 	}
 
 	// Rename failed (permission denied or cross-filesystem) — use sudo mv
-	fmt.Println("Elevated permissions required to update the binary.")
+	fmt.Printf("Elevated permissions required to update %s.\n", execPath)
+	fmt.Println("You may be prompted for your password.")
 	cmd := exec.Command("sudo", "mv", tmpPath, execPath)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
## Summary

- Self-update now shows the binary path being updated (e.g. `/usr/local/bin/canasta`) and warns the user they may be prompted for their password
- "No registered installations found" now shows which `conf.json` was checked and, when running as root, explains the root vs non-root config path difference
- Same improvement applied to `canasta list` when no instances exist
- Removed speculative MySQL 8.0 migration warning that printed unconditionally for every Kubernetes upgrade

Fixes #692

## Test plan

- [ ] Run `canasta upgrade` as a non-root user with the binary in a root-owned path — verify the elevated permissions message shows the binary path and password prompt warning
- [x] Run `canasta list` with no installations — verify it shows the conf.json path checked
- [x] Run `canasta upgrade --dry-run` with no installations — verify it shows the conf.json path checked
- [x] Run `canasta upgrade --dry-run` normally — verify existing behavior is unchanged