### PR TITLE
Standardize terminology: installation → instance

### DIFF
--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -53,7 +53,7 @@ import (
 // Client → Caddy (SSL/domain routing) → Varnish (caching, if enabled) → Apache → MediaWiki (wiki routing based on URL)
 
 func NewCmd() *cobra.Command {
-	var instance config.Installation
+	var instance config.Instance
 	var wikiID string
 	var domainName string
 	var wikiPath string
@@ -74,7 +74,7 @@ func NewCmd() *cobra.Command {
 	addCmd := &cobra.Command{
 		Use:   "add",
 		Short: "Add a new wiki to a Canasta instance",
-		Long: `Add a new wiki to an existing Canasta installation, creating a wiki farm.
+		Long: `Add a new wiki to an existing Canasta instance, creating a wiki farm.
 The new wiki is registered in wikis.yaml, the Caddyfile is regenerated,
 and the MediaWiki installer runs for the new wiki. You can also import
 an existing database dump instead of running the installer.`,
@@ -172,7 +172,7 @@ an existing database dump instead of running the installer.`,
 
 // AddWikiOptions contains the parameters needed to add a wiki to a Canasta instance.
 type AddWikiOptions struct {
-	Instance         config.Installation
+	Instance         config.Instance
 	WikiID           string
 	SiteName         string
 	Domain           string
@@ -217,7 +217,7 @@ func AddWiki(opts AddWikiOptions) error {
 		return err
 	}
 	if urlExists {
-		return fmt.Errorf("a wiki with the same installation path '%s' in the Canasta instance '%s' exists", opts.WikiID+": "+opts.Domain+"/"+opts.WikiPath, opts.Instance.ID)
+		return fmt.Errorf("a wiki with the same URL '%s' in the Canasta instance '%s' exists", opts.WikiID+": "+opts.Domain+"/"+opts.WikiPath, opts.Instance.ID)
 	}
 
 	// Import the database if databasePath is specified

--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -15,7 +15,7 @@ import (
 
 func NewCmd() *cobra.Command {
 	var (
-		instance config.Installation
+		instance config.Instance
 		orch     orchestrators.Orchestrator
 		envPath  string
 		repoURL  string
@@ -29,11 +29,11 @@ func NewCmd() *cobra.Command {
 
 	backupCmd := &cobra.Command{
 		Use:   "backup",
-		Short: "Backup and restore Canasta installations",
-		Long: `Manage backups of a Canasta installation. Subcommands allow you to initialize
+		Short: "Backup and restore Canasta instances",
+		Long: `Manage backups of a Canasta instance. Subcommands allow you to initialize
 a backup repository, create and restore backups, list and compare backups,
 and schedule recurring backups. Requires RESTIC_REPOSITORY (or AWS S3 settings)
-and RESTIC_PASSWORD to be configured in the installation's .env file.`,
+and RESTIC_PASSWORD to be configured in the instance's .env file.`,
 		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
 			var err error
 			instance, err = canasta.CheckCanastaID(instance)

--- a/cmd/backup/check.go
+++ b/cmd/backup/check.go
@@ -9,7 +9,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-func newCheckCmd(orch *orchestrators.Orchestrator, instance *config.Installation, envPath, repoURL *string) *cobra.Command {
+func newCheckCmd(orch *orchestrators.Orchestrator, instance *config.Instance, envPath, repoURL *string) *cobra.Command {
 
 	checkCmd := &cobra.Command{
 		Use:   "check",

--- a/cmd/backup/create.go
+++ b/cmd/backup/create.go
@@ -14,13 +14,13 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-func newCreateCmd(orch *orchestrators.Orchestrator, instance *config.Installation, envPath, repoURL *string) *cobra.Command {
+func newCreateCmd(orch *orchestrators.Orchestrator, instance *config.Instance, envPath, repoURL *string) *cobra.Command {
 	var tag string
 
 	createBackupCmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a backup",
-		Long: `Create a new backup snapshot of the Canasta installation. This dumps each
+		Long: `Create a new backup snapshot of the Canasta instance. This dumps each
 wiki's database (read from wikis.yaml), stages configuration files,
 extensions, images, skins, and public_assets into a Docker volume, along
 with .env, docker-compose.override.yml, and my.cnf (if present), then
@@ -42,7 +42,7 @@ uploads the snapshot to the backup repository with the specified tag.`,
 	return createBackupCmd
 }
 
-func takeSnapshot(orch orchestrators.Orchestrator, instance config.Installation, envPath, repoURL, tag string) error {
+func takeSnapshot(orch orchestrators.Orchestrator, instance config.Instance, envPath, repoURL, tag string) error {
 	fmt.Printf("Taking snapshot '%s'...\n", tag)
 	envVariables, err := canasta.GetEnvVariable(envPath)
 	if err != nil {

--- a/cmd/backup/delete.go
+++ b/cmd/backup/delete.go
@@ -9,7 +9,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-func newDeleteCmd(orch *orchestrators.Orchestrator, instance *config.Installation, envPath, repoURL *string) *cobra.Command {
+func newDeleteCmd(orch *orchestrators.Orchestrator, instance *config.Instance, envPath, repoURL *string) *cobra.Command {
 	var snapshot string
 
 	deleteCmd := &cobra.Command{

--- a/cmd/backup/diff.go
+++ b/cmd/backup/diff.go
@@ -9,7 +9,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-func newDiffCmd(orch *orchestrators.Orchestrator, instance *config.Installation, envPath, repoURL *string) *cobra.Command {
+func newDiffCmd(orch *orchestrators.Orchestrator, instance *config.Instance, envPath, repoURL *string) *cobra.Command {
 	var snapshot1, snapshot2 string
 
 	diffCmd := &cobra.Command{

--- a/cmd/backup/files.go
+++ b/cmd/backup/files.go
@@ -9,7 +9,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-func newFilesCmd(orch *orchestrators.Orchestrator, instance *config.Installation, envPath, repoURL *string) *cobra.Command {
+func newFilesCmd(orch *orchestrators.Orchestrator, instance *config.Instance, envPath, repoURL *string) *cobra.Command {
 	var snapshot string
 
 	filesCmd := &cobra.Command{

--- a/cmd/backup/init.go
+++ b/cmd/backup/init.go
@@ -9,14 +9,14 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-func newInitCmd(orch *orchestrators.Orchestrator, instance *config.Installation, envPath, repoURL *string) *cobra.Command {
+func newInitCmd(orch *orchestrators.Orchestrator, instance *config.Instance, envPath, repoURL *string) *cobra.Command {
 
 	initCmd := &cobra.Command{
 		Use:   "init",
 		Short: "Initialize a backup repository",
 		Long: `Initialize a new backup repository. This must be run once before
 creating any backups. The repository location is read from the
-RESTIC_REPOSITORY variable (or AWS S3 settings) in the installation's .env file.`,
+RESTIC_REPOSITORY variable (or AWS S3 settings) in the instance's .env file.`,
 		Example: `  canasta backup init -i myinstance`,
 		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {

--- a/cmd/backup/list.go
+++ b/cmd/backup/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-func newListCmd(orch *orchestrators.Orchestrator, instance *config.Installation, envPath, repoURL *string) *cobra.Command {
+func newListCmd(orch *orchestrators.Orchestrator, instance *config.Instance, envPath, repoURL *string) *cobra.Command {
 
 	listCmd := &cobra.Command{
 		Use:   "list",

--- a/cmd/backup/purge.go
+++ b/cmd/backup/purge.go
@@ -9,7 +9,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-func newPurgeCmd(orch *orchestrators.Orchestrator, instance *config.Installation, envPath, repoURL *string) *cobra.Command {
+func newPurgeCmd(orch *orchestrators.Orchestrator, instance *config.Instance, envPath, repoURL *string) *cobra.Command {
 	var (
 		olderThan string
 		keepLast  int

--- a/cmd/backup/restore.go
+++ b/cmd/backup/restore.go
@@ -14,7 +14,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-func newRestoreCmd(orch *orchestrators.Orchestrator, instance *config.Installation, envPath, repoURL *string) *cobra.Command {
+func newRestoreCmd(orch *orchestrators.Orchestrator, instance *config.Instance, envPath, repoURL *string) *cobra.Command {
 
 	var (
 		snapshotID         string
@@ -25,7 +25,7 @@ func newRestoreCmd(orch *orchestrators.Orchestrator, instance *config.Installati
 	restoreCmd := &cobra.Command{
 		Use:   "restore",
 		Short: "Restore a backup",
-		Long: `Restore a Canasta installation from a backup snapshot. By default, a safety
+		Long: `Restore a Canasta instance from a backup snapshot. By default, a safety
 snapshot is taken before restoring. The restore replaces configuration files,
 extensions, images, skins, public_assets, .env, docker-compose.override.yml,
 my.cnf, and all wiki databases with the contents of the specified snapshot.
@@ -53,7 +53,7 @@ images, and public assets from the backup, leaving shared files untouched.`,
 	return restoreCmd
 }
 
-func restoreSnapshot(orch orchestrators.Orchestrator, instance config.Installation, envPath, repoURL, snapshotID string, skipBeforeSnapshot bool, wikiID string) error {
+func restoreSnapshot(orch orchestrators.Orchestrator, instance config.Instance, envPath, repoURL, snapshotID string, skipBeforeSnapshot bool, wikiID string) error {
 	envVariables, envErr := canasta.GetEnvVariable(envPath)
 	if envErr != nil {
 		return envErr
@@ -81,8 +81,8 @@ func restoreSnapshot(orch orchestrators.Orchestrator, instance config.Installati
 
 // restoreWiki restores a single wiki's database, per-wiki settings, images,
 // and public assets from a backup, leaving shared files untouched.
-func restoreWiki(orch orchestrators.Orchestrator, instance config.Installation, wikiID string, env map[string]string) error {
-	// Validate that the wiki ID exists in the current installation's wikis.yaml
+func restoreWiki(orch orchestrators.Orchestrator, instance config.Instance, wikiID string, env map[string]string) error {
+	// Validate that the wiki ID exists in the current instance's wikis.yaml
 	wikiIDs, err := farmsettings.GetWikiIDs(instance.Path)
 	if err != nil {
 		return err
@@ -95,7 +95,7 @@ func restoreWiki(orch orchestrators.Orchestrator, instance config.Installation, 
 		}
 	}
 	if !found {
-		return fmt.Errorf("wiki '%s' not found in current installation's wikis.yaml", wikiID)
+		return fmt.Errorf("wiki '%s' not found in current instance's wikis.yaml", wikiID)
 	}
 
 	// Copy per-wiki files from the backup volume:
@@ -140,7 +140,7 @@ func restoreWiki(orch orchestrators.Orchestrator, instance config.Installation, 
 }
 
 // restoreFull performs a full restore of all files and databases from a backup.
-func restoreFull(orch orchestrators.Orchestrator, instance config.Installation, env map[string]string) error {
+func restoreFull(orch orchestrators.Orchestrator, instance config.Instance, env map[string]string) error {
 	logging.Print("Copying files from backup volume...")
 	paths := make(map[string]string)
 	for _, dir := range []string{"config", "extensions", "images", "skins", "public_assets"} {

--- a/cmd/backup/schedule.go
+++ b/cmd/backup/schedule.go
@@ -14,12 +14,12 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-func newScheduleCmd(instance *config.Installation) *cobra.Command {
+func newScheduleCmd(instance *config.Instance) *cobra.Command {
 	scheduleCmd := &cobra.Command{
 		Use:   "schedule",
 		Short: "Manage scheduled backups",
 		Long: `Manage recurring backup schedules using crontab. Backup output is
-logged to backup.log in the installation directory.`,
+logged to backup.log in the instance directory.`,
 	}
 
 	scheduleCmd.AddCommand(newScheduleSetCmd(instance))
@@ -28,7 +28,7 @@ logged to backup.log in the installation directory.`,
 	return scheduleCmd
 }
 
-func newScheduleSetCmd(instance *config.Installation) *cobra.Command {
+func newScheduleSetCmd(instance *config.Instance) *cobra.Command {
 	var purgeOlderThan string
 
 	cmd := &cobra.Command{
@@ -37,7 +37,7 @@ func newScheduleSetCmd(instance *config.Installation) *cobra.Command {
 		Long: `Schedule recurring backups using a cron expression. This adds or
 updates a crontab entry that runs 'canasta backup create' on the
 specified schedule. Backup output is logged to backup.log in the
-installation directory.
+instance directory.
 
 Use --purge-older-than to automatically purge old backups after each
 scheduled backup.`,
@@ -59,11 +59,11 @@ scheduled backup.`,
 	return cmd
 }
 
-func newScheduleListCmd(instance *config.Installation) *cobra.Command {
+func newScheduleListCmd(instance *config.Instance) *cobra.Command {
 	return &cobra.Command{
 		Use:     "list",
 		Short:   "Show the backup schedule",
-		Long:    `Show the current backup schedule for this installation, if one exists.`,
+		Long:    `Show the current backup schedule for this instance, if one exists.`,
 		Example: `  canasta backup schedule list -i myinstance`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return listSchedule(*instance)
@@ -71,11 +71,11 @@ func newScheduleListCmd(instance *config.Installation) *cobra.Command {
 	}
 }
 
-func newScheduleRemoveCmd(instance *config.Installation) *cobra.Command {
+func newScheduleRemoveCmd(instance *config.Instance) *cobra.Command {
 	return &cobra.Command{
 		Use:     "remove",
 		Short:   "Remove a scheduled backup",
-		Long:    `Remove the crontab entry for recurring backups of this installation.`,
+		Long:    `Remove the crontab entry for recurring backups of this instance.`,
 		Example: `  canasta backup schedule remove -i myinstance`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return unscheduleBackup(*instance)
@@ -120,7 +120,7 @@ func writeCrontab(lines []string) error {
 	return nil
 }
 
-func scheduleBackup(instance config.Installation, cronExpression, purgeOlderThan string) error {
+func scheduleBackup(instance config.Instance, cronExpression, purgeOlderThan string) error {
 	if err := validateCron(cronExpression); err != nil {
 		return err
 	}
@@ -174,7 +174,7 @@ func scheduleBackup(instance config.Installation, cronExpression, purgeOlderThan
 	return nil
 }
 
-func listSchedule(instance config.Installation) error {
+func listSchedule(instance config.Instance) error {
 	lines, err := readCrontab()
 	if err != nil {
 		return err
@@ -194,7 +194,7 @@ func listSchedule(instance config.Installation) error {
 	return fmt.Errorf("no backup schedule found for instance '%s'", instance.ID)
 }
 
-func unscheduleBackup(instance config.Installation) error {
+func unscheduleBackup(instance config.Instance) error {
 	removed, err := RemoveSchedule(instance.ID)
 	if err != nil {
 		return err

--- a/cmd/backup/unlock.go
+++ b/cmd/backup/unlock.go
@@ -9,7 +9,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-func newUnlockCmd(orch *orchestrators.Orchestrator, instance *config.Installation, envPath, repoURL *string) *cobra.Command {
+func newUnlockCmd(orch *orchestrators.Orchestrator, instance *config.Instance, envPath, repoURL *string) *cobra.Command {
 
 	unlockCmd := &cobra.Command{
 		Use:   "unlock",

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -13,7 +13,7 @@ import (
 
 func NewCmd() *cobra.Command {
 	var (
-		instance config.Installation
+		instance config.Instance
 		orch     orchestrators.Orchestrator
 	)
 
@@ -26,17 +26,17 @@ func NewCmd() *cobra.Command {
 	configCmd := &cobra.Command{
 		Use:   "config",
 		Short: "View and modify Canasta configuration",
-		Long: `View and modify the .env configuration for a Canasta installation.
+		Long: `View and modify the .env configuration for a Canasta instance.
 
 Use "canasta config get" to view current settings and "canasta config set"
 to change them. The set command handles side effects automatically (e.g.,
 updating wikis.yaml when changing HTTPS_PORT) and restarts the instance.
-Editing .env by hand may leave the installation in an inconsistent state.
+Editing .env by hand may leave the instance in an inconsistent state.
 
 Key names are case-insensitive and hyphens are treated as underscores,
 so "https-port", "HTTPS_PORT", and "Https_Port" all work.
 
-Settings safe to change on a running installation:
+Settings safe to change on a running instance:
 
   Network
     HTTP_PORT                       HTTP port (default: 80)

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -131,7 +131,7 @@ func TestUpdateSiteServerPort(t *testing.T) {
 }
 
 func TestValidatePort(t *testing.T) {
-	inst := config.Installation{}
+	inst := config.Instance{}
 
 	tests := []struct {
 		name    string
@@ -184,7 +184,7 @@ func TestUpdateWikisYamlPorts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	inst := config.Installation{Path: tmpDir}
+	inst := config.Instance{Path: tmpDir}
 
 	// Change to standard port
 	err := applyHTTPSPortChange(inst, "443")

--- a/cmd/config/get.go
+++ b/cmd/config/get.go
@@ -11,12 +11,12 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
 )
 
-func newGetCmd(instance *config.Installation) *cobra.Command {
+func newGetCmd(instance *config.Instance) *cobra.Command {
 	var force bool
 	cmd := &cobra.Command{
 		Use:   "get [KEY]",
 		Short: "Show configuration settings",
-		Long: `Show configuration settings from the .env file of a Canasta installation.
+		Long: `Show configuration settings from the .env file of a Canasta instance.
 
 With no arguments, prints all settings sorted alphabetically as KEY=VALUE lines.
 With a KEY argument, prints just the value (no KEY= prefix) for easy scripting.

--- a/cmd/config/helpers.go
+++ b/cmd/config/helpers.go
@@ -37,7 +37,7 @@ func isKnownKey(key string) bool {
 
 // restartInstance performs the UpdateConfig → Stop → optional kind cluster
 // recreation → Start sequence shared by config set and config unset.
-func restartInstance(orch *orchestrators.Orchestrator, instance config.Installation, portKeyChanged bool) error {
+func restartInstance(orch *orchestrators.Orchestrator, instance config.Instance, portKeyChanged bool) error {
 	fmt.Println("Applying configuration and restarting...")
 	if err := (*orch).UpdateConfig(instance.Path); err != nil {
 		return fmt.Errorf("failed to update config: %w", err)

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -20,16 +20,16 @@ import (
 )
 
 type sideEffect struct {
-	validate func(instance config.Installation, value string) error
-	apply    func(instance config.Installation, value string) error
-	unapply  func(instance config.Installation) error
+	validate func(instance config.Instance, value string) error
+	apply    func(instance config.Instance, value string) error
+	unapply  func(instance config.Instance) error
 }
 
 var sideEffects = map[string]sideEffect{
 	"HTTPS_PORT": {
 		validate: validatePort,
 		apply:    applyHTTPSPortChange,
-		unapply: func(inst config.Installation) error {
+		unapply: func(inst config.Instance) error {
 			return applyHTTPSPortChange(inst, "443")
 		},
 	},
@@ -88,13 +88,13 @@ type setting struct {
 	value string
 }
 
-func newSetCmd(instance *config.Installation, orch *orchestrators.Orchestrator) *cobra.Command {
+func newSetCmd(instance *config.Instance, orch *orchestrators.Orchestrator) *cobra.Command {
 	var force bool
 	var noRestart bool
 	cmd := &cobra.Command{
 		Use:   "set KEY=VALUE [KEY=VALUE ...]",
 		Short: "Change a configuration setting",
-		Long: `Set one or more configuration values in the .env file of a Canasta installation.
+		Long: `Set one or more configuration values in the .env file of a Canasta instance.
 
 Each argument must be in KEY=VALUE format. Multiple settings can be changed
 in a single invocation and only one restart is performed.
@@ -182,7 +182,7 @@ Use --no-restart to skip the restart (useful for batching multiple changes).`,
 }
 
 // validatePort checks that the value is a valid port number.
-func validatePort(_ config.Installation, value string) error {
+func validatePort(_ config.Instance, value string) error {
 	port, err := strconv.Atoi(value)
 	if err != nil || port < 1 || port > 65535 {
 		return fmt.Errorf("invalid port number: %s", value)
@@ -192,7 +192,7 @@ func validatePort(_ config.Installation, value string) error {
 
 // applyHTTPSPortChange updates wikis.yaml URLs and MW_SITE_SERVER/MW_SITE_FQDN
 // in .env to reflect the new HTTPS port.
-func applyHTTPSPortChange(inst config.Installation, newPort string) error {
+func applyHTTPSPortChange(inst config.Instance, newPort string) error {
 	wikisPath := filepath.Join(inst.Path, "config", "wikis.yaml")
 	envPath := filepath.Join(inst.Path, ".env")
 
@@ -288,7 +288,7 @@ func updateSiteServerPort(siteServer, newPort string) string {
 
 // recreateKindCluster deletes and recreates the kind cluster with the current
 // port settings from .env so the new host-port mappings take effect.
-func recreateKindCluster(inst config.Installation) error {
+func recreateKindCluster(inst config.Instance) error {
 	httpPort, httpsPort := orchestrators.GetPortsFromEnv(inst.Path)
 	logging.Print(fmt.Sprintf("Recreating kind cluster %s with ports %d/%d...\n", inst.KindCluster, httpPort, httpsPort))
 
@@ -302,7 +302,7 @@ func recreateKindCluster(inst config.Installation) error {
 }
 
 // applyObservabilityChange generates observability credentials when enabling.
-func applyObservabilityChange(inst config.Installation, value string) error {
+func applyObservabilityChange(inst config.Instance, value string) error {
 	if !strings.EqualFold(value, "true") {
 		return nil
 	}

--- a/cmd/config/unset.go
+++ b/cmd/config/unset.go
@@ -12,13 +12,13 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-func newUnsetCmd(instance *config.Installation, orch *orchestrators.Orchestrator) *cobra.Command {
+func newUnsetCmd(instance *config.Instance, orch *orchestrators.Orchestrator) *cobra.Command {
 	var force bool
 	var noRestart bool
 	cmd := &cobra.Command{
 		Use:   "unset KEY [KEY ...]",
 		Short: "Remove a configuration setting",
-		Long: `Remove one or more configuration keys from the .env file of a Canasta installation.
+		Long: `Remove one or more configuration keys from the .env file of a Canasta instance.
 
 Each argument is a key name to remove. Multiple keys can be removed in a single
 invocation and only one restart is performed.

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -44,12 +44,12 @@ func NewCmd() *cobra.Command {
 	)
 	createCmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a Canasta installation",
-		Long: `Create a new Canasta MediaWiki installation. This generates configuration
+		Short: "Create a Canasta instance",
+		Long: `Create a new Canasta MediaWiki instance. This generates configuration
 files, starts the containers, and runs the MediaWiki installer. You can
 optionally import an existing database dump instead of running the installer.
 After creating, use 'canasta devmode enable' to enable development mode.`,
-		Example: `  # Create a basic single-wiki installation
+		Example: `  # Create a basic single-wiki instance
   canasta create -i myinstance -w main -n example.com
 
   # Create with an existing database dump
@@ -66,7 +66,7 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
 
 			// Check for duplicate ID before doing any work
 			if _, err := config.GetDetails(canastaInfo.ID); err == nil {
-				return fmt.Errorf("canasta installation with ID '%s' already exists", canastaInfo.ID)
+				return fmt.Errorf("canasta instance with ID '%s' already exists", canastaInfo.ID)
 			}
 
 			// Resolve all relative file paths to absolute (relative to working directory)
@@ -95,7 +95,7 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
 				domain = BuildDomainWithPort(domain, envVars)
 			}
 
-			stopSpinner := spinner.New("Creating Canasta installation '" + canastaInfo.ID + "'...")
+			stopSpinner := spinner.New("Creating Canasta instance '" + canastaInfo.ID + "'...")
 
 			orch, err := orchestrators.New(orchestrator)
 			if err != nil {
@@ -135,9 +135,9 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
 				fmt.Print(err.Error(), "\n")
 				if !keepConfig {
 					deleteConfigAndContainers(filepath.Join(path, canastaInfo.ID), orch)
-					return fmt.Errorf("installation failed and files were cleaned up")
+					return fmt.Errorf("create failed and files were cleaned up")
 				}
-				return fmt.Errorf("installation failed. Keeping all the containers and config files")
+				return fmt.Errorf("create failed. Keeping all the containers and config files")
 			}
 			stopSpinner()
 			fmt.Println("\033[32mPlease note that mailing does not currently work on this wiki, because Canasta requires $wgSMTP to be set in order to send emails (see https://www.mediawiki.org/wiki/Manual:$wgSMTP).\033[0m")
@@ -159,7 +159,7 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
 	createCmd.Flags().StringVarP(&canastaInfo.AdminName, "admin", "a", "WikiSysop", "Initial wiki admin username (default: \"WikiSysop\")")
 	createCmd.Flags().StringVarP(&canastaInfo.AdminPassword, "password", "s", "", "Initial wiki admin password (if not provided, auto-generates and saves to config/admin-password_{wikiid})")
 	createCmd.Flags().StringVarP(&yamlPath, "yamlfile", "f", "", "Initial wiki yaml file")
-	createCmd.Flags().BoolVarP(&keepConfig, "keep-config", "k", false, "Keep the config files on installation failure")
+	createCmd.Flags().BoolVarP(&keepConfig, "keep-config", "k", false, "Keep the config files on failure")
 	createCmd.Flags().StringVarP(&override, "override", "r", "", "Name of a file to copy to docker-compose.override.yml (Compose only)")
 	createCmd.Flags().StringVar(&canastaInfo.RootDBPassword, "rootdbpass", "", "Root database password (if not provided, auto-generates and saves to .env). Tip: Use --rootdbpass \"$ROOT_DB_PASS\" to avoid exposing password in shell history")
 	createCmd.Flags().StringVar(&canastaInfo.WikiDBUsername, "wikidbuser", "root", "The username of the wiki database user (default: \"root\")")
@@ -172,7 +172,7 @@ After creating, use 'canasta devmode enable' to enable development mode.`,
 	createCmd.Flags().StringVarP(&globalSettingsPath, "global-settings", "g", "", "Path to global settings file to copy to config/settings/global/ (filename preserved)")
 	createCmd.Flags().StringVar(&composerFile, "composer", "", "Path to custom composer.local.json to copy to config/")
 	createCmd.Flags().StringVar(&registry, "registry", "localhost:5000", "Container registry for pushing locally built images (used with --build-from on Kubernetes)")
-	createCmd.Flags().BoolVar(&createCluster, "create-cluster", false, "Create and manage a local Kubernetes cluster for this installation (Kubernetes only)")
+	createCmd.Flags().BoolVar(&createCluster, "create-cluster", false, "Create and manage a local Kubernetes cluster for this instance (Kubernetes only)")
 
 	// Mark required flags
 	_ = createCmd.MarkFlagRequired("id")
@@ -201,7 +201,7 @@ type createOptions struct {
 	GlobalSettingsPath string
 }
 
-// createCanasta accepts all the keyword arguments and creates an installation of the latest Canasta.
+// createCanasta accepts all the keyword arguments and creates an instance of the latest Canasta.
 func createCanasta(opts createOptions) error {
 	// Determine the base image to use
 	var baseImage string
@@ -224,16 +224,16 @@ func createCanasta(opts createOptions) error {
 		baseImage = canasta.GetDefaultImage()
 	}
 
-	// Create the installation directory and write orchestrator stack files
+	// Create the instance directory and write orchestrator stack files
 	path := filepath.Join(opts.Path, opts.CanastaInfo.ID)
 	if err := os.MkdirAll(path, permissions.DirectoryPermission); err != nil {
-		return fmt.Errorf("failed to create installation directory: %w", err)
+		return fmt.Errorf("failed to create instance directory: %w", err)
 	}
 	if err := opts.Orch.WriteStackFiles(path); err != nil {
 		return fmt.Errorf("failed to write stack files: %w", err)
 	}
 
-	// Copy shared installation template files (config, settings, etc.)
+	// Copy shared instance template files (config, settings, etc.)
 	if err := canasta.CopyInstallationTemplate(path); err != nil {
 		return err
 	}
@@ -246,7 +246,7 @@ func createCanasta(opts createOptions) error {
 			return err
 		}
 	} else {
-		// Generate wikis.yaml directly in the installation directory
+		// Generate wikis.yaml directly in the instance directory
 		yamlPath = filepath.Join(path, "config", "wikis.yaml")
 		if _, err := farmsettings.GenerateWikisYaml(yamlPath, opts.WikiID, opts.Domain, opts.SiteName); err != nil {
 			return err
@@ -255,8 +255,8 @@ func createCanasta(opts createOptions) error {
 	if err := canasta.UpdateEnvFile(opts.EnvFile, path, opts.CanastaInfo.RootDBPassword, opts.CanastaInfo.WikiDBPassword); err != nil {
 		return err
 	}
-	// Always set CANASTA_IMAGE in .env so the installation is pinned to a
-	// specific image. For default installs this is the CLI's pinned version;
+	// Always set CANASTA_IMAGE in .env so the instance is pinned to a
+	// specific image. For default creates this is the CLI's pinned version;
 	// for --canasta-image or --build-from it's the user-specified image.
 	if err := canasta.SaveEnvVariable(filepath.Join(path, ".env"), "CANASTA_IMAGE", baseImage); err != nil {
 		return err
@@ -329,9 +329,9 @@ func createCanasta(opts createOptions) error {
 		}
 	}
 
-	// Start without dev mode for installation
+	// Start without dev mode for initial setup
 	// (xdebug can cause hangs if a debugger is listening during install.php)
-	tempInstance := config.Installation{Path: path, Orchestrator: opts.Orchestrator, DevMode: false, KindCluster: kindClusterName}
+	tempInstance := config.Instance{Path: path, Orchestrator: opts.Orchestrator, DevMode: false, KindCluster: kindClusterName}
 	if err := opts.Orch.Start(tempInstance); err != nil {
 		return err
 	}
@@ -368,7 +368,7 @@ func createCanasta(opts createOptions) error {
 	if isK8s {
 		reg = opts.Registry
 	}
-	instance := config.Installation{ID: opts.CanastaInfo.ID, Path: path, Orchestrator: opts.Orchestrator, DevMode: false, ManagedCluster: opts.CreateCluster, Registry: reg, KindCluster: kindClusterName, BuildFrom: opts.BuildFromPath}
+	instance := config.Instance{ID: opts.CanastaInfo.ID, Path: path, Orchestrator: opts.Orchestrator, DevMode: false, ManagedCluster: opts.CreateCluster, Registry: reg, KindCluster: kindClusterName, BuildFrom: opts.BuildFromPath}
 	if err := config.Add(instance); err != nil {
 		return err
 	}
@@ -387,22 +387,22 @@ func createCanasta(opts createOptions) error {
 	return nil
 }
 
-func deleteConfigAndContainers(installationDir string, orch orchestrators.Orchestrator) {
+func deleteConfigAndContainers(instanceDir string, orch orchestrators.Orchestrator) {
 	fmt.Println("Removing containers")
-	if _, err := orch.Destroy(installationDir); err != nil {
+	if _, err := orch.Destroy(instanceDir); err != nil {
 		fmt.Printf("Warning: failed to remove containers: %v\n", err)
 	}
 	// Clean up any kind cluster created during this attempt.
 	// KindClusterName derives the name from the directory basename (the ID).
 	// DeleteKindCluster is a no-op if the cluster doesn't exist.
 	if _, ok := orch.(*orchestrators.KubernetesOrchestrator); ok {
-		clusterName := orchestrators.KindClusterName(filepath.Base(installationDir))
+		clusterName := orchestrators.KindClusterName(filepath.Base(instanceDir))
 		if err := orchestrators.DeleteKindCluster(clusterName); err != nil {
 			fmt.Printf("Warning: failed to delete kind cluster: %v\n", err)
 		}
 	}
 	fmt.Println("Deleting config files")
-	if _, err := orchestrators.DeleteConfig(installationDir); err != nil {
+	if _, err := orchestrators.DeleteConfig(instanceDir); err != nil {
 		fmt.Printf("Warning: failed to delete config files: %v\n", err)
 	}
 	fmt.Println("Deleted all containers and config files")

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -15,7 +15,7 @@ import (
 )
 
 func NewCmd() *cobra.Command {
-	var instance config.Installation
+	var instance config.Instance
 	workingDir, err := os.Getwd()
 	if err != nil {
 		logging.Fatal(err)
@@ -26,12 +26,12 @@ func NewCmd() *cobra.Command {
 
 	var deleteCmd = &cobra.Command{
 		Use:   "delete",
-		Short: "Delete a Canasta installation",
-		Long: `Permanently delete a Canasta installation. This stops and removes all
+		Short: "Delete a Canasta instance",
+		Long: `Permanently delete a Canasta instance. This stops and removes all
 Docker containers and volumes, deletes all configuration files and data,
-and removes the installation from the Canasta registry. You will be
+and removes the instance from the Canasta registry. You will be
 prompted for confirmation before any data is deleted.`,
-		Example: `  # Delete an installation by ID
+		Example: `  # Delete an instance by ID
   canasta delete -i myinstance
 
   # Delete without confirmation prompt
@@ -44,7 +44,7 @@ prompted for confirmation before any data is deleted.`,
 				return err
 			}
 			if !yes {
-				if !canasta.ConfirmAction(fmt.Sprintf("This will permanently delete the Canasta installation '%s' and all its data. Continue? [y/N] ", instance.ID)) {
+				if !canasta.ConfirmAction(fmt.Sprintf("This will permanently delete the Canasta instance '%s' and all its data. Continue? [y/N] ", instance.ID)) {
 					fmt.Println("Operation cancelled.")
 					return nil
 				}
@@ -60,8 +60,8 @@ prompted for confirmation before any data is deleted.`,
 	return deleteCmd
 }
 
-func Delete(instance config.Installation) error {
-	description := "Deleting Canasta installation '" + instance.ID + "'..."
+func Delete(instance config.Instance) error {
+	description := "Deleting Canasta instance '" + instance.ID + "'..."
 	stopSpinner := spinner.New(description)
 	defer stopSpinner() // ensure cleanup on error paths
 
@@ -105,7 +105,7 @@ func Delete(instance config.Installation) error {
 		logging.Print("Removed backup schedule.\n")
 	}
 
-	// Deleting installation details from conf.json
+	// Deleting instance details from conf.json
 	if err = config.Delete(instance.ID); err != nil {
 		return err
 	}

--- a/cmd/devmode/devmode.go
+++ b/cmd/devmode/devmode.go
@@ -14,7 +14,7 @@ import (
 
 func NewCmd() *cobra.Command {
 	var (
-		instance config.Installation
+		instance config.Instance
 		orch     orchestrators.Orchestrator
 	)
 
@@ -27,7 +27,7 @@ func NewCmd() *cobra.Command {
 	devmodeCmd := &cobra.Command{
 		Use:   "devmode",
 		Short: "Manage development mode",
-		Long: `Enable or disable development mode on a Canasta installation. Development
+		Long: `Enable or disable development mode on a Canasta instance. Development
 mode extracts MediaWiki code for live editing and enables Xdebug for step
 debugging. This is only supported with Docker Compose.`,
 		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {

--- a/cmd/devmode/disable.go
+++ b/cmd/devmode/disable.go
@@ -11,15 +11,15 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-func newDisableCmd(instance *config.Installation, orch *orchestrators.Orchestrator) *cobra.Command {
+func newDisableCmd(instance *config.Instance, orch *orchestrators.Orchestrator) *cobra.Command {
 	return &cobra.Command{
 		Use:   "disable",
 		Short: "Disable development mode",
-		Long: `Disable development mode on a Canasta installation. This restores extensions
+		Long: `Disable development mode on a Canasta instance. This restores extensions
 and skins as real directories and restarts without Xdebug. The mediawiki-code/
 directory is preserved so you can re-enable dev mode later without
 re-extracting code.`,
-		Example: `  # Disable dev mode on an installation
+		Example: `  # Disable dev mode on an instance
   canasta devmode disable -i myinstance`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {

--- a/cmd/devmode/enable.go
+++ b/cmd/devmode/enable.go
@@ -12,14 +12,14 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-func newEnableCmd(instance *config.Installation, orch *orchestrators.Orchestrator) *cobra.Command {
+func newEnableCmd(instance *config.Instance, orch *orchestrators.Orchestrator) *cobra.Command {
 	return &cobra.Command{
 		Use:   "enable",
 		Short: "Enable development mode",
-		Long: `Enable development mode on an existing Canasta installation. This extracts
+		Long: `Enable development mode on an existing Canasta instance. This extracts
 MediaWiki code for live editing, builds an Xdebug-enabled image, and restarts
 the instance with dev mode compose files. Only supported with Docker Compose.`,
-		Example: `  # Enable dev mode on an installation
+		Example: `  # Enable dev mode on an instance
   canasta devmode enable -i myinstance`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
@@ -53,7 +53,7 @@ the instance with dev mode compose files. Only supported with Docker Compose.`,
 			}
 
 			fmt.Println("\033[32mDevelopment mode enabled. Edit files in mediawiki-code/ - changes appear immediately.\033[0m")
-			fmt.Println("\033[32mVSCode: Open the installation directory, install PHP Debug extension, and start 'Listen for Xdebug'.\033[0m")
+			fmt.Println("\033[32mVSCode: Open the instance directory, install PHP Debug extension, and start 'Listen for Xdebug'.\033[0m")
 			return nil
 		},
 	}

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -16,7 +16,7 @@ import (
 )
 
 func NewCmd() *cobra.Command {
-	var instance config.Installation
+	var instance config.Instance
 	var wikiID string
 	var outputPath string
 
@@ -91,7 +91,7 @@ Use a .gz extension on the output path to get a gzip-compressed dump.`,
 	return exportCmd
 }
 
-func exportDatabase(instance config.Installation, wikiID, outputPath string) error {
+func exportDatabase(instance config.Instance, wikiID, outputPath string) error {
 	orch, err := orchestrators.New(instance.Orchestrator)
 	if err != nil {
 		return err

--- a/cmd/gitops/add.go
+++ b/cmd/gitops/add.go
@@ -12,14 +12,14 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/gitops"
 )
 
-func newAddCmd(instance *config.Installation) *cobra.Command {
+func newAddCmd(instance *config.Instance) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add [files...]",
 		Short: "Stage files for the next gitops push",
 		Long: `Explicitly stage files to be included in the next gitops push.
 Only staged files will be committed when you run gitops push.
 File paths can be relative to the current directory or to the
-installation root.`,
+instance root.`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			return runAdd(instance.Path, args)
@@ -29,7 +29,7 @@ installation root.`,
 }
 
 // resolveToInstallPath converts a file path (which may be relative to the
-// user's current directory) into a path relative to the installation root.
+// user's current directory) into a path relative to the instance root.
 // When requireExists is true the file must exist on disk (used by add);
 // when false, deleted-but-tracked files are allowed (used by rm).
 func resolveToInstallPath(installPath, file string, requireExists bool) (string, error) {
@@ -66,13 +66,13 @@ func resolveToInstallPath(installPath, file string, requireExists bool) (string,
 		return "", fmt.Errorf("resolving install path: %w", err)
 	}
 
-	// Ensure the file is inside the installation directory.
+	// Ensure the file is inside the instance directory.
 	rel, err := filepath.Rel(absInstall, absFile)
 	if err != nil {
 		return "", fmt.Errorf("computing relative path: %w", err)
 	}
 	if strings.HasPrefix(rel, "..") {
-		return "", fmt.Errorf("%q is outside the installation directory %q", file, absInstall)
+		return "", fmt.Errorf("%q is outside the instance directory %q", file, absInstall)
 	}
 
 	return rel, nil

--- a/cmd/gitops/diff.go
+++ b/cmd/gitops/diff.go
@@ -10,7 +10,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/gitops"
 )
 
-func newDiffCmd(instance *config.Installation) *cobra.Command {
+func newDiffCmd(instance *config.Instance) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "diff",
 		Short: "Show local and remote changes since the branches diverged",

--- a/cmd/gitops/fix_submodules.go
+++ b/cmd/gitops/fix_submodules.go
@@ -6,7 +6,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/config"
 )
 
-func newFixSubmodulesCmd(instance *config.Installation) *cobra.Command {
+func newFixSubmodulesCmd(instance *config.Instance) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "fix-submodules",
 		Short: "Convert extensions and skins to proper git submodules",

--- a/cmd/gitops/gitops.go
+++ b/cmd/gitops/gitops.go
@@ -12,7 +12,7 @@ import (
 
 // NewCmd creates the "canasta gitops" parent command.
 func NewCmd() *cobra.Command {
-	var instance config.Installation
+	var instance config.Instance
 
 	workingDir, wdErr := os.Getwd()
 	if wdErr != nil {
@@ -23,7 +23,7 @@ func NewCmd() *cobra.Command {
 	gitopsCmd := &cobra.Command{
 		Use:   "gitops",
 		Short: "Git-based configuration management",
-		Long: `Manage Canasta installation configuration through a Git repository.
+		Long: `Manage Canasta instance configuration through a Git repository.
 Supports version-controlled configuration backup, encrypted secrets via
 git-crypt, and multi-server deployments with push/pull workflows.`,
 		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {

--- a/cmd/gitops/init.go
+++ b/cmd/gitops/init.go
@@ -26,7 +26,7 @@ func validateInitFlags(hostName string) error {
 	return nil
 }
 
-func newInitCmd(instance *config.Installation) *cobra.Command {
+func newInitCmd(instance *config.Instance) *cobra.Command {
 	var (
 		hostName     string
 		role         string
@@ -38,8 +38,8 @@ func newInitCmd(instance *config.Installation) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "init",
-		Short: "Bootstrap a new gitops repository from an existing installation",
-		Long: `Bootstrap git-based configuration management for a Canasta installation.
+		Short: "Bootstrap a new gitops repository from an existing instance",
+		Long: `Bootstrap git-based configuration management for a Canasta instance.
 
 Sets up git, git-crypt, env.template, hosts.yaml, converts extensions/skins
 to submodules, and pushes to the remote. The remote repository must be empty

--- a/cmd/gitops/join.go
+++ b/cmd/gitops/join.go
@@ -14,7 +14,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/permissions"
 )
 
-func newJoinCmd(instance *config.Installation) *cobra.Command {
+func newJoinCmd(instance *config.Instance) *cobra.Command {
 	var (
 		hostName string
 		role     string
@@ -25,13 +25,13 @@ func newJoinCmd(instance *config.Installation) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "join",
 		Short: "Join an existing gitops repository",
-		Long: `Join an existing gitops repository for a Canasta installation.
+		Long: `Join an existing gitops repository for a Canasta instance.
 
 Clones the repo, unlocks git-crypt with the provided key, adds this host
 to the host inventory, extracts host-specific values into vars.yaml, and
 pushes the new host entry back to the repo.
 
-The installation must already exist and have a working .env file. Use
+The instance must already exist and have a working .env file. Use
 "canasta gitops init" to bootstrap a new gitops repository instead.`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
@@ -69,7 +69,7 @@ func runInitJoin(installPath, hostName, role, repoURL, keyFile string) error {
 
 	fmt.Println("Joining existing gitops repository...")
 
-	// 1. Clone the repo to a temp dir, then merge into the installation.
+	// 1. Clone the repo to a temp dir, then merge into the instance.
 	tmpDir, err := os.MkdirTemp("", "canasta-gitops-*")
 	if err != nil {
 		return fmt.Errorf("creating temp directory: %w", err)
@@ -89,7 +89,7 @@ func runInitJoin(installPath, hostName, role, repoURL, keyFile string) error {
 	}
 
 	// 2. Load the hosts config from the cloned repo and validate
-	// the host name before modifying the installation directory.
+	// the host name before modifying the instance directory.
 	cfg, err := gitops.LoadHostsConfig(tmpDir)
 	if err != nil {
 		return err
@@ -98,12 +98,12 @@ func runInitJoin(installPath, hostName, role, repoURL, keyFile string) error {
 		return fmt.Errorf("host %q already exists in %s — choose a different name with --name", hostName, "hosts.yaml")
 	}
 
-	// Move .git directory into the installation.
+	// Move .git directory into the instance.
 	if err := moveGitDir(tmpDir, installPath); err != nil {
 		return err
 	}
 
-	// Checkout tracked files from the repo into the installation directory.
+	// Checkout tracked files from the repo into the instance directory.
 	// git-crypt is already unlocked (carried over from the temp clone), so
 	// the checked-out files will be decrypted.
 	if err := gitops.CheckoutHead(installPath); err != nil {

--- a/cmd/gitops/pull.go
+++ b/cmd/gitops/pull.go
@@ -14,7 +14,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/permissions"
 )
 
-func newPullCmd(instance *config.Installation) *cobra.Command {
+func newPullCmd(instance *config.Instance) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pull",
 		Short: "Pull latest configuration from the git repository",

--- a/cmd/gitops/push.go
+++ b/cmd/gitops/push.go
@@ -13,7 +13,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/gitops"
 )
 
-func newPushCmd(instance *config.Installation) *cobra.Command {
+func newPushCmd(instance *config.Instance) *cobra.Command {
 	var message string
 
 	cmd := &cobra.Command{

--- a/cmd/gitops/rm.go
+++ b/cmd/gitops/rm.go
@@ -9,13 +9,13 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/gitops"
 )
 
-func newRmCmd(instance *config.Installation) *cobra.Command {
+func newRmCmd(instance *config.Instance) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "rm [files...]",
 		Short: "Remove files from the gitops repository",
 		Long: `Remove tracked files from the gitops repository. The removal is staged
 for the next gitops push. File paths can be relative to the current
-directory or to the installation root.`,
+directory or to the instance root.`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			return runRm(instance.Path, args)

--- a/cmd/gitops/status.go
+++ b/cmd/gitops/status.go
@@ -9,10 +9,10 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/gitops"
 )
 
-func newStatusCmd(instance *config.Installation) *cobra.Command {
+func newStatusCmd(instance *config.Instance) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
-		Short: "Show gitops status for the installation",
+		Short: "Show gitops status for the instance",
 		Long:  `Show the current host, role, uncommitted changes, and ahead/behind status relative to the remote.`,
 		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {

--- a/cmd/import/import.go
+++ b/cmd/import/import.go
@@ -18,7 +18,7 @@ import (
 )
 
 func NewCmd() *cobra.Command {
-	var instance config.Installation
+	var instance config.Instance
 	var wikiID string
 	var databasePath string
 	var settingsPath string
@@ -103,7 +103,7 @@ To create a new wiki from a database dump, use the --database flag with
 	return importCmd
 }
 
-func importDatabase(orch orchestrators.Orchestrator, instance config.Installation, wikiID, databasePath, settingsPath string) error {
+func importDatabase(orch orchestrators.Orchestrator, instance config.Instance, wikiID, databasePath, settingsPath string) error {
 	// Read database password from .env
 	envVariables, err := canasta.GetEnvVariable(filepath.Join(instance.Path, ".env"))
 	if err != nil {

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -11,16 +11,16 @@ import (
 )
 
 func NewCmd() *cobra.Command {
-	var instance config.Installation
+	var instance config.Instance
 	var cleanup bool
 
 	var listCmd = &cobra.Command{
 		Use:   "list",
-		Short: "List all Canasta installations",
-		Long: `List all registered Canasta installations. Displays each installation's
+		Short: "List all Canasta instances",
+		Long: `List all registered Canasta instances. Displays each instance's
 ID, path, and orchestrator as recorded in the Canasta configuration file.
 
-Use --cleanup to remove stale entries whose installation directories no longer exist.`,
+Use --cleanup to remove stale entries whose instance directories no longer exist.`,
 		Example: `  canasta list
   canasta list --cleanup`,
 		Args: cobra.NoArgs,
@@ -28,23 +28,23 @@ Use --cleanup to remove stale entries whose installation directories no longer e
 			return List(instance, cleanup)
 		},
 	}
-	listCmd.Flags().BoolVar(&cleanup, "cleanup", false, "Remove stale entries whose installation directories no longer exist")
+	listCmd.Flags().BoolVar(&cleanup, "cleanup", false, "Remove stale entries whose instance directories no longer exist")
 	return listCmd
 }
 
-func List(_ config.Installation, cleanup bool) error {
+func List(_ config.Instance, cleanup bool) error {
 	if cleanup {
 		installations, err := config.GetAll()
 		if err != nil {
 			return err
 		}
-		for id, installation := range installations {
-			if _, err := os.Stat(installation.Path); os.IsNotExist(err) {
-				if installation.KindCluster != "" {
-					if err := orchestrators.DeleteKindCluster(installation.KindCluster); err != nil {
-						fmt.Printf("Warning: failed to delete kind cluster '%s': %s\n", installation.KindCluster, err)
+		for id, inst := range installations {
+			if _, err := os.Stat(inst.Path); os.IsNotExist(err) {
+				if inst.KindCluster != "" {
+					if err := orchestrators.DeleteKindCluster(inst.KindCluster); err != nil {
+						fmt.Printf("Warning: failed to delete kind cluster '%s': %s\n", inst.KindCluster, err)
 					} else {
-						fmt.Printf("Deleted kind cluster '%s'\n", installation.KindCluster)
+						fmt.Printf("Deleted kind cluster '%s'\n", inst.KindCluster)
 					}
 				}
 				if err := config.Delete(id); err != nil {

--- a/cmd/list/list_test.go
+++ b/cmd/list/list_test.go
@@ -33,21 +33,21 @@ func TestList(t *testing.T) {
 		t.Fatalf("Failed to add second mock wiki: %v", err)
 	}
 
-	installation := config.Installation{
+	instance := config.Instance{
 		ID:           "test-instance",
 		Path:         installPath,
 		Orchestrator: "compose",
 	}
-	err = config.Add(installation)
+	err = config.Add(instance)
 	if err != nil {
-		t.Fatalf("Failed to add installation to config: %v", err)
+		t.Fatalf("Failed to add instance to config: %v", err)
 	}
 
 	oldStdout := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	err = List(config.Installation{}, false)
+	err = List(config.Instance{}, false)
 
 	w.Close()
 
@@ -66,7 +66,7 @@ func TestList(t *testing.T) {
 	outputStr := out.String()
 
 	expectedValues := []string{
-		"Canasta ID", "Wiki ID", "Server Name", "Server Path", "Installation Path", "Orchestrator",
+		"Canasta ID", "Wiki ID", "Server Name", "Server Path", "Instance Path", "Orchestrator",
 		"test-instance",
 		"testwiki", "testwiki.local",
 		"devwiki", "devwiki.local",
@@ -88,22 +88,22 @@ func TestListCleanup(t *testing.T) {
 	config.ResetForTesting(tmpDir)
 	t.Cleanup(func() { config.ResetForTesting("") })
 
-	installPath := filepath.Join(tmpDir, "stale-installation")
+	installPath := filepath.Join(tmpDir, "stale-instance")
 
-	installation := config.Installation{
+	instance := config.Instance{
 		ID:           "stale-instance",
 		Path:         installPath,
 		Orchestrator: "compose",
 	}
-	if err := config.Add(installation); err != nil {
-		t.Fatalf("Failed to add installation to config: %v", err)
+	if err := config.Add(instance); err != nil {
+		t.Fatalf("Failed to add instance to config: %v", err)
 	}
 
 	oldStdout := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	err := List(config.Installation{}, true)
+	err := List(config.Instance{}, true)
 
 	w.Close()
 	os.Stdout = oldStdout
@@ -144,22 +144,22 @@ func TestListNotFound(t *testing.T) {
 	config.ResetForTesting(tmpDir)
 	t.Cleanup(func() { config.ResetForTesting("") })
 
-	installPath := filepath.Join(tmpDir, "missing-installation")
+	installPath := filepath.Join(tmpDir, "missing-instance")
 
-	installation := config.Installation{
+	instance := config.Instance{
 		ID:           "missing-instance",
 		Path:         installPath,
 		Orchestrator: "compose",
 	}
-	if err := config.Add(installation); err != nil {
-		t.Fatalf("Failed to add installation to config: %v", err)
+	if err := config.Add(instance); err != nil {
+		t.Fatalf("Failed to add instance to config: %v", err)
 	}
 
 	oldStdout := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	err := List(config.Installation{}, false)
+	err := List(config.Instance{}, false)
 
 	w.Close()
 	os.Stdout = oldStdout

--- a/cmd/maintenance/exec.go
+++ b/cmd/maintenance/exec.go
@@ -11,7 +11,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-func newExecCmd(instance *config.Installation) *cobra.Command {
+func newExecCmd(instance *config.Instance) *cobra.Command {
 	var service string
 
 	cmd := &cobra.Command{
@@ -19,7 +19,7 @@ func newExecCmd(instance *config.Installation) *cobra.Command {
 		DisableFlagsInUseLine: true,
 		Short:                 "Execute a command in a running container",
 		Long: `Execute a command or open an interactive shell in a running container
-of a Canasta installation.
+of a Canasta instance.
 
 With no arguments and no --service flag, lists the running services.
 With --service (or -s) and no command, opens an interactive bash shell.

--- a/cmd/maintenance/extension.go
+++ b/cmd/maintenance/extension.go
@@ -23,7 +23,7 @@ var errExtNotLoaded = errors.New("extension not loaded")
 // wikiArgRe matches --wiki=value or --wiki value in a script argument string.
 var wikiArgRe = regexp.MustCompile(`(?:^|\s)--wiki[=\s](\S+)`)
 
-func newExtensionCmd(instance *config.Installation) *cobra.Command {
+func newExtensionCmd(instance *config.Instance) *cobra.Command {
 	var wiki string
 
 	extensionCmd := &cobra.Command{
@@ -108,11 +108,11 @@ Use --wiki to target a specific wiki.`,
 	return extensionCmd
 }
 
-func listExtensionsWithMaintenance(inst config.Installation, wikiFlag string) error {
+func listExtensionsWithMaintenance(inst config.Instance, wikiFlag string) error {
 	return listExtensionsWithMaintenanceWith(nil, inst, wikiFlag)
 }
 
-func listExtensionsWithMaintenanceWith(orch orchestrators.Orchestrator, inst config.Installation, wikiFlag string) error {
+func listExtensionsWithMaintenanceWith(orch orchestrators.Orchestrator, inst config.Instance, wikiFlag string) error {
 	if orch == nil {
 		var err error
 		orch, err = orchestrators.New(inst.Orchestrator)
@@ -165,11 +165,11 @@ func listExtensionsWithMaintenanceWith(orch orchestrators.Orchestrator, inst con
 	return nil
 }
 
-func listExtensionScripts(inst config.Installation, extName, wikiFlag string) error {
+func listExtensionScripts(inst config.Instance, extName, wikiFlag string) error {
 	return listExtensionScriptsWith(nil, inst, extName, wikiFlag)
 }
 
-func listExtensionScriptsWith(orch orchestrators.Orchestrator, inst config.Installation, extName, wikiFlag string) error {
+func listExtensionScriptsWith(orch orchestrators.Orchestrator, inst config.Instance, extName, wikiFlag string) error {
 	if orch == nil {
 		var err error
 		orch, err = orchestrators.New(inst.Orchestrator)
@@ -232,11 +232,11 @@ func listExtensionScriptsWith(orch orchestrators.Orchestrator, inst config.Insta
 	return nil
 }
 
-func runExtensionScript(inst config.Installation, extName, scriptStr, wikiID string) error {
+func runExtensionScript(inst config.Instance, extName, scriptStr, wikiID string) error {
 	return runExtensionScriptWith(nil, inst, extName, scriptStr, wikiID)
 }
 
-func runExtensionScriptWith(orch orchestrators.Orchestrator, inst config.Installation, extName, scriptStr, wikiID string) error {
+func runExtensionScriptWith(orch orchestrators.Orchestrator, inst config.Instance, extName, scriptStr, wikiID string) error {
 	if orch == nil {
 		var err error
 		orch, err = orchestrators.New(inst.Orchestrator)
@@ -327,7 +327,7 @@ func resolveWikiFlag(cliWiki, scriptStr string) (resolvedWiki, cleanedScript str
 
 // resolveWikiIDs returns the list of wiki IDs to operate on.
 // If wikiFlag is set, returns just that wiki; otherwise returns all wikis.
-func resolveWikiIDs(inst config.Installation, wikiFlag string) ([]string, error) {
+func resolveWikiIDs(inst config.Instance, wikiFlag string) ([]string, error) {
 	if wikiFlag != "" {
 		return []string{wikiFlag}, nil
 	}

--- a/cmd/maintenance/extension_test.go
+++ b/cmd/maintenance/extension_test.go
@@ -24,10 +24,10 @@ func (m *extMockOrchestrator) WriteStackFiles(_ string) error { return nil }
 func (m *extMockOrchestrator) UpdateStackFiles(_ string, _ bool) (bool, error) {
 	return false, nil
 }
-func (m *extMockOrchestrator) Start(_ config.Installation) error {
+func (m *extMockOrchestrator) Start(_ config.Instance) error {
 	return nil
 }
-func (m *extMockOrchestrator) Stop(_ config.Installation) error {
+func (m *extMockOrchestrator) Stop(_ config.Instance) error {
 	return nil
 }
 func (m *extMockOrchestrator) Update(_ string) (*orchestrators.UpdateReport, error) {
@@ -51,7 +51,7 @@ func (m *extMockOrchestrator) ExecStreaming(_, _, command string) error {
 	m.streamingCalls = append(m.streamingCalls, command)
 	return m.streamingErr
 }
-func (m *extMockOrchestrator) CheckRunningStatus(_ config.Installation) error {
+func (m *extMockOrchestrator) CheckRunningStatus(_ config.Instance) error {
 	return nil
 }
 func (m *extMockOrchestrator) CopyFrom(_, _, _, _ string) error {
@@ -78,16 +78,16 @@ func (m *extMockOrchestrator) MigrateConfig(_ string, _ bool) (bool, error) {
 	return false, nil
 }
 
-func (m *extMockOrchestrator) ListServices(_ config.Installation) ([]string, error) {
+func (m *extMockOrchestrator) ListServices(_ config.Instance) ([]string, error) {
 	return nil, nil
 }
-func (m *extMockOrchestrator) ExecInteractive(_ config.Installation, _ string, _ []string) error {
+func (m *extMockOrchestrator) ExecInteractive(_ config.Instance, _ string, _ []string) error {
 	return nil
 }
 func (m *extMockOrchestrator) Name() string            { return "Mock" }
 func (m *extMockOrchestrator) SupportsDevMode() bool   { return true }
 func (m *extMockOrchestrator) SupportsImagePull() bool { return true }
-func (m *extMockOrchestrator) StopAndStart(_ config.Installation) error {
+func (m *extMockOrchestrator) StopAndStart(_ config.Instance) error {
 	return nil
 }
 
@@ -167,7 +167,7 @@ func TestListExtensionsWithMaintenance(t *testing.T) {
 			"find extensions": "extensions/CirrusSearch/maintenance\ncanasta-extensions/SemanticMediaWiki/maintenance\nextensions/Cargo/maintenance\n",
 		},
 	}
-	inst := config.Installation{Path: "/test"}
+	inst := config.Instance{Path: "/test"}
 	// Pass a specific wiki to avoid needing wikis.yaml
 	err := listExtensionsWithMaintenanceWith(mock, inst, "main")
 	if err != nil {
@@ -183,7 +183,7 @@ func TestListExtensionsFiltersToLoaded(t *testing.T) {
 			"find extensions": "extensions/CirrusSearch/maintenance\ncanasta-extensions/SemanticMediaWiki/maintenance\nextensions/Cargo/maintenance\n",
 		},
 	}
-	inst := config.Installation{Path: "/test"}
+	inst := config.Instance{Path: "/test"}
 	// We can't easily capture stdout in this test, but at least verify no error
 	err := listExtensionsWithMaintenanceWith(mock, inst, "main")
 	if err != nil {
@@ -213,7 +213,7 @@ func TestListExtensionScripts(t *testing.T) {
 extensions/SemanticMediaWiki/maintenance/setupStore.php`,
 		},
 	}
-	inst := config.Installation{Path: "/test"}
+	inst := config.Instance{Path: "/test"}
 	err := listExtensionScriptsWith(mock, inst, "SemanticMediaWiki", "main")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -226,7 +226,7 @@ func TestListExtensionScriptsNotLoaded(t *testing.T) {
 			"eval.php": "VisualEditor\nCite\n",
 		},
 	}
-	inst := config.Installation{Path: "/test"}
+	inst := config.Instance{Path: "/test"}
 	err := listExtensionScriptsWith(mock, inst, "SemanticMediaWiki", "main")
 	if err == nil {
 		t.Fatal("expected error for extension not loaded")
@@ -242,7 +242,7 @@ func TestListExtensionScriptsNotFound(t *testing.T) {
 			"eval.php": "NonExistent\n",
 		},
 	}
-	inst := config.Installation{Path: "/test"}
+	inst := config.Instance{Path: "/test"}
 	err := listExtensionScriptsWith(mock, inst, "NonExistent", "main")
 	if err == nil {
 		t.Fatal("expected error for non-existent extension")
@@ -261,7 +261,7 @@ func TestRunExtensionScript(t *testing.T) {
 			"test -d extensions/SemanticMediaWiki": "exists",
 		},
 	}
-	inst := config.Installation{Path: "/test"}
+	inst := config.Instance{Path: "/test"}
 	err := runExtensionScriptWith(mock, inst, "SemanticMediaWiki", "rebuildData.php", "main")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -282,7 +282,7 @@ func TestRunExtensionScriptWithWiki(t *testing.T) {
 			"test -d extensions/CirrusSearch": "exists",
 		},
 	}
-	inst := config.Installation{Path: "/test"}
+	inst := config.Instance{Path: "/test"}
 	err := runExtensionScriptWith(mock, inst, "CirrusSearch", "UpdateSearchIndexConfig.php", "docs")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -300,7 +300,7 @@ func TestRunExtensionScriptWithArgs(t *testing.T) {
 			"test -d extensions/SemanticMediaWiki": "exists",
 		},
 	}
-	inst := config.Installation{Path: "/test"}
+	inst := config.Instance{Path: "/test"}
 	err := runExtensionScriptWith(mock, inst, "SemanticMediaWiki", "rebuildData.php -s 1000 -e 2000", "main")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -317,7 +317,7 @@ func TestRunExtensionScriptNotLoaded(t *testing.T) {
 			"eval.php": "VisualEditor\nCite\n",
 		},
 	}
-	inst := config.Installation{Path: "/test"}
+	inst := config.Instance{Path: "/test"}
 	err := runExtensionScriptWith(mock, inst, "SemanticMediaWiki", "rebuildData.php", "main")
 	if err == nil {
 		t.Fatal("expected error for extension not loaded")
@@ -333,7 +333,7 @@ func TestRunExtensionScriptNotFound(t *testing.T) {
 			"eval.php": "NonExistent\n",
 		},
 	}
-	inst := config.Installation{Path: "/test"}
+	inst := config.Instance{Path: "/test"}
 	err := runExtensionScriptWith(mock, inst, "NonExistent", "something.php", "main")
 	if err == nil {
 		t.Fatal("expected error for non-existent extension")
@@ -351,7 +351,7 @@ func TestRunExtensionScriptStreamingError(t *testing.T) {
 		},
 		streamingErr: fmt.Errorf("container error"),
 	}
-	inst := config.Installation{Path: "/test"}
+	inst := config.Instance{Path: "/test"}
 	err := runExtensionScriptWith(mock, inst, "SemanticMediaWiki", "rebuildData.php", "main")
 	if err == nil {
 		t.Fatal("expected error when streaming fails")
@@ -369,7 +369,7 @@ func TestRunExtensionScriptCanastaExtensions(t *testing.T) {
 			"test -d canasta-extensions/Foo": "exists",
 		},
 	}
-	inst := config.Installation{Path: "/test"}
+	inst := config.Instance{Path: "/test"}
 	err := runExtensionScriptWith(mock, inst, "Foo", "doSomething.php", "main")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -467,7 +467,7 @@ func TestRunExtensionScriptWikiInScriptString(t *testing.T) {
 			"test -d extensions/SemanticMediaWiki": "exists",
 		},
 	}
-	inst := config.Installation{Path: "/test"}
+	inst := config.Instance{Path: "/test"}
 	err := runExtensionScriptWith(mock, inst, "SemanticMediaWiki", "rebuildData.php --wiki=docs", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -488,7 +488,7 @@ func TestRunExtensionScriptWikiConflict(t *testing.T) {
 			"test -d extensions/SemanticMediaWiki": "exists",
 		},
 	}
-	inst := config.Installation{Path: "/test"}
+	inst := config.Instance{Path: "/test"}
 	err := runExtensionScriptWith(mock, inst, "SemanticMediaWiki", "rebuildData.php --wiki=main", "docs")
 	if err == nil {
 		t.Fatal("expected error for conflicting --wiki values")
@@ -553,7 +553,7 @@ func TestRunExtensionScriptNotLoadedSentinel(t *testing.T) {
 					"eval.php": tt.extensions,
 				},
 			}
-			inst := config.Installation{Path: "/test"}
+			inst := config.Instance{Path: "/test"}
 			err := runExtensionScriptWith(mock, inst, tt.extName, "rebuildData.php", tt.wikiID)
 			if err == nil {
 				t.Fatal("expected error for extension not loaded")
@@ -626,7 +626,7 @@ func TestRunExtensionScriptMultiWikiSkip(t *testing.T) {
 			mock.execOutputs = map[string]string{
 				"test -d extensions/" + tt.extName: "exists",
 			}
-			inst := config.Installation{Path: "/test"}
+			inst := config.Instance{Path: "/test"}
 
 			// Simulate what RunE does when wiki == "" (no -w flag)
 			ran := 0

--- a/cmd/maintenance/maintenance.go
+++ b/cmd/maintenance/maintenance.go
@@ -10,7 +10,7 @@ import (
 )
 
 func NewCmd() *cobra.Command {
-	var instance config.Installation
+	var instance config.Instance
 
 	workingDir, wdErr := os.Getwd()
 	if wdErr != nil {
@@ -21,7 +21,7 @@ func NewCmd() *cobra.Command {
 	maintenanceCmd := &cobra.Command{
 		Use:   "maintenance",
 		Short: "Use to run update and other maintenance scripts",
-		Long: `Run MediaWiki maintenance operations on a Canasta installation. This command
+		Long: `Run MediaWiki maintenance operations on a Canasta instance. This command
 group provides subcommands to run the standard update sequence, execute
 arbitrary core maintenance scripts, or run extension-specific maintenance scripts.`,
 	}

--- a/cmd/maintenance/maintenanceScript.go
+++ b/cmd/maintenance/maintenanceScript.go
@@ -13,7 +13,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-func newScriptCmd(instance *config.Installation) *cobra.Command {
+func newScriptCmd(instance *config.Instance) *cobra.Command {
 	var wiki string
 
 	scriptCmd := &cobra.Command{
@@ -64,11 +64,11 @@ specific wiki.`,
 	return scriptCmd
 }
 
-func listMaintenanceScripts(inst config.Installation) error {
+func listMaintenanceScripts(inst config.Instance) error {
 	return listMaintenanceScriptsWith(nil, inst)
 }
 
-func listMaintenanceScriptsWith(orch orchestrators.Orchestrator, inst config.Installation) error {
+func listMaintenanceScriptsWith(orch orchestrators.Orchestrator, inst config.Instance) error {
 	if orch == nil {
 		var err error
 		orch, err = orchestrators.New(inst.Orchestrator)
@@ -94,11 +94,11 @@ func listMaintenanceScriptsWith(orch orchestrators.Orchestrator, inst config.Ins
 	return nil
 }
 
-func runMaintenanceScript(instance config.Installation, script string, wiki string) error {
+func runMaintenanceScript(instance config.Instance, script string, wiki string) error {
 	return runMaintenanceScriptWith(nil, instance, script, wiki)
 }
 
-func runMaintenanceScriptWith(orch orchestrators.Orchestrator, inst config.Installation, script string, wiki string) error {
+func runMaintenanceScriptWith(orch orchestrators.Orchestrator, inst config.Instance, script string, wiki string) error {
 	if orch == nil {
 		var err error
 		orch, err = orchestrators.New(inst.Orchestrator)
@@ -131,7 +131,7 @@ func runMaintenanceScriptWith(orch orchestrators.Orchestrator, inst config.Insta
 	return nil
 }
 
-func runScriptForWiki(orch orchestrators.Orchestrator, inst config.Installation, script, wikiID string) error {
+func runScriptForWiki(orch orchestrators.Orchestrator, inst config.Instance, script, wikiID string) error {
 	wikiFlag := ""
 	if wikiID != "" {
 		wikiFlag = " --wiki=" + wikiID

--- a/cmd/maintenance/maintenanceUpdate.go
+++ b/cmd/maintenance/maintenanceUpdate.go
@@ -13,7 +13,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-func newUpdateCmd(instance *config.Installation) *cobra.Command {
+func newUpdateCmd(instance *config.Instance) *cobra.Command {
 	var (
 		wiki     string
 		skipJobs bool
@@ -65,7 +65,7 @@ specific wiki.`,
 	return updateCmd
 }
 
-func runMaintenanceUpdate(instance config.Installation, wikiID string, skipJobs, skipSMW bool) error {
+func runMaintenanceUpdate(instance config.Instance, wikiID string, skipJobs, skipSMW bool) error {
 	orch, err := orchestrators.New(instance.Orchestrator)
 	if err != nil {
 		return err

--- a/cmd/maintenance/maintenance_test.go
+++ b/cmd/maintenance/maintenance_test.go
@@ -103,7 +103,7 @@ func TestScriptRunsAllWikisOnFarm(t *testing.T) {
 	writeWikisYAML(t, dir, "wikis:\n  - id: main\n    url: http://localhost\n  - id: docs\n    url: http://localhost\n")
 
 	mock := &extMockOrchestrator{}
-	inst := config.Installation{Path: dir}
+	inst := config.Instance{Path: dir}
 	err := runMaintenanceScriptWith(mock, inst, "rebuildrecentchanges.php", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -124,7 +124,7 @@ func TestScriptRunsSpecificWikiOnFarm(t *testing.T) {
 	writeWikisYAML(t, dir, "wikis:\n  - id: main\n    url: http://localhost\n  - id: docs\n    url: http://localhost\n")
 
 	mock := &extMockOrchestrator{}
-	inst := config.Installation{Path: dir}
+	inst := config.Instance{Path: dir}
 	err := runMaintenanceScriptWith(mock, inst, "rebuildrecentchanges.php", "docs")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -142,7 +142,7 @@ func TestScriptRunsAllWikisOnSingleWikiFarm(t *testing.T) {
 	writeWikisYAML(t, dir, "wikis:\n  - id: main\n    url: http://localhost\n")
 
 	mock := &extMockOrchestrator{}
-	inst := config.Installation{Path: dir}
+	inst := config.Instance{Path: dir}
 	err := runMaintenanceScriptWith(mock, inst, "rebuildrecentchanges.php", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -17,7 +17,7 @@ import (
 )
 
 func NewCmd() *cobra.Command {
-	var instance config.Installation
+	var instance config.Instance
 	var wikiID string
 	var yes bool
 
@@ -30,7 +30,7 @@ func NewCmd() *cobra.Command {
 	addCmd := &cobra.Command{
 		Use:   "remove",
 		Short: "Remove a wiki from a Canasta instance",
-		Long: `Remove a wiki from an existing Canasta installation. This deletes the wiki's
+		Long: `Remove a wiki from an existing Canasta instance. This deletes the wiki's
 database, settings files, uploaded images, and its entry in wikis.yaml, then
 regenerates the Caddyfile and restarts the instance. You will be prompted
 for confirmation before any data is deleted.`,
@@ -65,7 +65,7 @@ for confirmation before any data is deleted.`,
 }
 
 // RemoveWiki removes a wiki with the given wikiID from a Canasta instance.
-func RemoveWiki(instance config.Installation, wikiID string, yes bool) error {
+func RemoveWiki(instance config.Instance, wikiID string, yes bool) error {
 	orch, err := orchestrators.New(instance.Orchestrator)
 	if err != nil {
 		return err

--- a/cmd/restart/restart.go
+++ b/cmd/restart/restart.go
@@ -13,7 +13,7 @@ import (
 )
 
 func NewCmd() *cobra.Command {
-	var instance config.Installation
+	var instance config.Instance
 
 	workingDir, err := os.Getwd()
 	if err != nil {
@@ -23,12 +23,12 @@ func NewCmd() *cobra.Command {
 
 	var restartCmd = &cobra.Command{
 		Use:   "restart",
-		Short: "Restart the Canasta installation",
-		Long: `Restart a Canasta installation by stopping and then starting all Docker
+		Short: "Restart the Canasta instance",
+		Long: `Restart a Canasta instance by stopping and then starting all Docker
 containers. Any pending configuration migrations are applied during the
 restart. Use 'canasta devmode enable' or 'canasta devmode disable' to
 change the development mode setting.`,
-		Example: `  # Restart an installation by ID
+		Example: `  # Restart an instance by ID
   canasta restart -i myinstance`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
@@ -36,7 +36,7 @@ change the development mode setting.`,
 			if err != nil {
 				return err
 			}
-			fmt.Println("Restarting Canasta installation '" + resolvedInstance.ID + "'...")
+			fmt.Println("Restarting Canasta instance '" + resolvedInstance.ID + "'...")
 			if err = Restart(resolvedInstance); err != nil {
 				return err
 			}
@@ -48,7 +48,7 @@ change the development mode setting.`,
 	return restartCmd
 }
 
-func Restart(instance config.Installation) error {
+func Restart(instance config.Instance) error {
 	orch, err := orchestrators.NewFromInstance(instance)
 	if err != nil {
 		return err

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -32,8 +32,8 @@ var verbose bool
 
 var rootCmd = &cobra.Command{
 	Use:   "canasta",
-	Short: "A CLI tool for Canasta installations.",
-	Long: `Canasta CLI manages Canasta MediaWiki installations using Docker Compose
+	Short: "A CLI tool for managing Canasta instances.",
+	Long: `Canasta CLI manages Canasta MediaWiki instances using Docker Compose
 or Kubernetes. It supports creating, importing, starting, stopping, upgrading,
 and backing up multiple Canasta instances, including wiki farms with multiple
 wikis per instance.`,

--- a/cmd/sitemap/generate.go
+++ b/cmd/sitemap/generate.go
@@ -12,13 +12,13 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-func newGenerateCmd(instance *config.Installation, orch *orchestrators.Orchestrator) *cobra.Command {
+func newGenerateCmd(instance *config.Instance, orch *orchestrators.Orchestrator) *cobra.Command {
 	var wikiID string
 
 	cmd := &cobra.Command{
 		Use:   "generate",
 		Short: "Generate sitemaps for one or all wikis",
-		Long: `Generate XML sitemaps for wikis in a Canasta installation. If --wiki is
+		Long: `Generate XML sitemaps for wikis in a Canasta instance. If --wiki is
 specified, generates a sitemap for that wiki only. Otherwise, generates
 sitemaps for all wikis in the instance. Once generated, the background
 generator will automatically refresh them.`,
@@ -38,7 +38,7 @@ generator will automatically refresh them.`,
 	return cmd
 }
 
-func runGenerate(instance config.Installation, orch orchestrators.Orchestrator, wikiID string) error {
+func runGenerate(instance config.Instance, orch orchestrators.Orchestrator, wikiID string) error {
 	// Check containers are running
 	if err := orch.CheckRunningStatus(instance); err != nil {
 		return fmt.Errorf("containers are not running: %w", err)

--- a/cmd/sitemap/remove.go
+++ b/cmd/sitemap/remove.go
@@ -14,14 +14,14 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/orchestrators"
 )
 
-func newRemoveCmd(instance *config.Installation, orch *orchestrators.Orchestrator) *cobra.Command {
+func newRemoveCmd(instance *config.Instance, orch *orchestrators.Orchestrator) *cobra.Command {
 	var wikiID string
 	var yes bool
 
 	cmd := &cobra.Command{
 		Use:   "remove",
 		Short: "Remove sitemaps for one or all wikis",
-		Long: `Remove XML sitemap files for wikis in a Canasta installation. If --wiki is
+		Long: `Remove XML sitemap files for wikis in a Canasta instance. If --wiki is
 specified, removes the sitemap for that wiki only. Otherwise, removes sitemaps
 for all wikis. Once removed, the background generator will skip those wikis.`,
 		Example: `  # Remove sitemap for a specific wiki
@@ -44,7 +44,7 @@ for all wikis. Once removed, the background generator will skip those wikis.`,
 	return cmd
 }
 
-func runRemove(instance config.Installation, orch orchestrators.Orchestrator, wikiID string, yes bool) error {
+func runRemove(instance config.Instance, orch orchestrators.Orchestrator, wikiID string, yes bool) error {
 	// Check containers are running
 	if err := orch.CheckRunningStatus(instance); err != nil {
 		return fmt.Errorf("containers are not running: %w", err)

--- a/cmd/sitemap/sitemap.go
+++ b/cmd/sitemap/sitemap.go
@@ -13,7 +13,7 @@ import (
 
 func NewCmd() *cobra.Command {
 	var (
-		instance config.Installation
+		instance config.Instance
 		orch     orchestrators.Orchestrator
 	)
 
@@ -26,7 +26,7 @@ func NewCmd() *cobra.Command {
 	sitemapCmd := &cobra.Command{
 		Use:   "sitemap",
 		Short: "Manage sitemaps for a Canasta instance",
-		Long: `Generate or remove XML sitemaps for wikis in a Canasta installation.
+		Long: `Generate or remove XML sitemaps for wikis in a Canasta instance.
 Sitemaps improve search engine indexing by listing all pages on your wiki.
 Use "canasta sitemap generate" to create sitemaps and "canasta sitemap remove"
 to delete them.`,

--- a/cmd/sitemap/sitemap_test.go
+++ b/cmd/sitemap/sitemap_test.go
@@ -58,7 +58,7 @@ func TestNewCmd(t *testing.T) {
 }
 
 func TestGenerateCmd(t *testing.T) {
-	var instance config.Installation
+	var instance config.Instance
 	var orch orchestrators.Orchestrator
 	cmd := newGenerateCmd(&instance, &orch)
 	if cmd.Use != "generate" {
@@ -76,7 +76,7 @@ func TestGenerateCmd(t *testing.T) {
 }
 
 func TestRemoveCmd(t *testing.T) {
-	var instance config.Installation
+	var instance config.Instance
 	var orch orchestrators.Orchestrator
 	cmd := newRemoveCmd(&instance, &orch)
 	if cmd.Use != "remove" {

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -13,7 +13,7 @@ import (
 )
 
 func NewCmd() *cobra.Command {
-	var instance config.Installation
+	var instance config.Instance
 	workingDir, err := os.Getwd()
 	if err != nil {
 		logging.Fatal(err)
@@ -22,12 +22,12 @@ func NewCmd() *cobra.Command {
 
 	var startCmd = &cobra.Command{
 		Use:   "start",
-		Short: "Start the Canasta installation",
-		Long: `Start the Docker containers for a Canasta installation. If the installation
+		Short: "Start the Canasta instance",
+		Long: `Start the Docker containers for a Canasta instance. If the instance
 has development mode enabled, it starts with Xdebug automatically. Use
 'canasta devmode enable' or 'canasta devmode disable' to change the
 development mode setting.`,
-		Example: `  # Start an installation by ID
+		Example: `  # Start an instance by ID
   canasta start -i myinstance`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
@@ -35,7 +35,7 @@ development mode setting.`,
 			if err != nil {
 				return err
 			}
-			fmt.Println("Starting Canasta installation '" + resolvedInstance.ID + "'...")
+			fmt.Println("Starting Canasta instance '" + resolvedInstance.ID + "'...")
 			if err := Start(resolvedInstance); err != nil {
 				return err
 			}
@@ -47,7 +47,7 @@ development mode setting.`,
 	return startCmd
 }
 
-func Start(instance config.Installation) error {
+func Start(instance config.Instance) error {
 	orch, err := orchestrators.NewFromInstance(instance)
 	if err != nil {
 		return err

--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -13,7 +13,7 @@ import (
 )
 
 func NewCmd() *cobra.Command {
-	var instance config.Installation
+	var instance config.Instance
 	workingDir, err := os.Getwd()
 	if err != nil {
 		logging.Fatal(err)
@@ -22,10 +22,10 @@ func NewCmd() *cobra.Command {
 
 	var stopCmd = &cobra.Command{
 		Use:   "stop",
-		Short: "Shuts down the Canasta installation",
-		Long: `Stop all Docker containers for a Canasta installation. The containers
+		Short: "Shuts down the Canasta instance",
+		Long: `Stop all Docker containers for a Canasta instance. The containers
 are stopped gracefully, preserving all data in Docker volumes.`,
-		Example: `  # Stop an installation by ID
+		Example: `  # Stop an instance by ID
   canasta stop -i myinstance`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
@@ -33,7 +33,7 @@ are stopped gracefully, preserving all data in Docker volumes.`,
 			if err != nil {
 				return err
 			}
-			fmt.Println("Stopping Canasta installation '" + resolvedInstance.ID + "'...")
+			fmt.Println("Stopping Canasta instance '" + resolvedInstance.ID + "'...")
 			if err = Stop(resolvedInstance); err != nil {
 				return err
 			}
@@ -45,7 +45,7 @@ are stopped gracefully, preserving all data in Docker volumes.`,
 	return stopCmd
 }
 
-func Stop(instance config.Installation) error {
+func Stop(instance config.Instance) error {
 	orch, err := orchestrators.NewFromInstance(instance)
 	if err != nil {
 		return err

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -27,26 +27,26 @@ func NewCmd() *cobra.Command {
 
 	var upgradeCmd = &cobra.Command{
 		Use:   "upgrade",
-		Short: "Upgrade the Canasta CLI and all registered installations",
-		Long: `Upgrade the Canasta CLI binary and all registered installations.
+		Short: "Upgrade the Canasta CLI and all registered instances",
+		Long: `Upgrade the Canasta CLI binary and all registered instances.
 
-Each installation is updated by refreshing configuration files, pulling the
+Each instance is updated by refreshing configuration files, pulling the
 latest container images, running any necessary migrations, and restarting
 the containers.
 
 The CLI itself is also updated to the latest version before upgrading instances.
 Dev builds (compiled without version ldflags) skip the CLI self-update automatically.
 
-If an installation fails to upgrade, the error is printed and the remaining
-installations are still upgraded. A summary at the end reports how many succeeded.
+If an instance fails to upgrade, the error is printed and the remaining
+instances are still upgraded. A summary at the end reports how many succeeded.
 
 Use --dry-run to preview migrations without applying them.
 
-Installations created with --build-from automatically rebuild the Canasta image
-from the stored source path during upgrade. For Kubernetes installations created
+Instances created with --build-from automatically rebuild the Canasta image
+from the stored source path during upgrade. For Kubernetes instances created
 with a kind cluster or custom registry, the rebuilt image is automatically
 distributed using the stored configuration.`,
-		Example: `  # Upgrade the CLI and all installations
+		Example: `  # Upgrade the CLI and all instances
   canasta upgrade
 
   # Preview what would change without applying
@@ -74,11 +74,11 @@ func upgradeAllInstances(dryRun bool) error {
 		return err
 	}
 	if len(installations) == 0 {
-		fmt.Printf("No registered installations found (looked in %s)\n", config.GetConfFilePath())
+		fmt.Printf("No registered instances found (looked in %s)\n", config.GetConfFilePath())
 		if config.IsRunningAsRoot() {
-			fmt.Println("Note: Running as root uses /etc/canasta/conf.json. Installations")
+			fmt.Println("Note: Running as root uses /etc/canasta/conf.json. Instances")
 			fmt.Println("registered by a non-root user are stored in ~/.config/canasta/conf.json.")
-			fmt.Println("Try running without sudo if your installations were created as a regular user.")
+			fmt.Println("Try running without sudo if your instances were created as a regular user.")
 		}
 		return nil
 	}
@@ -110,10 +110,10 @@ func upgradeAllInstances(dryRun bool) error {
 	return nil
 }
 
-func Upgrade(instance config.Installation, dryRun bool) error {
+func Upgrade(instance config.Instance, dryRun bool) error {
 	var err error
 
-	// Check installation existence
+	// Check instance existence
 	instance, err = canasta.CheckCanastaID(instance)
 	if err != nil {
 		return err
@@ -231,7 +231,7 @@ func Upgrade(instance config.Installation, dryRun bool) error {
 		if stackChanged || templateChanged || migrationsNeeded || mysqlMigrationNeeded {
 			fmt.Println("Run 'canasta upgrade' to apply these changes.")
 		} else {
-			fmt.Println("Installation is up to date. No upgrade needed.")
+			fmt.Println("Instance is up to date. No upgrade needed.")
 		}
 		return nil
 	}
@@ -290,7 +290,7 @@ func Upgrade(instance config.Installation, dryRun bool) error {
 		fmt.Println("Canasta upgraded successfully!")
 	} else {
 		fmt.Println()
-		fmt.Println("Installation is already up to date.")
+		fmt.Println("Instance is already up to date.")
 	}
 
 	return nil
@@ -618,9 +618,9 @@ func removeSkipBinaryAsHex(installPath string, dryRun bool) (bool, error) {
 	return true, nil
 }
 
-// removeLegacyGitDir removes the .git directory from installations that were
+// removeLegacyGitDir removes the .git directory from instances that were
 // previously cloned from the Canasta-DockerCompose repo. Stack files are now
-// embedded in the CLI binary, so installations are no longer git repos.
+// embedded in the CLI binary, so instances are no longer git repos.
 // Skips removal if gitops is active (indicated by a .gitops-host file).
 func removeLegacyGitDir(installPath string, dryRun bool) (bool, error) {
 	gitDir := filepath.Join(installPath, ".git")
@@ -649,8 +649,8 @@ func removeLegacyGitDir(installPath string, dryRun bool) (bool, error) {
 }
 
 // backfillCanastaImage ensures CANASTA_IMAGE in .env matches the current
-// CLI's default image tag. This handles both installations that predate the
-// CANASTA_IMAGE variable and installations where the CLI was upgraded to a
+// CLI's default image tag. This handles both instances that predate the
+// CANASTA_IMAGE variable and instances where the CLI was upgraded to a
 // newer version but the image tag was not updated.
 func backfillCanastaImage(installPath string, dryRun bool) (bool, error) {
 	envPath := filepath.Join(installPath, ".env")

--- a/internal/canasta/canasta.go
+++ b/internal/canasta/canasta.go
@@ -896,7 +896,7 @@ func GetEnvVariable(envPath string) (map[string]string, error) {
 }
 
 // Checking Installation existence
-func CheckCanastaID(instance config.Installation) (config.Installation, error) {
+func CheckCanastaID(instance config.Instance) (config.Instance, error) {
 	var err error
 	if instance.ID != "" {
 		if instance, err = config.GetDetails(instance.ID); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,7 +13,7 @@ import (
 	"github.com/CanastaWiki/Canasta-CLI/internal/permissions"
 )
 
-type Installation struct {
+type Instance struct {
 	ID             string `json:"id"`
 	Path           string `json:"path"`
 	Orchestrator   string `json:"orchestrator"`
@@ -29,14 +29,15 @@ type Orchestrator struct {
 }
 
 type Canasta struct {
-	Orchestrators map[string]Orchestrator
-	Installations map[string]Installation
+	Orchestrators       map[string]Orchestrator
+	Instances           map[string]Instance `json:"Instances"`
+	LegacyInstallations map[string]Instance `json:"Installations,omitempty"`
 }
 
 var (
 	directory             string
 	confFile              string
-	existingInstallations Canasta
+	existingInstances Canasta
 	initOnce              sync.Once
 	initErr               error
 	configDirOverride     string
@@ -62,7 +63,7 @@ func ensureInitialized() error {
 		_, err = os.Stat(confFile)
 		if os.IsNotExist(err) {
 			// Creating conf.json
-			if err := write(Canasta{Installations: map[string]Installation{}, Orchestrators: map[string]Orchestrator{}}); err != nil {
+			if err := write(Canasta{Instances: map[string]Instance{}, Orchestrators: map[string]Orchestrator{}}); err != nil {
 				initErr = err
 				return
 			}
@@ -79,10 +80,20 @@ func ensureInitialized() error {
 		}
 		f.Close()
 
-		// Update the existingInstallations list
-		if err := read(&existingInstallations); err != nil {
+		// Update the existingInstances list
+		if err := read(&existingInstances); err != nil {
 			initErr = err
 			return
+		}
+
+		// Migrate legacy conf.json that used "Installations" key
+		if len(existingInstances.Instances) == 0 && len(existingInstances.LegacyInstallations) > 0 {
+			existingInstances.Instances = existingInstances.LegacyInstallations
+			existingInstances.LegacyInstallations = nil
+			if err := write(existingInstances); err != nil {
+				initErr = err
+				return
+			}
 		}
 	})
 	return initErr
@@ -97,98 +108,98 @@ func ResetForTesting(dir string) {
 	configDirOverride = dir
 	directory = ""
 	confFile = ""
-	existingInstallations = Canasta{}
+	existingInstances = Canasta{}
 }
 
 func Exists(canastaID string) (bool, error) {
 	if err := ensureInitialized(); err != nil {
 		return false, err
 	}
-	err := read(&existingInstallations)
+	err := read(&existingInstances)
 	if err != nil {
 		return false, err
 	}
-	return existingInstallations.Installations[canastaID].ID != "", nil
+	return existingInstances.Instances[canastaID].ID != "", nil
 }
 
 func OrchestratorExists(orchestrator string) (bool, error) {
 	if err := ensureInitialized(); err != nil {
 		return false, err
 	}
-	err := read(&existingInstallations)
+	err := read(&existingInstances)
 	if err != nil {
 		return false, err
 	}
-	return existingInstallations.Orchestrators[orchestrator].Path != "", nil
+	return existingInstances.Orchestrators[orchestrator].Path != "", nil
 }
 
 func ListAll() error {
 	if err := ensureInitialized(); err != nil {
 		return err
 	}
-	err := read(&existingInstallations)
+	err := read(&existingInstances)
 	if err != nil {
 		return err
 	}
 
-	if len(existingInstallations.Installations) == 0 {
+	if len(existingInstances.Instances) == 0 {
 		fmt.Printf("No instances found (looked in %s)\n", confFile)
 		if IsRunningAsRoot() {
-			fmt.Println("Note: Running as root uses /etc/canasta/conf.json. Installations")
+			fmt.Println("Note: Running as root uses /etc/canasta/conf.json. Instances")
 			fmt.Println("registered by a non-root user are stored in ~/.config/canasta/conf.json.")
 		}
 		return nil
 	}
 
 	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(writer, "Canasta ID\tWiki ID\tServer Name\tServer Path\tInstallation Path\tOrchestrator")
+	fmt.Fprintln(writer, "Canasta ID\tWiki ID\tServer Name\tServer Path\tInstance Path\tOrchestrator")
 
-	for _, installation := range existingInstallations.Installations {
-		installPath := installation.Path
+	for _, instance := range existingInstances.Instances {
+		installPath := instance.Path
 		pathMissing := false
-		if _, err := os.Stat(installation.Path); os.IsNotExist(err) {
-			installPath = installation.Path + " [not found]"
+		if _, err := os.Stat(instance.Path); os.IsNotExist(err) {
+			installPath = instance.Path + " [not found]"
 			pathMissing = true
 		}
 
 		if pathMissing {
 			fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\n",
-				installation.ID,
+				instance.ID,
 				"N/A",
 				"N/A",
 				"N/A",
 				installPath,
-				installation.Orchestrator)
+				instance.Orchestrator)
 			continue
 		}
 
-		if _, err := os.Stat(filepath.Join(installation.Path, "config", "wikis.yaml")); os.IsNotExist(err) {
-			// File does not exist, print only installation info
+		if _, err := os.Stat(filepath.Join(instance.Path, "config", "wikis.yaml")); os.IsNotExist(err) {
+			// File does not exist, print only instance info
 			fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\n",
-				installation.ID,
+				instance.ID,
 				"N/A", // Placeholder
 				"N/A", // Placeholder
 				"N/A", // Placeholder
 				installPath,
-				installation.Orchestrator)
+				instance.Orchestrator)
 			continue
 		}
 
-		ids, serverNames, paths, err := farmsettings.ReadWikisYaml(filepath.Join(installation.Path, "config", "wikis.yaml"))
+		ids, serverNames, paths, err := farmsettings.ReadWikisYaml(filepath.Join(instance.Path, "config", "wikis.yaml"))
 		if err != nil {
-			fmt.Printf("Error reading wikis.yaml for installation ID '%s': %s\n", installation.ID, err)
+			fmt.Printf("Error reading wikis.yaml for instance ID '%s': %s\n", instance.ID, err)
 			continue
 		}
 
 		for i := range ids {
 			if i == 0 {
 				fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\n",
-					installation.ID,
+					instance.ID,
 					ids[i],
 					serverNames[i],
 					paths[i],
 					installPath,
-					installation.Orchestrator)
+					instance.Orchestrator)
 			} else {
 				fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\n",
 					"-",
@@ -196,7 +207,7 @@ func ListAll() error {
 					serverNames[i],
 					paths[i],
 					installPath,
-					installation.Orchestrator)
+					instance.Orchestrator)
 			}
 
 		}
@@ -205,15 +216,15 @@ func ListAll() error {
 	return nil
 }
 
-func GetAll() (map[string]Installation, error) {
+func GetAll() (map[string]Instance, error) {
 	if err := ensureInitialized(); err != nil {
 		return nil, err
 	}
-	err := read(&existingInstallations)
+	err := read(&existingInstances)
 	if err != nil {
 		return nil, err
 	}
-	return existingInstallations.Installations, nil
+	return existingInstances.Instances, nil
 }
 
 // GetConfFilePath returns the path to the conf.json file currently in use.
@@ -231,28 +242,28 @@ func IsRunningAsRoot() bool {
 	return currentUser.Username == "root"
 }
 
-func GetDetails(canastaID string) (Installation, error) {
+func GetDetails(canastaID string) (Instance, error) {
 	if err := ensureInitialized(); err != nil {
-		return Installation{}, err
+		return Instance{}, err
 	}
 	exists, err := Exists(canastaID)
 	if err != nil {
-		return Installation{}, err
+		return Instance{}, err
 	}
 	if exists {
-		return existingInstallations.Installations[canastaID], nil
+		return existingInstances.Instances[canastaID], nil
 	}
-	return Installation{}, fmt.Errorf("canasta installation with the ID doesn't exist")
+	return Instance{}, fmt.Errorf("canasta instance with the ID doesn't exist")
 }
 
 func GetCanastaID(installPath string) (string, error) {
 	if err := ensureInitialized(); err != nil {
 		return "", err
 	}
-	// Walk up the directory tree to find an enclosing installation.
+	// Walk up the directory tree to find an enclosing instance.
 	dir := installPath
 	for {
-		for _, inst := range existingInstallations.Installations {
+		for _, inst := range existingInstances.Instances {
 			if inst.Path == dir {
 				return inst.ID, nil
 			}
@@ -263,10 +274,10 @@ func GetCanastaID(installPath string) (string, error) {
 		}
 		dir = parent
 	}
-	return "", fmt.Errorf("no Canasta installations exist at %s", installPath)
+	return "", fmt.Errorf("no Canasta instances exist at %s", installPath)
 }
 
-func Add(details Installation) error {
+func Add(details Instance) error {
 	if err := ensureInitialized(); err != nil {
 		return err
 	}
@@ -275,18 +286,18 @@ func Add(details Installation) error {
 		return err
 	}
 	if exists {
-		return fmt.Errorf("canasta ID is already used for another installation")
+		return fmt.Errorf("canasta ID is already used for another instance")
 	}
-	existingInstallations.Installations[details.ID] = details
-	return write(existingInstallations)
+	existingInstances.Instances[details.ID] = details
+	return write(existingInstances)
 }
 
 func AddOrchestrator(details Orchestrator) error {
 	if err := ensureInitialized(); err != nil {
 		return err
 	}
-	if existingInstallations.Orchestrators == nil {
-		existingInstallations.Orchestrators = map[string]Orchestrator{}
+	if existingInstances.Orchestrators == nil {
+		existingInstances.Orchestrators = map[string]Orchestrator{}
 	}
 	supportedOrchestrators := map[string]bool{
 		"compose":    true,
@@ -296,8 +307,8 @@ func AddOrchestrator(details Orchestrator) error {
 	if !supportedOrchestrators[details.ID] {
 		return fmt.Errorf("orchestrator %s is not supported", details.ID)
 	}
-	existingInstallations.Orchestrators[details.ID] = details
-	err := write(existingInstallations)
+	existingInstances.Orchestrators[details.ID] = details
+	err := write(existingInstances)
 	return err
 }
 
@@ -310,7 +321,7 @@ func GetOrchestrator(orchestrator string) (Orchestrator, error) {
 		return Orchestrator{}, err
 	}
 	if exists {
-		return existingInstallations.Orchestrators[orchestrator], nil
+		return existingInstances.Orchestrators[orchestrator], nil
 	}
 	return Orchestrator{}, nil
 }
@@ -324,14 +335,14 @@ func Delete(canastaID string) error {
 		return err
 	}
 	if !exists {
-		return fmt.Errorf("canasta installation with the ID doesn't exist")
+		return fmt.Errorf("canasta instance with the ID doesn't exist")
 	}
-	delete(existingInstallations.Installations, canastaID)
-	return write(existingInstallations)
+	delete(existingInstances.Instances, canastaID)
+	return write(existingInstances)
 }
 
-// Update updates an existing installation's configuration
-func Update(details Installation) error {
+// Update updates an existing instance's configuration
+func Update(details Instance) error {
 	if err := ensureInitialized(); err != nil {
 		return err
 	}
@@ -340,10 +351,10 @@ func Update(details Installation) error {
 		return err
 	}
 	if !exists {
-		return fmt.Errorf("canasta installation with ID '%s' doesn't exist", details.ID)
+		return fmt.Errorf("canasta instance with ID '%s' doesn't exist", details.ID)
 	}
-	existingInstallations.Installations[details.ID] = details
-	return write(existingInstallations)
+	existingInstances.Instances[details.ID] = details
+	return write(existingInstances)
 }
 
 func write(details Canasta) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,12 +35,12 @@ type Canasta struct {
 }
 
 var (
-	directory             string
-	confFile              string
+	directory         string
+	confFile          string
 	existingInstances Canasta
-	initOnce              sync.Once
-	initErr               error
-	configDirOverride     string
+	initOnce          sync.Once
+	initErr           error
+	configDirOverride string
 )
 
 func ensureInitialized() error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -17,7 +17,7 @@ func setupTestDir(t *testing.T) string {
 func TestAddAndGetDetails(t *testing.T) {
 	setupTestDir(t)
 
-	inst := Installation{
+	inst := Instance{
 		ID:           "test1",
 		Path:         "/tmp/test1",
 		Orchestrator: "compose",
@@ -39,7 +39,7 @@ func TestAddAndGetDetails(t *testing.T) {
 func TestExists(t *testing.T) {
 	setupTestDir(t)
 
-	inst := Installation{ID: "exists1", Path: "/tmp/exists1", Orchestrator: "compose"}
+	inst := Instance{ID: "exists1", Path: "/tmp/exists1", Orchestrator: "compose"}
 	if err := Add(inst); err != nil {
 		t.Fatalf("Add() error = %v", err)
 	}
@@ -64,7 +64,7 @@ func TestExists(t *testing.T) {
 func TestDelete(t *testing.T) {
 	setupTestDir(t)
 
-	inst := Installation{ID: "del1", Path: "/tmp/del1", Orchestrator: "compose"}
+	inst := Instance{ID: "del1", Path: "/tmp/del1", Orchestrator: "compose"}
 	if err := Add(inst); err != nil {
 		t.Fatalf("Add() error = %v", err)
 	}
@@ -85,7 +85,7 @@ func TestDelete(t *testing.T) {
 func TestUpdate(t *testing.T) {
 	setupTestDir(t)
 
-	inst := Installation{ID: "upd1", Path: "/tmp/upd1", Orchestrator: "compose"}
+	inst := Instance{ID: "upd1", Path: "/tmp/upd1", Orchestrator: "compose"}
 	if err := Add(inst); err != nil {
 		t.Fatalf("Add() error = %v", err)
 	}
@@ -107,7 +107,7 @@ func TestUpdate(t *testing.T) {
 func TestDuplicateAdd(t *testing.T) {
 	setupTestDir(t)
 
-	inst := Installation{ID: "dup1", Path: "/tmp/dup1", Orchestrator: "compose"}
+	inst := Instance{ID: "dup1", Path: "/tmp/dup1", Orchestrator: "compose"}
 	if err := Add(inst); err != nil {
 		t.Fatalf("Add() error = %v", err)
 	}
@@ -130,8 +130,8 @@ func TestDeleteNonexistent(t *testing.T) {
 func TestGetAll(t *testing.T) {
 	setupTestDir(t)
 
-	inst1 := Installation{ID: "all1", Path: "/tmp/all1", Orchestrator: "compose"}
-	inst2 := Installation{ID: "all2", Path: "/tmp/all2", Orchestrator: "compose"}
+	inst1 := Instance{ID: "all1", Path: "/tmp/all1", Orchestrator: "compose"}
+	inst2 := Instance{ID: "all2", Path: "/tmp/all2", Orchestrator: "compose"}
 	if err := Add(inst1); err != nil {
 		t.Fatalf("Add() error = %v", err)
 	}
@@ -144,14 +144,14 @@ func TestGetAll(t *testing.T) {
 		t.Fatalf("GetAll() error = %v", err)
 	}
 	if len(all) != 2 {
-		t.Errorf("expected 2 installations, got %d", len(all))
+		t.Errorf("expected 2 instances, got %d", len(all))
 	}
 }
 
 func TestGetCanastaID(t *testing.T) {
 	setupTestDir(t)
 
-	inst := Installation{ID: "pathtest", Path: "/tmp/pathtest", Orchestrator: "compose"}
+	inst := Instance{ID: "pathtest", Path: "/tmp/pathtest", Orchestrator: "compose"}
 	if err := Add(inst); err != nil {
 		t.Fatalf("Add() error = %v", err)
 	}
@@ -173,7 +173,7 @@ func TestGetCanastaID(t *testing.T) {
 func TestGetCanastaIDFromSubdirectory(t *testing.T) {
 	setupTestDir(t)
 
-	inst := Installation{ID: "subdir-test", Path: "/srv/canasta/my-wiki", Orchestrator: "compose"}
+	inst := Instance{ID: "subdir-test", Path: "/srv/canasta/my-wiki", Orchestrator: "compose"}
 	if err := Add(inst); err != nil {
 		t.Fatalf("Add() error = %v", err)
 	}
@@ -234,7 +234,7 @@ func TestAddOrchestratorSupported(t *testing.T) {
 func TestBuildFromRoundTrip(t *testing.T) {
 	dir := setupTestDir(t)
 
-	inst := Installation{
+	inst := Instance{
 		ID:           "bf1",
 		Path:         "/tmp/bf1",
 		Orchestrator: "compose",
@@ -265,7 +265,7 @@ func TestBuildFromRoundTrip(t *testing.T) {
 func TestBuildFromOmittedWhenEmpty(t *testing.T) {
 	dir := setupTestDir(t)
 
-	inst := Installation{
+	inst := Instance{
 		ID:           "nobf1",
 		Path:         "/tmp/nobf1",
 		Orchestrator: "compose",

--- a/internal/devmode/devmode.go
+++ b/internal/devmode/devmode.go
@@ -43,7 +43,7 @@ var phpstormServerConfig string
 //go:embed files/phpstorm/Listen_for_Xdebug.xml
 var phpstormRunConfig string
 
-// CreateDevModeFiles creates all the xdebug-related files in the installation directory
+// CreateDevModeFiles creates all the xdebug-related files in the instance directory
 func CreateDevModeFiles(installPath string) error {
 	logging.Print("Creating development mode files...\n")
 
@@ -355,7 +355,7 @@ func WriteIDEConfigs(installPath string) error {
 	return nil
 }
 
-// IsDevModeSetup checks if dev mode files exist in the installation
+// IsDevModeSetup checks if dev mode files exist in the instance
 func IsDevModeSetup(installPath string) bool {
 	devComposePath := filepath.Join(installPath, DevComposeFile)
 	dockerfilePath := filepath.Join(installPath, "Dockerfile.xdebug")
@@ -366,7 +366,7 @@ func IsDevModeSetup(installPath string) bool {
 	return err1 == nil && err2 == nil
 }
 
-// EnableDevMode enables dev mode on an existing installation
+// EnableDevMode enables dev mode on an existing instance
 // If dev mode files exist but symlinks need to be restored, it handles that
 // baseImage is the full Canasta image name (e.g., "ghcr.io/canastawiki/canasta:latest" or "canasta:local")
 func EnableDevMode(installPath string, orch orchestrators.Orchestrator, baseImage string) error {
@@ -385,7 +385,7 @@ func EnableDevMode(installPath string, orch orchestrators.Orchestrator, baseImag
 	}
 
 	// Full dev mode setup needed
-	logging.Print("Setting up dev mode for existing installation...\n")
+	logging.Print("Setting up dev mode for existing instance...\n")
 	return SetupFullDevMode(installPath, orch, baseImage)
 }
 
@@ -407,7 +407,7 @@ func ensureDevModeSymlinks(installPath, codeDir string) error {
 	return nil
 }
 
-// DisableDevMode disables dev mode on an installation
+// DisableDevMode disables dev mode on an instance
 // This reverses the symlinks created by EnableDevMode, restoring extensions/ and skins/
 // as real directories with their contents copied from mediawiki-code/
 func DisableDevMode(installPath string) error {

--- a/internal/extensionsskins/commands.go
+++ b/internal/extensionsskins/commands.go
@@ -18,7 +18,7 @@ import (
 // for an extension-or-skin item type.
 func NewCmd(constants Item) *cobra.Command {
 	var (
-		instance config.Installation
+		instance config.Instance
 		orch     orchestrators.Orchestrator
 		wiki     string
 	)
@@ -32,7 +32,7 @@ func NewCmd(constants Item) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   constants.CmdName,
 		Short: fmt.Sprintf("Manage Canasta %s", constants.Plural),
-		Long: fmt.Sprintf(`Manage MediaWiki %s in a Canasta installation. Subcommands allow you
+		Long: fmt.Sprintf(`Manage MediaWiki %s in a Canasta instance. Subcommands allow you
 to list all available %s, and enable or disable them globally or for
 a specific wiki in a farm.`, constants.Plural, constants.Plural),
 		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
@@ -56,11 +56,11 @@ a specific wiki in a farm.`, constants.Plural, constants.Plural),
 	return cmd
 }
 
-func newListCmd(instance *config.Installation, orch *orchestrators.Orchestrator, _ *string, constants *Item) *cobra.Command {
+func newListCmd(instance *config.Instance, orch *orchestrators.Orchestrator, _ *string, constants *Item) *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
 		Short: fmt.Sprintf("Lists all the installed Canasta %s", constants.Plural),
-		Long: fmt.Sprintf(`List all Canasta %s available in the installation. Each %s
+		Long: fmt.Sprintf(`List all Canasta %s available in the instance. Each %s
 is shown with its enabled/disabled status.`, constants.Plural, constants.CmdName),
 		Example: fmt.Sprintf("  canasta %s list -i myinstance", constants.CmdName),
 		RunE: func(_ *cobra.Command, _ []string) error {
@@ -69,7 +69,7 @@ is shown with its enabled/disabled status.`, constants.Plural, constants.CmdName
 	}
 }
 
-func newEnableCmd(instance *config.Installation, orch *orchestrators.Orchestrator, wiki *string, constants *Item) *cobra.Command {
+func newEnableCmd(instance *config.Instance, orch *orchestrators.Orchestrator, wiki *string, constants *Item) *cobra.Command {
 	var skipUpdate bool
 
 	// Build the Use string with an appropriate argument placeholder
@@ -136,7 +136,7 @@ database changes. Use --skip-update to skip this step.`, constants.Plural, const
 	return cmd
 }
 
-func newDisableCmd(instance *config.Installation, _ *orchestrators.Orchestrator, wiki *string, constants *Item) *cobra.Command {
+func newDisableCmd(instance *config.Instance, _ *orchestrators.Orchestrator, wiki *string, constants *Item) *cobra.Command {
 	// Build the Use string with an appropriate argument placeholder
 	argName := strings.ToUpper(constants.CmdName)
 	useStr := fmt.Sprintf("disable %s1,%s2,...", argName, argName)

--- a/internal/extensionsskins/extensionsskins.go
+++ b/internal/extensionsskins/extensionsskins.go
@@ -48,7 +48,7 @@ type Item struct {
 	ExampleNames             string // e.g. "VisualEditor,Cite,ParserFunctions" or "Timeless"
 }
 
-// configPath returns the host path to settings.yaml for the given installation and wiki.
+// configPath returns the host path to settings.yaml for the given instance and wiki.
 func configPath(instancePath, wiki string) string {
 	if wiki != "" {
 		return filepath.Join(instancePath, "config", "settings", "wikis", wiki, configFileName)
@@ -101,7 +101,7 @@ func getSlice(cfg *configYAML, constants Item) *[]string {
 	return &cfg.Extensions
 }
 
-func List(instance config.Installation, orch orchestrators.Orchestrator, constants Item) error {
+func List(instance config.Instance, orch orchestrators.Orchestrator, constants Item) error {
 	fmt.Printf("Available %s:\n", constants.Name)
 	output, err := orch.ExecWithError(instance.Path, orchestrators.ServiceWeb, "cd $MW_HOME/"+constants.RelativeInstallationPath+" && find -L * -maxdepth 0 -type d")
 	if err != nil {
@@ -111,7 +111,7 @@ func List(instance config.Installation, orch orchestrators.Orchestrator, constan
 	return nil
 }
 
-func CheckInstalled(name string, instance config.Installation, orch orchestrators.Orchestrator, constants Item) (string, error) {
+func CheckInstalled(name string, instance config.Instance, orch orchestrators.Orchestrator, constants Item) (string, error) {
 	if err := ValidateName(name, constants); err != nil {
 		return "", err
 	}
@@ -125,7 +125,7 @@ func CheckInstalled(name string, instance config.Installation, orch orchestrator
 	return name, nil
 }
 
-func Enable(name, wiki string, instance config.Installation, constants Item) error {
+func Enable(name, wiki string, instance config.Instance, constants Item) error {
 	if err := ValidateName(name, constants); err != nil {
 		return err
 	}
@@ -155,7 +155,7 @@ func Enable(name, wiki string, instance config.Installation, constants Item) err
 	return nil
 }
 
-func CheckEnabled(name, wiki string, instance config.Installation, constants Item) (string, error) {
+func CheckEnabled(name, wiki string, instance config.Instance, constants Item) (string, error) {
 	if err := ValidateName(name, constants); err != nil {
 		return "", err
 	}
@@ -173,7 +173,7 @@ func CheckEnabled(name, wiki string, instance config.Installation, constants Ite
 	return name, nil
 }
 
-func Disable(name, wiki string, instance config.Installation, constants Item) error {
+func Disable(name, wiki string, instance config.Instance, constants Item) error {
 	if err := ValidateName(name, constants); err != nil {
 		return err
 	}

--- a/internal/extensionsskins/extensionsskins_test.go
+++ b/internal/extensionsskins/extensionsskins_test.go
@@ -162,10 +162,10 @@ func TestWriteConfigDeletesEmptyFile(t *testing.T) {
 	}
 }
 
-func newTestInstance(t *testing.T) config.Installation {
+func newTestInstance(t *testing.T) config.Instance {
 	t.Helper()
 	dir := t.TempDir()
-	return config.Installation{Path: dir}
+	return config.Instance{Path: dir}
 }
 
 func TestEnableExtension(t *testing.T) {

--- a/internal/farmsettings/farmsettings.go
+++ b/internal/farmsettings/farmsettings.go
@@ -128,7 +128,7 @@ func ReadWikisYaml(filePath string) ([]string, []string, []string, error) {
 	return ids, serverNames, paths, nil
 }
 
-// GetWikiIDs returns the list of wiki IDs from the installation's wikis.yaml.
+// GetWikiIDs returns the list of wiki IDs from the instance's wikis.yaml.
 func GetWikiIDs(installPath string) ([]string, error) {
 	filePath := filepath.Join(installPath, "config", "wikis.yaml")
 	ids, _, _, err := ReadWikisYaml(filePath)
@@ -138,7 +138,7 @@ func GetWikiIDs(installPath string) ([]string, error) {
 	return ids, nil
 }
 
-// WikiIDExists checks if a wiki with the given wikiID exists in the installation
+// WikiIDExists checks if a wiki with the given wikiID exists in the instance
 func WikiIDExists(installPath, wikiID string) (bool, error) {
 	// Get the absolute path to the wikis.yaml file
 	filePath := filepath.Join(installPath, "config", "wikis.yaml")
@@ -165,7 +165,7 @@ func WikiIDExists(installPath, wikiID string) (bool, error) {
 	return false, nil
 }
 
-// WikiURLExists checks if a wiki with the given URL (domain/path combo) exists in the installation
+// WikiURLExists checks if a wiki with the given URL (domain/path combo) exists in the instance
 func WikiURLExists(installPath, domain, wikiPath string) (bool, error) {
 	// Get the absolute path to the wikis.yaml file
 	filePath := filepath.Join(installPath, "config", "wikis.yaml")

--- a/internal/maintenance/update.go
+++ b/internal/maintenance/update.go
@@ -9,7 +9,7 @@ import (
 )
 
 // RunUpdatePhp runs update.php --quick for a single wiki.
-func RunUpdatePhp(instance config.Installation, orch orchestrators.Orchestrator, wikiID string) error {
+func RunUpdatePhp(instance config.Instance, orch orchestrators.Orchestrator, wikiID string) error {
 	wikiFlag := ""
 	if wikiID != "" {
 		wikiFlag = " --wiki=" + wikiID
@@ -29,7 +29,7 @@ func RunUpdatePhp(instance config.Installation, orch orchestrators.Orchestrator,
 
 // RunUpdateAllWikis runs update.php --quick. If wiki is non-empty, runs only
 // for that wiki. Otherwise runs for all wikis from wikis.yaml.
-func RunUpdateAllWikis(instance config.Installation, orch orchestrators.Orchestrator, wiki string) error {
+func RunUpdateAllWikis(instance config.Instance, orch orchestrators.Orchestrator, wiki string) error {
 	if wiki != "" {
 		return RunUpdatePhp(instance, orch, wiki)
 	}

--- a/internal/orchestrators/compose.go
+++ b/internal/orchestrators/compose.go
@@ -97,7 +97,7 @@ func (c *ComposeOrchestrator) GetDevFiles(installPath string) []string {
 	return files
 }
 
-func (c *ComposeOrchestrator) Start(instance config.Installation) error {
+func (c *ComposeOrchestrator) Start(instance config.Instance) error {
 	// Sync COMPOSE_PROFILES before starting so that toggling feature flags
 	// in .env (e.g. CANASTA_ENABLE_ELASTICSEARCH) takes effect on restart.
 	if err := syncComposeProfiles(instance.Path); err != nil {
@@ -128,7 +128,7 @@ func (c *ComposeOrchestrator) Start(instance config.Installation) error {
 	return nil
 }
 
-func (c *ComposeOrchestrator) Stop(instance config.Installation) error {
+func (c *ComposeOrchestrator) Stop(instance config.Instance) error {
 	var files []string
 	if instance.DevMode {
 		logging.Print("Stopping Canasta (dev mode)\n")
@@ -243,7 +243,7 @@ func (c *ComposeOrchestrator) Destroy(installPath string) (string, error) {
 	return output, nil
 }
 
-func (c *ComposeOrchestrator) ListServices(instance config.Installation) ([]string, error) {
+func (c *ComposeOrchestrator) ListServices(instance config.Instance) ([]string, error) {
 	compose, err := c.getCompose()
 	if err != nil {
 		return nil, err
@@ -264,7 +264,7 @@ func (c *ComposeOrchestrator) ListServices(instance config.Installation) ([]stri
 	return services, nil
 }
 
-func (c *ComposeOrchestrator) ExecInteractive(instance config.Installation, service string, command []string) error {
+func (c *ComposeOrchestrator) ExecInteractive(instance config.Instance, service string, command []string) error {
 	compose, err := c.getCompose()
 	if err != nil {
 		return err
@@ -310,7 +310,7 @@ func (c *ComposeOrchestrator) ExecStreaming(installPath, service, command string
 	return nil
 }
 
-func (c *ComposeOrchestrator) CheckRunningStatus(instance config.Installation) error {
+func (c *ComposeOrchestrator) CheckRunningStatus(instance config.Instance) error {
 	containerName := "web"
 	compose, err := c.getCompose()
 	if err != nil {

--- a/internal/orchestrators/kubernetes.go
+++ b/internal/orchestrators/kubernetes.go
@@ -65,7 +65,7 @@ func (k *KubernetesOrchestrator) UpdateStackFiles(installPath string, dryRun boo
 	return updateStackFiles(kubernetes.StackFiles, "files/kubernetes", installPath, dryRun)
 }
 
-func (k *KubernetesOrchestrator) Start(instance config.Installation) error {
+func (k *KubernetesOrchestrator) Start(instance config.Instance) error {
 	// For kind-managed clusters, ensure the cluster exists (recreate if
 	// manually deleted) and set the kubectl context before applying.
 	if instance.KindCluster != "" {
@@ -101,7 +101,7 @@ func (k *KubernetesOrchestrator) Start(instance config.Installation) error {
 	return nil
 }
 
-func (k *KubernetesOrchestrator) Stop(instance config.Installation) error {
+func (k *KubernetesOrchestrator) Stop(instance config.Instance) error {
 	if instance.KindCluster != "" {
 		if err := setKindKubectlContext(instance.KindCluster); err != nil {
 			return err
@@ -178,7 +178,7 @@ func (k *KubernetesOrchestrator) Destroy(installPath string) (string, error) {
 	return string(output), nil
 }
 
-func (k *KubernetesOrchestrator) ListServices(instance config.Installation) ([]string, error) {
+func (k *KubernetesOrchestrator) ListServices(instance config.Instance) ([]string, error) {
 	if err := ensureKindContext(instance.Path); err != nil {
 		return nil, err
 	}
@@ -207,7 +207,7 @@ func (k *KubernetesOrchestrator) ListServices(instance config.Installation) ([]s
 	return services, nil
 }
 
-func (k *KubernetesOrchestrator) ExecInteractive(instance config.Installation, service string, command []string) error {
+func (k *KubernetesOrchestrator) ExecInteractive(instance config.Instance, service string, command []string) error {
 	if err := ensureKindContext(instance.Path); err != nil {
 		return err
 	}
@@ -279,7 +279,7 @@ func (k *KubernetesOrchestrator) ExecStreaming(installPath, service, command str
 	return nil
 }
 
-func (k *KubernetesOrchestrator) CheckRunningStatus(instance config.Installation) error {
+func (k *KubernetesOrchestrator) CheckRunningStatus(instance config.Instance) error {
 	// For kind-managed clusters, ensure the cluster exists and set context.
 	if instance.KindCluster != "" {
 		exists, err := kindClusterExists(instance.KindCluster)

--- a/internal/orchestrators/orchestrator.go
+++ b/internal/orchestrators/orchestrator.go
@@ -31,19 +31,19 @@ type Orchestrator interface {
 	CheckDependencies() error
 	WriteStackFiles(installPath string) error
 	UpdateStackFiles(installPath string, dryRun bool) (bool, error)
-	Start(instance config.Installation) error
-	Stop(instance config.Installation) error
+	Start(instance config.Instance) error
+	Stop(instance config.Instance) error
 	Update(installPath string) (*UpdateReport, error)
 	Destroy(installPath string) (string, error)
 	ExecWithError(installPath, service, command string) (string, error)
 	ExecStreaming(installPath, service, command string) error
-	CheckRunningStatus(instance config.Installation) error
+	CheckRunningStatus(instance config.Instance) error
 	CopyFrom(installPath, service, containerPath, hostPath string) error
 	CopyTo(installPath, service, hostPath, containerPath string) error
 	RunBackup(installPath, envPath string, volumes map[string]string, args ...string) (string, error)
 	RestoreFromBackupVolume(installPath string, dirs map[string]string) error
 
-	// InitConfig sets up orchestrator-specific configuration for a new installation.
+	// InitConfig sets up orchestrator-specific configuration for a new instance.
 	// Called once during "canasta create" after wikis.yaml and .env are in place.
 	InitConfig(installPath string) error
 
@@ -55,12 +55,12 @@ type Orchestrator interface {
 	// "canasta upgrade". Returns true if any changes were made.
 	MigrateConfig(installPath string, dryRun bool) (bool, error)
 
-	// ListServices returns the names of running services for the installation.
-	ListServices(instance config.Installation) ([]string, error)
+	// ListServices returns the names of running services for the instance.
+	ListServices(instance config.Instance) ([]string, error)
 
 	// ExecInteractive runs an interactive command in a service container with
 	// stdin/stdout/stderr attached. If command is nil, defaults to a shell.
-	ExecInteractive(instance config.Installation, service string, command []string) error
+	ExecInteractive(instance config.Instance, service string, command []string) error
 
 	// Name returns a human-readable name for the orchestrator (e.g. "Docker Compose").
 	Name() string
@@ -85,7 +85,7 @@ type UpdateReport struct {
 	UnchangedImages []ImageInfo // Images that remained the same
 }
 
-// DeleteConfig removes the installation directory from disk.
+// DeleteConfig removes the instance directory from disk.
 // This is a pure filesystem operation, not orchestrator-specific.
 func DeleteConfig(installPath string) (string, error) {
 	output, err := execute.Run("", "rm", "-rf", installPath)
@@ -102,7 +102,7 @@ func Exec(orch Orchestrator, installPath, service, command string) (string, erro
 }
 
 // StopAndStart stops and then starts the containers for an installation.
-func StopAndStart(orch Orchestrator, instance config.Installation) error {
+func StopAndStart(orch Orchestrator, instance config.Instance) error {
 	if err := orch.Stop(instance); err != nil {
 		return err
 	}
@@ -110,7 +110,7 @@ func StopAndStart(orch Orchestrator, instance config.Installation) error {
 }
 
 // EnsureRunning checks if containers are running and starts them if not.
-func EnsureRunning(orch Orchestrator, instance config.Installation) error {
+func EnsureRunning(orch Orchestrator, instance config.Instance) error {
 	if err := orch.CheckRunningStatus(instance); err != nil {
 		logging.Print("Containers not running, starting them...\n")
 		if err := orch.Start(instance); err != nil {
@@ -121,7 +121,7 @@ func EnsureRunning(orch Orchestrator, instance config.Installation) error {
 }
 
 // ImportDatabase copies a SQL dump into the db container and imports it.
-func ImportDatabase(orch Orchestrator, databaseName, databasePath, dbPassword string, instance config.Installation) error {
+func ImportDatabase(orch Orchestrator, databaseName, databasePath, dbPassword string, instance config.Instance) error {
 	dbUser := "root"
 	if dbPassword == "" {
 		dbPassword = "mediawiki"

--- a/internal/orchestrators/orchestrator_test.go
+++ b/internal/orchestrators/orchestrator_test.go
@@ -25,12 +25,12 @@ func (m *mockOrchestrator) UpdateStackFiles(_ string, _ bool) (bool, error) {
 	return false, nil
 }
 
-func (m *mockOrchestrator) Start(_ config.Installation) error {
+func (m *mockOrchestrator) Start(_ config.Instance) error {
 	m.calls = append(m.calls, "Start")
 	return m.startErr
 }
 
-func (m *mockOrchestrator) Stop(_ config.Installation) error {
+func (m *mockOrchestrator) Stop(_ config.Instance) error {
 	m.calls = append(m.calls, "Stop")
 	return m.stopErr
 }
@@ -52,7 +52,7 @@ func (m *mockOrchestrator) ExecStreaming(_, _, _ string) error {
 	return nil
 }
 
-func (m *mockOrchestrator) CheckRunningStatus(_ config.Installation) error {
+func (m *mockOrchestrator) CheckRunningStatus(_ config.Instance) error {
 	m.calls = append(m.calls, "CheckRunningStatus")
 	return m.checkRunningErr
 }
@@ -92,10 +92,10 @@ func (m *mockOrchestrator) MigrateConfig(_ string, _ bool) (bool, error) {
 	return false, nil
 }
 
-func (m *mockOrchestrator) ListServices(_ config.Installation) ([]string, error) {
+func (m *mockOrchestrator) ListServices(_ config.Instance) ([]string, error) {
 	return nil, nil
 }
-func (m *mockOrchestrator) ExecInteractive(_ config.Installation, _ string, _ []string) error {
+func (m *mockOrchestrator) ExecInteractive(_ config.Instance, _ string, _ []string) error {
 	return nil
 }
 func (m *mockOrchestrator) Name() string            { return "Mock" }
@@ -156,7 +156,7 @@ func TestExecError(t *testing.T) {
 
 func TestStopAndStart(t *testing.T) {
 	mock := &mockOrchestrator{}
-	instance := config.Installation{ID: "test", Path: "/tmp/test"}
+	instance := config.Instance{ID: "test", Path: "/tmp/test"}
 
 	err := StopAndStart(mock, instance)
 	if err != nil {
@@ -170,7 +170,7 @@ func TestStopAndStart(t *testing.T) {
 
 func TestStopAndStartStopError(t *testing.T) {
 	mock := &mockOrchestrator{stopErr: fmt.Errorf("stop failed")}
-	instance := config.Installation{ID: "test", Path: "/tmp/test"}
+	instance := config.Instance{ID: "test", Path: "/tmp/test"}
 
 	err := StopAndStart(mock, instance)
 	if err == nil {
@@ -187,7 +187,7 @@ func TestStopAndStartStopError(t *testing.T) {
 
 func TestImportDatabase(t *testing.T) {
 	mock := &mockOrchestrator{}
-	instance := config.Installation{ID: "test", Path: "/tmp/test"}
+	instance := config.Instance{ID: "test", Path: "/tmp/test"}
 
 	err := ImportDatabase(mock, "mywiki", "/path/to/dump.sql", "secret", instance)
 	if err != nil {
@@ -223,7 +223,7 @@ func TestImportDatabase(t *testing.T) {
 
 func TestImportDatabaseCompressed(t *testing.T) {
 	mock := &mockOrchestrator{}
-	instance := config.Installation{ID: "test", Path: "/tmp/test"}
+	instance := config.Instance{ID: "test", Path: "/tmp/test"}
 
 	err := ImportDatabase(mock, "mywiki", "/path/to/dump.sql.gz", "secret", instance)
 	if err != nil {
@@ -244,7 +244,7 @@ func TestImportDatabaseCompressed(t *testing.T) {
 
 func TestImportDatabaseCopyError(t *testing.T) {
 	mock := &mockOrchestrator{copyToErr: fmt.Errorf("copy failed")}
-	instance := config.Installation{ID: "test", Path: "/tmp/test"}
+	instance := config.Instance{ID: "test", Path: "/tmp/test"}
 
 	err := ImportDatabase(mock, "mywiki", "/path/to/dump.sql", "secret", instance)
 	if err == nil {
@@ -254,7 +254,7 @@ func TestImportDatabaseCopyError(t *testing.T) {
 
 func TestImportDatabaseDefaultPassword(t *testing.T) {
 	mock := &mockOrchestrator{}
-	instance := config.Installation{ID: "test", Path: "/tmp/test"}
+	instance := config.Instance{ID: "test", Path: "/tmp/test"}
 
 	err := ImportDatabase(mock, "mywiki", "/path/to/dump.sql", "", instance)
 	if err != nil {
@@ -359,7 +359,7 @@ func TestRunBackupError(t *testing.T) {
 
 func TestEnsureRunningAlreadyRunning(t *testing.T) {
 	mock := &mockOrchestrator{} // checkRunningErr is nil → containers already running
-	instance := config.Installation{ID: "test", Path: "/tmp/test"}
+	instance := config.Instance{ID: "test", Path: "/tmp/test"}
 
 	err := EnsureRunning(mock, instance)
 	if err != nil {
@@ -373,7 +373,7 @@ func TestEnsureRunningAlreadyRunning(t *testing.T) {
 
 func TestEnsureRunningNotRunning(t *testing.T) {
 	mock := &mockOrchestrator{checkRunningErr: fmt.Errorf("containers not running")}
-	instance := config.Installation{ID: "test", Path: "/tmp/test"}
+	instance := config.Instance{ID: "test", Path: "/tmp/test"}
 
 	err := EnsureRunning(mock, instance)
 	if err != nil {
@@ -390,7 +390,7 @@ func TestEnsureRunningStartFails(t *testing.T) {
 		checkRunningErr: fmt.Errorf("containers not running"),
 		startErr:        fmt.Errorf("start failed"),
 	}
-	instance := config.Installation{ID: "test", Path: "/tmp/test"}
+	instance := config.Instance{ID: "test", Path: "/tmp/test"}
 
 	err := EnsureRunning(mock, instance)
 	if err == nil {

--- a/internal/orchestrators/registry.go
+++ b/internal/orchestrators/registry.go
@@ -19,9 +19,9 @@ func New(orchestratorID string) (Orchestrator, error) {
 	}
 }
 
-// NewFromInstance creates an Orchestrator from a config.Installation, restoring
+// NewFromInstance creates an Orchestrator from a config.Instance, restoring
 // any orchestrator-specific state (e.g. ManagedCluster for Kubernetes).
-func NewFromInstance(instance config.Installation) (Orchestrator, error) {
+func NewFromInstance(instance config.Instance) (Orchestrator, error) {
 	orch, err := New(instance.Orchestrator)
 	if err != nil {
 		return nil, err

--- a/tools/wiki-publish/main.go
+++ b/tools/wiki-publish/main.go
@@ -66,7 +66,7 @@ func main() {
 		names   []string
 	}
 	cmdGroups := []cmdGroup{
-		{"Installation", []string{"create", "delete", "list", "upgrade", "version", "config"}},
+		{"Instance Management", []string{"create", "delete", "list", "upgrade", "version", "config"}},
 		{"Wiki Management", []string{"add", "remove", "import", "export"}},
 		{"Container Lifecycle", []string{"start", "stop", "restart"}},
 		{"Extensions & Skins", []string{"extension", "skin"}},

--- a/tools/wiki-publish/main_test.go
+++ b/tools/wiki-publish/main_test.go
@@ -32,16 +32,16 @@ func TestExtractDefault(t *testing.T) {
 func newTestCmd() *cobra.Command {
 	root := &cobra.Command{
 		Use:   "canasta",
-		Short: "Manage Canasta installations",
+		Short: "Manage Canasta instances",
 	}
 	child := &cobra.Command{
 		Use:     "create",
-		Short:   "Create a new installation",
-		Long:    "Create a new Canasta installation with all required services.",
+		Short:   "Create a new instance",
+		Long:    "Create a new Canasta instance with all required services.",
 		Example: "canasta create -i myinstance -w mywiki -n localhost",
 		Run:     func(cmd *cobra.Command, args []string) {},
 	}
-	child.Flags().StringP("id", "i", "", "Installation ID")
+	child.Flags().StringP("id", "i", "", "Instance ID")
 	//nolint:errcheck
 	child.MarkFlagRequired("id")
 	child.Flags().String("orchestrator", "docker-compose", "Container orchestrator (default: docker-compose)")
@@ -76,7 +76,7 @@ func TestGenWikitext(t *testing.T) {
 	}
 
 	// Short description
-	if !strings.Contains(text, "Create a new installation") {
+	if !strings.Contains(text, "Create a new instance") {
 		t.Error("expected short description")
 	}
 


### PR DESCRIPTION
## Summary
- Rename `Installation` struct to `Instance` and `Canasta.Installations` field to `Canasta.Instances` across 70 files
- Add backward-compatible conf.json migration: old `"Installations"` key is read via `LegacyInstallations` and automatically rewritten as `"Instances"` on first access
- Update all user-facing strings (cobra Short/Long/Example, fmt.Print messages, error messages, table headers) from "installation" to "instance"
- Update code comments and test assertions to match

Closes #697

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 70 files, all tests green)
- [x] Verify `canasta list` shows "Instance Path" column header
- [x] Verify `canasta --help` says "instances" not "installations"
- [x] Verify old conf.json with `"Installations"` key is auto-migrated on any command that reads config