### PR TITLE
fix: collect integration test coverage in CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,7 +36,7 @@ jobs:
       # take effect in the current shell session).
       run: sg www-data -c "go test -tags integration -timeout 20m -v ./tests/integration/..."
       env:
-        INTEGRATION_COVER_PROFILE: integration-coverage.out
+        INTEGRATION_COVER_PROFILE: ${{ github.workspace }}/integration-coverage.out
     - name: Coverage summary
       if: always() && hashFiles('unit-coverage.out') != ''
       run: |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -290,9 +290,6 @@ func Add(details Instance) error {
 	if exists {
 		return fmt.Errorf("canasta ID is already used for another instance")
 	}
-	if existingInstances.Instances == nil {
-		existingInstances.Instances = map[string]Instance{}
-	}
 	existingInstances.Instances[details.ID] = details
 	return write(existingInstances)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -290,6 +290,9 @@ func Add(details Instance) error {
 	if exists {
 		return fmt.Errorf("canasta ID is already used for another instance")
 	}
+	if existingInstances.Instances == nil {
+		existingInstances.Instances = map[string]Instance{}
+	}
 	existingInstances.Instances[details.ID] = details
 	return write(existingInstances)
 }

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -59,7 +59,7 @@ func TestMain(m *testing.M) {
 	cmd := exec.Command("go", "build",
 		"-cover", "-coverpkg=github.com/CanastaWiki/Canasta-CLI/...",
 		"-ldflags", ldflags,
-		"-o", binPath, "../../canasta.go")
+		"-o", binPath, "github.com/CanastaWiki/Canasta-CLI")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
## Summary
- Use full module path as build target — `go build -cover` only instruments packages, not individual files (`../../canasta.go`)
- Use absolute path for `INTEGRATION_COVER_PROFILE` so the coverage file lands at the repo root instead of `tests/integration/`
- Guard against nil `Instances` map in `config.Add()` which panics when `conf.json` exists but is empty

## Test plan
- [ ] Integration workflow produces and uploads `integration-coverage.out` artifact
- [ ] Coverage summary shows combined (unit + integration) total
- [ ] `canasta create` works with an empty `conf.json`

Fixes #716