### PR TITLE
test: add unit tests for purgeFromLine

### DIFF
--- a/cmd/backup/schedule_test.go
+++ b/cmd/backup/schedule_test.go
@@ -70,3 +70,51 @@ func TestValidateCronEdgeCases(t *testing.T) {
 		})
 	}
 }
+
+func TestPurgeFromLine(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{
+			name: "unquoted value",
+			line: "0 2 * * * /usr/local/bin/canasta backup create -i wiki && canasta backup purge -i wiki --older-than 30d >> backup.log 2>&1",
+			want: "30d",
+		},
+		{
+			name: "double-quoted value",
+			line: `0 2 * * * /usr/local/bin/canasta backup create -i wiki && canasta backup purge -i wiki --older-than "30d" >> backup.log 2>&1`,
+			want: "30d",
+		},
+		{
+			name: "single-quoted value",
+			line: "0 2 * * * /usr/local/bin/canasta backup create -i wiki && canasta backup purge -i wiki --older-than '30d' >> backup.log 2>&1",
+			want: "30d",
+		},
+		{
+			name: "no flag present",
+			line: "0 2 * * * /usr/local/bin/canasta backup create -i wiki --tag scheduled >> backup.log 2>&1",
+			want: "",
+		},
+		{
+			name: "multiple flags including older-than",
+			line: "0 2 * * * /usr/local/bin/canasta backup create -i wiki --tag scheduled && canasta backup purge -i wiki --older-than 6m --verbose >> backup.log 2>&1",
+			want: "6m",
+		},
+		{
+			name: "empty line",
+			line: "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := purgeFromLine(tt.line)
+			if got != tt.want {
+				t.Errorf("purgeFromLine(%q) = %q, want %q", tt.line, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The pull request adds unit tests for the `purgeFromLine` function in `cmd/backup/schedule.go`.

As mentioned in the issue the tests covers:
- Unquoted value (`30d`)
- Double-quoted value (`"30d"`)
- Single-quoted value (`'30d'`)
- No flag present
- Multiple flags including `--older-than`
- Empty line

```
kajal@kajal-HP-Pavilion-Laptop-15-eh2xxx:~/Canasta-CLI$ go test ./cmd/backup/... -run TestPurgeFromLine -v
=== RUN   TestPurgeFromLine
=== RUN   TestPurgeFromLine/unquoted_value
=== RUN   TestPurgeFromLine/double-quoted_value
=== RUN   TestPurgeFromLine/single-quoted_value
=== RUN   TestPurgeFromLine/no_flag_present
=== RUN   TestPurgeFromLine/multiple_flags_including_older-than
=== RUN   TestPurgeFromLine/empty_line
--- PASS: TestPurgeFromLine (0.00s)
    --- PASS: TestPurgeFromLine/unquoted_value (0.00s)
    --- PASS: TestPurgeFromLine/double-quoted_value (0.00s)
    --- PASS: TestPurgeFromLine/single-quoted_value (0.00s)
    --- PASS: TestPurgeFromLine/no_flag_present (0.00s)
    --- PASS: TestPurgeFromLine/multiple_flags_including_older-than (0.00s)
    --- PASS: TestPurgeFromLine/empty_line (0.00s)
PASS
ok      github.com/CanastaWiki/Canasta-CLI/cmd/backup   
```


Fixes: #614 