### PR TITLE
fix: integration test failures (path resolution + private wiki health check)

### DIFF
--- a/tests/integration/gitops_test.go
+++ b/tests/integration/gitops_test.go
@@ -139,7 +139,7 @@ func TestGitops_InitAndPush(t *testing.T) {
 	}
 
 	// Stage and push the change
-	out, err = inst.run(t, "gitops", "add", "-i", inst.ID, "config/settings/global/GitopsTest.php")
+	out, err = inst.run(t, "gitops", "add", "-i", inst.ID, testFile)
 	if err != nil {
 		t.Fatalf("gitops add failed: %v\n%s", err, out)
 	}

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -186,6 +186,14 @@ func waitForWiki(t *testing.T, httpPort string, timeout time.Duration) {
 			t.Logf("Wiki is up at port %s", httpPort)
 			return
 		}
+		// Private wikis (DefaultSettings.php) return readapidenied for
+		// anonymous requests — this still means MediaWiki is running.
+		if errMap, ok := result["error"].(map[string]interface{}); ok {
+			if errMap["code"] == "readapidenied" {
+				t.Logf("Wiki is up at port %s (private wiki, read denied for anonymous)", httpPort)
+				return
+			}
+		}
 		lastErr = fmt.Sprintf("HTTP %d, no 'query' key in response", resp.StatusCode)
 		time.Sleep(5 * time.Second)
 	}


### PR DESCRIPTION
## Summary
Two fixes for integration test failures since 3.6.2:

1. **`gitops add` path resolution** — The test passed a relative path to `canasta gitops add`, but the test runner's working directory is the parent of the instance directory, so `resolveToInstallPath` (#695) couldn't find the file. Fixed by using the absolute path.

2. **Private wiki health check** — `DefaultSettings.php` (added in 3.6.2) makes new wikis private by default, so the unauthenticated `waitForWiki` API call gets `readapidenied` instead of `query` results. Fixed by accepting `readapidenied` as a valid "wiki is running" response.

Verified locally: `TestGitops_InitAndPush` passes in 42 seconds.

Fixes #699

## Test plan
- [x] `TestGitops_InitAndPush` passes locally
- [ ] All integration tests pass in CI after merge