### PR TITLE
Add coverage collection for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,24 @@ jobs:
     - name: Vet
       run: go vet ./...
     - name: Test
-      run: go test -coverprofile=unit-coverage.out ./...
+      run: |
+        go test -cover ./... | tee test-output.txt
+        go test -coverprofile=unit-coverage.out ./... > /dev/null 2>&1
+    - name: Coverage summary
+      if: always() && hashFiles('unit-coverage.out') != ''
+      run: |
+        TOTAL=$(go tool cover -func=unit-coverage.out | tail -1 | awk '{print $NF}')
+        echo "## Unit Test Coverage: ${TOTAL}" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Package | Coverage |" >> "$GITHUB_STEP_SUMMARY"
+        echo "|---------|----------|" >> "$GITHUB_STEP_SUMMARY"
+        grep '^ok' test-output.txt \
+          | sed 's|github.com/CanastaWiki/Canasta-CLI/||' \
+          | awk '{printf "| %s | %s |\n", $2, $5}' \
+          | sort \
+          >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "**Total: ${TOTAL}**" >> "$GITHUB_STEP_SUMMARY"
     - name: Upload unit coverage
       if: always()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,11 @@ jobs:
     - name: Vet
       run: go vet ./...
     - name: Test
-      run: go test ./...
+      run: go test -coverprofile=unit-coverage.out ./...
+    - name: Upload unit coverage
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: unit-coverage
+        path: unit-coverage.out
+        if-no-files-found: warn

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,3 +33,12 @@ jobs:
       # sg runs the command under the www-data group (usermod doesn't
       # take effect in the current shell session).
       run: sg www-data -c "go test -tags integration -timeout 20m -v ./tests/integration/..."
+      env:
+        INTEGRATION_COVER_PROFILE: integration-coverage.out
+    - name: Upload integration coverage
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: integration-coverage
+        path: integration-coverage.out
+        if-no-files-found: warn

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,16 +29,49 @@ jobs:
       # (e.g. config/) become owned by that group. The host user must be
       # in the www-data group to write files back into them.
       run: sudo usermod -aG www-data $(whoami)
+    - name: Run unit tests with coverage
+      run: go test -coverprofile=unit-coverage.out ./...
     - name: Run integration tests
       # sg runs the command under the www-data group (usermod doesn't
       # take effect in the current shell session).
       run: sg www-data -c "go test -tags integration -timeout 20m -v ./tests/integration/..."
       env:
         INTEGRATION_COVER_PROFILE: integration-coverage.out
+    - name: Coverage summary
+      if: always() && hashFiles('unit-coverage.out') != ''
+      run: |
+        UNIT_TOTAL=$(go tool cover -func=unit-coverage.out | tail -1 | awk '{print $NF}')
+
+        if [ -f integration-coverage.out ]; then
+          # Merge unit and integration profiles
+          echo "mode: set" > combined-coverage.out
+          tail -n +2 unit-coverage.out >> combined-coverage.out
+          tail -n +2 integration-coverage.out >> combined-coverage.out
+          COMBINED_TOTAL=$(go tool cover -func=combined-coverage.out | tail -1 | awk '{print $NF}')
+          echo "## Combined Test Coverage: ${COMBINED_TOTAL}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Unit: ${UNIT_TOTAL} | Combined (unit + integration): ${COMBINED_TOTAL}" >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo "## Unit Test Coverage: ${UNIT_TOTAL}" >> "$GITHUB_STEP_SUMMARY"
+          echo "(Integration coverage profile not available)" >> "$GITHUB_STEP_SUMMARY"
+        fi
+    - name: Upload unit coverage
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: unit-coverage
+        path: unit-coverage.out
+        if-no-files-found: warn
     - name: Upload integration coverage
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: integration-coverage
         path: integration-coverage.out
+        if-no-files-found: warn
+    - name: Upload combined coverage
+      if: always() && hashFiles('combined-coverage.out') != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: combined-coverage
+        path: combined-coverage.out
         if-no-files-found: warn

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,23 @@ lint:
 		@printf "\e[1;36m>> golangci-lint\e[0m\n"
 		@golangci-lint run ./...
 
