### PR TITLE
fix: exit non-zero when wiki-publish fails to upload pages

### DIFF
--- a/tools/wiki-publish/main.go
+++ b/tools/wiki-publish/main.go
@@ -134,15 +134,20 @@ func main() {
 		log.Fatalf("Failed to login: %v", err)
 	}
 
+	var errCount int
 	for i, p := range pages {
 		if i > 0 {
 			time.Sleep(editDelay)
 		}
 		if err := client.editPage(p.Title, p.Content, "Update CLI reference"); err != nil {
 			log.Printf("ERROR uploading %s: %v", p.Title, err)
+			errCount++
 		} else {
 			log.Printf("Published %s", p.Title)
 		}
+	}
+	if errCount > 0 {
+		log.Fatalf("Failed to publish %d of %d pages", errCount, len(pages))
 	}
 	log.Printf("Done: %d pages published", len(pages))
 }


### PR DESCRIPTION
## Summary
- `wiki-publish` logged upload errors but always exited 0, causing CI to show green even when no pages were published
- Track error count and call `log.Fatalf` if any uploads failed

Fixes #701

## Test plan
- [ ] Merge and verify that the wiki-publish workflow correctly shows red if uploads fail, and green if all succeed