### PR TITLE
Remove unused Orchestrators field from conf.json

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,12 +25,7 @@ type Instance struct {
 	BuildFrom      string `json:"buildFrom,omitempty"`
 }
 
-type Orchestrator struct {
-	ID, Path string
-}
-
 type Canasta struct {
-	Orchestrators       map[string]Orchestrator
 	Instances           map[string]Instance `json:"Instances"`
 	LegacyInstallations map[string]Instance `json:"Installations,omitempty"`
 }
@@ -64,7 +59,7 @@ func ensureInitialized() error {
 		_, err = os.Stat(confFile)
 		if os.IsNotExist(err) {
 			// Creating conf.json
-			if err := write(Canasta{Instances: map[string]Instance{}, Orchestrators: map[string]Orchestrator{}}); err != nil {
+			if err := write(Canasta{Instances: map[string]Instance{}}); err != nil {
 				initErr = err
 				return
 			}
@@ -123,17 +118,6 @@ func Exists(canastaID string) (bool, error) {
 	return existingInstances.Instances[canastaID].ID != "", nil
 }
 
-func OrchestratorExists(orchestrator string) (bool, error) {
-	if err := ensureInitialized(); err != nil {
-		return false, err
-	}
-	err := read(&existingInstances)
-	if err != nil {
-		return false, err
-	}
-	return existingInstances.Orchestrators[orchestrator].Path != "", nil
-}
-
 func ListAll(w io.Writer) error {
 	if err := ensureInitialized(); err != nil {
 		return err
@@ -189,7 +173,9 @@ func ListAll(w io.Writer) error {
 
 		ids, serverNames, paths, err := farmsettings.ReadWikisYaml(filepath.Join(instance.Path, "config", "wikis.yaml"))
 		if err != nil {
-			fmt.Printf("Error reading wikis.yaml for instance ID '%s': %s\n", instance.ID, err)
+			if _, werr := fmt.Fprintf(w, "Error reading wikis.yaml for instance ID '%s': %s\n", instance.ID, err); werr != nil {
+				return werr
+			}
 			continue
 		}
 
@@ -295,40 +281,6 @@ func Add(details Instance) error {
 	}
 	existingInstances.Instances[details.ID] = details
 	return write(existingInstances)
-}
-
-func AddOrchestrator(details Orchestrator) error {
-	if err := ensureInitialized(); err != nil {
-		return err
-	}
-	if existingInstances.Orchestrators == nil {
-		existingInstances.Orchestrators = map[string]Orchestrator{}
-	}
-	supportedOrchestrators := map[string]bool{
-		"compose":    true,
-		"kubernetes": true,
-		"k8s":        true,
-	}
-	if !supportedOrchestrators[details.ID] {
-		return fmt.Errorf("orchestrator %s is not supported", details.ID)
-	}
-	existingInstances.Orchestrators[details.ID] = details
-	err := write(existingInstances)
-	return err
-}
-
-func GetOrchestrator(orchestrator string) (Orchestrator, error) {
-	if err := ensureInitialized(); err != nil {
-		return Orchestrator{}, err
-	}
-	exists, err := OrchestratorExists(orchestrator)
-	if err != nil {
-		return Orchestrator{}, err
-	}
-	if exists {
-		return existingInstances.Orchestrators[orchestrator], nil
-	}
-	return Orchestrator{}, nil
 }
 
 func Delete(canastaID string) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -206,32 +206,6 @@ func TestGetCanastaIDFromSubdirectory(t *testing.T) {
 	}
 }
 
-func TestAddOrchestratorSupported(t *testing.T) {
-	tests := []struct {
-		name    string
-		id      string
-		wantErr bool
-	}{
-		{"compose accepted", "compose", false},
-		{"kubernetes accepted", "kubernetes", false},
-		{"k8s alias accepted", "k8s", false},
-		{"unknown rejected", "nomad", true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			setupTestDir(t)
-			err := AddOrchestrator(Orchestrator{ID: tt.id, Path: "/usr/bin/test"})
-			if (err != nil) != tt.wantErr {
-				t.Errorf("AddOrchestrator(%q) error = %v, wantErr %v", tt.id, err, tt.wantErr)
-			}
-			if tt.wantErr && err != nil && !strings.Contains(err.Error(), "not supported") {
-				t.Errorf("AddOrchestrator(%q) error = %q, want 'not supported'", tt.id, err.Error())
-			}
-		})
-	}
-}
-
 func TestBuildFromRoundTrip(t *testing.T) {
 	dir := setupTestDir(t)
 

--- a/internal/orchestrators/compose.go
+++ b/internal/orchestrators/compose.go
@@ -28,37 +28,44 @@ func (c *ComposeOrchestrator) Name() string            { return "Docker Compose"
 func (c *ComposeOrchestrator) SupportsDevMode() bool   { return true }
 func (c *ComposeOrchestrator) SupportsImagePull() bool { return true }
 
-// getCompose returns the configured compose orchestrator path.
-func (c *ComposeOrchestrator) getCompose() (config.Orchestrator, error) {
-	return config.GetOrchestrator("compose")
+type composeBinary struct {
+	Path string
+}
+
+// getCompose discovers the compose binary at runtime.
+func (c *ComposeOrchestrator) getCompose() (composeBinary, error) {
+	if path, err := exec.LookPath("docker-compose"); err == nil {
+		return composeBinary{Path: path}, nil
+	}
+	return composeBinary{}, nil
 }
 
 // runCompose runs a compose command via execute.Run and returns the output.
-func runCompose(installPath string, compose config.Orchestrator, args ...string) (string, error) {
-	if compose.Path != "" {
-		return execute.Run(installPath, compose.Path, args...)
+func runCompose(installPath string, composeBin composeBinary, args ...string) (string, error) {
+	if composeBin.Path != "" {
+		return execute.Run(installPath, composeBin.Path, args...)
 	}
 	allArgs := append([]string{"compose"}, args...)
 	return execute.Run(installPath, "docker", allArgs...)
 }
 
 // composeCommand returns an exec.Cmd configured for the compose orchestrator.
-func composeCommand(compose config.Orchestrator, args ...string) *exec.Cmd {
-	if compose.Path != "" {
-		// compose.Path is from system lookup.
+func composeCommand(composeBin composeBinary, args ...string) *exec.Cmd {
+	if composeBin.Path != "" {
+		// composeBin.Path is from system lookup.
 		//nolint:gosec
-		return exec.Command(compose.Path, args...)
+		return exec.Command(composeBin.Path, args...)
 	}
 	allArgs := append([]string{"compose"}, args...)
 	return exec.Command("docker", allArgs...)
 }
 
 func (c *ComposeOrchestrator) CheckDependencies() error {
-	compose, err := c.getCompose()
+	composeBin, err := c.getCompose()
 	if err != nil {
 		return err
 	}
-	cmd := composeCommand(compose, "version")
+	cmd := composeCommand(composeBin, "version")
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("docker compose is not available: %w", err)
 	}
@@ -112,7 +119,7 @@ func (c *ComposeOrchestrator) Start(instance config.Instance) error {
 		logging.Print("Starting Canasta\n")
 	}
 
-	compose, err := c.getCompose()
+	composeBin, err := c.getCompose()
 	if err != nil {
 		return err
 	}
@@ -121,7 +128,7 @@ func (c *ComposeOrchestrator) Start(instance config.Instance) error {
 		args = append(args, "-f", f)
 	}
 	args = append(args, "up", "-d")
-	output, err := runCompose(instance.Path, compose, args...)
+	output, err := runCompose(instance.Path, composeBin, args...)
 	if err != nil {
 		return fmt.Errorf("failed to start containers at %s: %s", instance.Path, output)
 	}
@@ -137,7 +144,7 @@ func (c *ComposeOrchestrator) Stop(instance config.Instance) error {
 		logging.Print("Stopping the containers\n")
 	}
 
-	compose, err := c.getCompose()
+	composeBin, err := c.getCompose()
 	if err != nil {
 		return err
 	}
@@ -146,7 +153,7 @@ func (c *ComposeOrchestrator) Stop(instance config.Instance) error {
 		args = append(args, "-f", f)
 	}
 	args = append(args, "down")
-	output, err := runCompose(instance.Path, compose, args...)
+	output, err := runCompose(instance.Path, composeBin, args...)
 	if err != nil {
 		return fmt.Errorf("failed to stop containers at %s: %s", instance.Path, output)
 	}
@@ -155,11 +162,11 @@ func (c *ComposeOrchestrator) Stop(instance config.Instance) error {
 
 func (c *ComposeOrchestrator) Pull(installPath string) error {
 	logging.Print("Pulling Canasta image\n")
-	compose, err := c.getCompose()
+	composeBin, err := c.getCompose()
 	if err != nil {
 		return err
 	}
-	output, err := runCompose(installPath, compose, "pull", "--ignore-buildable", "--ignore-pull-failures")
+	output, err := runCompose(installPath, composeBin, "pull", "--ignore-buildable", "--ignore-pull-failures")
 	if err != nil {
 		return fmt.Errorf("failed to pull images at %s: %s", installPath, output)
 	}
@@ -168,25 +175,25 @@ func (c *ComposeOrchestrator) Pull(installPath string) error {
 
 func (c *ComposeOrchestrator) Update(installPath string) (*UpdateReport, error) {
 	report := &UpdateReport{}
-	compose, err := c.getCompose()
+	composeBin, err := c.getCompose()
 	if err != nil {
 		return nil, err
 	}
 
 	// Get image info before pull
-	beforeImages, err := getComposeImages(installPath, compose)
+	beforeImages, err := getComposeImages(installPath, composeBin)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get images before pull: %w", err)
 	}
 
 	// Run pull
-	output, err := runCompose(installPath, compose, "pull", "--ignore-buildable", "--ignore-pull-failures")
+	output, err := runCompose(installPath, composeBin, "pull", "--ignore-buildable", "--ignore-pull-failures")
 	if err != nil {
 		return nil, fmt.Errorf("failed to pull images for update at %s: %s", installPath, output)
 	}
 
 	// Get image info after pull
-	afterImages, err := getComposeImages(installPath, compose)
+	afterImages, err := getComposeImages(installPath, composeBin)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get images after pull: %w", err)
 	}
@@ -209,7 +216,7 @@ func (c *ComposeOrchestrator) Update(installPath string) (*UpdateReport, error) 
 
 func (c *ComposeOrchestrator) Build(installPath string, files ...string) error {
 	logging.Print("Building images\n")
-	compose, err := c.getCompose()
+	composeBin, err := c.getCompose()
 	if err != nil {
 		return err
 	}
@@ -218,7 +225,7 @@ func (c *ComposeOrchestrator) Build(installPath string, files ...string) error {
 		args = append(args, "-f", f)
 	}
 	args = append(args, "build")
-	output, err := runCompose(installPath, compose, args...)
+	output, err := runCompose(installPath, composeBin, args...)
 	if err != nil {
 		return fmt.Errorf("failed to build images at %s: %s", installPath, output)
 	}
@@ -226,11 +233,11 @@ func (c *ComposeOrchestrator) Build(installPath string, files ...string) error {
 }
 
 func (c *ComposeOrchestrator) Destroy(installPath string) (string, error) {
-	compose, err := c.getCompose()
+	composeBin, err := c.getCompose()
 	if err != nil {
 		return "", err
 	}
-	output, err := runCompose(installPath, compose, "down", "-v")
+	output, err := runCompose(installPath, composeBin, "down", "-v")
 	if err != nil {
 		return output, err
 	}
@@ -244,11 +251,11 @@ func (c *ComposeOrchestrator) Destroy(installPath string) (string, error) {
 }
 
 func (c *ComposeOrchestrator) ListServices(instance config.Instance) ([]string, error) {
-	compose, err := c.getCompose()
+	composeBin, err := c.getCompose()
 	if err != nil {
 		return nil, err
 	}
-	cmd := composeCommand(compose, "ps", "--services")
+	cmd := composeCommand(composeBin, "ps", "--services")
 	cmd.Dir = instance.Path
 	outputByte, err := cmd.CombinedOutput()
 	if err != nil {
@@ -265,12 +272,12 @@ func (c *ComposeOrchestrator) ListServices(instance config.Instance) ([]string, 
 }
 
 func (c *ComposeOrchestrator) ExecInteractive(instance config.Instance, service string, command []string) error {
-	compose, err := c.getCompose()
+	composeBin, err := c.getCompose()
 	if err != nil {
 		return err
 	}
 	args := append([]string{"exec", service}, command...)
-	cmd := composeCommand(compose, args...)
+	cmd := composeCommand(composeBin, args...)
 	cmd.Dir = instance.Path
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
@@ -279,11 +286,11 @@ func (c *ComposeOrchestrator) ExecInteractive(instance config.Instance, service 
 }
 
 func (c *ComposeOrchestrator) ExecWithError(installPath, service, command string) (string, error) {
-	compose, err := c.getCompose()
+	composeBin, err := c.getCompose()
 	if err != nil {
 		return "", err
 	}
-	cmd := composeCommand(compose, "exec", "-T", service, "/bin/bash", "-c", command)
+	cmd := composeCommand(composeBin, "exec", "-T", service, "/bin/bash", "-c", command)
 	if installPath != "" {
 		cmd.Dir = installPath
 	}
@@ -294,11 +301,11 @@ func (c *ComposeOrchestrator) ExecWithError(installPath, service, command string
 }
 
 func (c *ComposeOrchestrator) ExecStreaming(installPath, service, command string) error {
-	compose, err := c.getCompose()
+	composeBin, err := c.getCompose()
 	if err != nil {
 		return err
 	}
-	cmd := composeCommand(compose, "exec", "-T", service, "/bin/bash", "-c", command)
+	cmd := composeCommand(composeBin, "exec", "-T", service, "/bin/bash", "-c", command)
 	if installPath != "" {
 		cmd.Dir = installPath
 	}
@@ -312,11 +319,11 @@ func (c *ComposeOrchestrator) ExecStreaming(installPath, service, command string
 
 func (c *ComposeOrchestrator) CheckRunningStatus(instance config.Instance) error {
 	containerName := "web"
-	compose, err := c.getCompose()
+	composeBin, err := c.getCompose()
 	if err != nil {
 		return err
 	}
-	output, err := runCompose(instance.Path, compose, "ps", "-q", containerName)
+	output, err := runCompose(instance.Path, composeBin, "ps", "-q", containerName)
 	if err != nil || output == "" {
 		return fmt.Errorf("container %s is not running", containerName)
 	}
@@ -324,11 +331,11 @@ func (c *ComposeOrchestrator) CheckRunningStatus(instance config.Instance) error
 }
 
 func (c *ComposeOrchestrator) CopyFrom(installPath, service, containerPath, hostPath string) error {
-	compose, err := c.getCompose()
+	composeBin, err := c.getCompose()
 	if err != nil {
 		return err
 	}
-	cmd := composeCommand(compose, "cp", service+":"+containerPath, hostPath)
+	cmd := composeCommand(composeBin, "cp", service+":"+containerPath, hostPath)
 	if installPath != "" {
 		cmd.Dir = installPath
 	}
@@ -340,11 +347,11 @@ func (c *ComposeOrchestrator) CopyFrom(installPath, service, containerPath, host
 }
 
 func (c *ComposeOrchestrator) CopyTo(installPath, service, hostPath, containerPath string) error {
-	compose, err := c.getCompose()
+	composeBin, err := c.getCompose()
 	if err != nil {
 		return err
 	}
-	cmd := composeCommand(compose, "cp", hostPath, service+":"+containerPath)
+	cmd := composeCommand(composeBin, "cp", hostPath, service+":"+containerPath)
 	if installPath != "" {
 		cmd.Dir = installPath
 	}
@@ -427,8 +434,8 @@ type composeImageEntry struct {
 }
 
 // getComposeImages returns a map of service name to ImageInfo.
-func getComposeImages(installPath string, compose config.Orchestrator) (map[string]ImageInfo, error) {
-	output, err := runCompose(installPath, compose, "images", "--format", "json")
+func getComposeImages(installPath string, composeBin composeBinary) (map[string]ImageInfo, error) {
+	output, err := runCompose(installPath, composeBin, "images", "--format", "json")
 	if err != nil {
 		return nil, fmt.Errorf("failed to run docker compose images: %s", output)
 	}


### PR DESCRIPTION
Removes the unused Orchestrators entry from conf.json handling in internal/config.
Deletes obsolete orchestrator config APIs: AddOrchestrator, GetOrchestrator, and OrchestratorExists.
Stops initializing an empty Orchestrators map in ensureInitialized.
Updates Compose runtime behavior to resolve the compose binary at runtime instead of reading it from config.
Removes tests that only covered the deleted orchestrator config APIs.