+test-cover:
+		go test -coverprofile=unit-coverage.out ./...
+		@echo "Unit coverage written to unit-coverage.out"
+
+integration-cover:
+		INTEGRATION_COVER_PROFILE=integration-coverage.out \
+		go test -tags integration -timeout 20m -v ./tests/integration/...
+		@echo "Integration coverage written to integration-coverage.out"
+
+coverage-report: unit-coverage.out integration-coverage.out
+		@echo "mode: set" > combined-coverage.out
+		@tail -n +2 unit-coverage.out >> combined-coverage.out
+		@tail -n +2 integration-coverage.out >> combined-coverage.out
+		@go tool cover -func=combined-coverage.out | tail -1
+		@echo "Full report: go tool cover -func=combined-coverage.out"
+		@echo "HTML report: go tool cover -html=combined-coverage.out -o coverage.html"
+
 help:
 		@printf "\n"
 		@printf "\e[1mUsage:\e[0m\n"
@@ -44,5 +61,10 @@ help:
 		@printf "  \e[36mprepare-lint\e[0m         Install golangci-lint. This is used in CI, you should probably install golangci-lint using your package manager.\n"
 		@printf "  \e[36mlint\e[0m                     Run lint.\n"
 		@printf "\n"
+		@printf "\e[1mCoverage\e[0m\n"
+		@printf "  \e[36mtest-cover\e[0m               Run unit tests with coverage.\n"
+		@printf "  \e[36mintegration-cover\e[0m        Run integration tests with coverage (requires Docker).\n"
+		@printf "  \e[36mcoverage-report\e[0m          Merge unit and integration profiles and show combined coverage.\n"
+		@printf "\n"
 
-.PHONY: build install clean prepare-lint lint help
+.PHONY: build install clean prepare-lint lint test-cover integration-cover coverage-report help

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -18,6 +18,11 @@ import (
 // canastaBin is the path to the built CLI binary, set once in TestMain.
 var canastaBin string
 
+// coverDir is the directory where the coverage-instrumented binary writes
+// its coverage data. Each invocation appends a unique file, so all test
+// runs can share a single directory without conflicts.
+var coverDir string
+
 // portCounter is an atomic counter for assigning unique ports to each test instance.
 var portCounter uint32 = 10080
 
@@ -31,9 +36,13 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "failed to create temp dir: %v\n", err)
 		os.Exit(1)
 	}
-	defer os.RemoveAll(tmpDir)
 
 	binPath := filepath.Join(tmpDir, "canasta")
+	covDataDir := filepath.Join(tmpDir, "covdata")
+	if err := os.MkdirAll(covDataDir, 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create coverage dir: %v\n", err)
+		os.Exit(1)
+	}
 
 	// Read the CANASTA_VERSION file to set DefaultImageTag
 	versionBytes, err := os.ReadFile("../../CANASTA_VERSION")
@@ -43,8 +52,14 @@ func TestMain(m *testing.M) {
 	}
 	imageTag := strings.TrimSpace(string(versionBytes))
 
+	// Build with -cover so the binary writes coverage data to GOCOVERDIR
+	// on each invocation. The -coverpkg flag ensures all packages are
+	// instrumented, not just the main package.
 	ldflags := fmt.Sprintf("-X 'github.com/CanastaWiki/Canasta-CLI/internal/canasta.DefaultImageTag=%s'", imageTag)
-	cmd := exec.Command("go", "build", "-ldflags", ldflags, "-o", binPath, "../../canasta.go")
+	cmd := exec.Command("go", "build",
+		"-cover", "-coverpkg=./...",
+		"-ldflags", ldflags,
+		"-o", binPath, "../../canasta.go")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -53,7 +68,42 @@ func TestMain(m *testing.M) {
 	}
 
 	canastaBin = binPath
