### PR TITLE
fix: guard against nil Instances map in config.Add()

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -290,6 +290,9 @@ func Add(details Instance) error {
 	if exists {
 		return fmt.Errorf("canasta ID is already used for another instance")
 	}
+	if existingInstances.Instances == nil {
+		existingInstances.Instances = map[string]Instance{}
+	}
 	existingInstances.Instances[details.ID] = details
 	return write(existingInstances)
 }


### PR DESCRIPTION
## Summary
- Add nil check for `existingInstances.Instances` in `config.Add()` before map assignment
- Prevents panic when `conf.json` exists but is empty or has null `Instances` field
- Matches the pattern already used in `AddOrchestrator()`

## Test plan
- [ ] `canasta create` succeeds with an empty `conf.json`
- [ ] `canasta create` succeeds with a normal `conf.json`

Fixes #718