-	os.Exit(m.Run())
+	coverDir = covDataDir
+
+	exitCode := m.Run()
+
+	// Export coverage data collected from all binary invocations.
+	exportIntegrationCoverage(covDataDir)
+
+	os.RemoveAll(tmpDir)
+	os.Exit(exitCode)
+}
+
+// exportIntegrationCoverage converts the binary coverage data written by
+// the instrumented CLI into a standard Go coverage profile. The output
+// path defaults to "integration-coverage.out" but can be overridden with
+// the INTEGRATION_COVER_PROFILE environment variable.
+func exportIntegrationCoverage(covDataDir string) {
+	outFile := os.Getenv("INTEGRATION_COVER_PROFILE")
+	if outFile == "" {
+		outFile = "integration-coverage.out"
+	}
+
+	entries, err := os.ReadDir(covDataDir)
+	if err != nil || len(entries) == 0 {
+		fmt.Fprintf(os.Stderr, "no integration coverage data collected\n")
+		return
+	}
+
+	cmd := exec.Command("go", "tool", "covdata", "textfmt",
+		"-i="+covDataDir, "-o="+outFile)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to convert coverage data: %v\n", err)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "integration coverage written to %s\n", outFile)
 }
 
 // testInstance holds the state for an isolated integration test instance.
@@ -134,7 +184,10 @@ func createTestInstance(t *testing.T, id string) *testInstance {
 func (inst *testInstance) run(t *testing.T, args ...string) (string, error) {
 	t.Helper()
 	cmd := exec.Command(canastaBin, args...)
-	cmd.Env = append(os.Environ(), "CANASTA_CONFIG_DIR="+inst.ConfigDir)
+	cmd.Env = append(os.Environ(),
+		"CANASTA_CONFIG_DIR="+inst.ConfigDir,
+		"GOCOVERDIR="+coverDir,
+	)
 	cmd.Dir = inst.WorkDir
 	out, err := cmd.CombinedOutput()
 	t.Logf("canasta %v:\n%s", args, string(out))
@@ -146,7 +199,10 @@ func (inst *testInstance) run(t *testing.T, args ...string) (string, error) {
 func runCanasta(t *testing.T, configDir string, args ...string) (string, error) {
 	t.Helper()
 	cmd := exec.Command(canastaBin, args...)
-	cmd.Env = append(os.Environ(), "CANASTA_CONFIG_DIR="+configDir)
+	cmd.Env = append(os.Environ(),
+		"CANASTA_CONFIG_DIR="+configDir,
+		"GOCOVERDIR="+coverDir,
+	)
 	out, err := cmd.CombinedOutput()
 	t.Logf("canasta %v:\n%s", args, string(out))
 	return string(out), err


### PR DESCRIPTION
## Summary

- Build the integration test CLI binary with Go's `-cover` flag so each invocation writes coverage data to `GOCOVERDIR`
- After all tests complete, convert binary coverage data to a standard Go coverage profile
- Upload unit and integration coverage profiles as CI artifacts
- Add Makefile targets (`test-cover`, `integration-cover`, `coverage-report`) for local use
- Show per-package coverage table in CI step summaries on every PR
- Show combined (unit + integration) coverage total in integration workflow summary

The instrumented binary is only used during testing — it adds negligible overhead (atomic counter increments) and is never shipped.

Unit tests alone cover ~30% of statements. The existing 6 integration tests exercise ~1,150 additional statements across 23 packages (orchestrator interactions, command workflows, MediaWiki installation). Combined coverage is estimated at ~49%.

Closes #705

## Test plan

- [x] CI passes (unit tests build and run with `-coverprofile`)
- [ ] Integration tests pass with the instrumented binary (next push to main)
- [ ] `integration-coverage.out` artifact is uploaded after integration run
- [ ] Coverage summary table appears in CI step summary
- [ ] Combined coverage total appears in integration workflow summary
- [x] `make test-cover` produces `unit-coverage.out` locally
- [x] `make coverage-report` merges profiles and reports combined coverage