### PR TITLE
Simplify compose abstraction: remove LookPath, always use docker compose

### DIFF
--- a/internal/orchestrators/compose.go
+++ b/internal/orchestrators/compose.go
@@ -28,46 +28,20 @@ func (c *ComposeOrchestrator) Name() string            { return "Docker Compose"
 func (c *ComposeOrchestrator) SupportsDevMode() bool   { return true }
 func (c *ComposeOrchestrator) SupportsImagePull() bool { return true }
 
-type composeBinary struct {
-	Path string
-}
-
-// getCompose discovers the compose binary at runtime.
-//
-//nolint:unparam // error return removed in #728
-func (c *ComposeOrchestrator) getCompose() (composeBinary, error) {
-	if path, err := exec.LookPath("docker-compose"); err == nil {
-		return composeBinary{Path: path}, nil
-	}
-	return composeBinary{}, nil
-}
-
-// runCompose runs a compose command via execute.Run and returns the output.
-func runCompose(installPath string, composeBin composeBinary, args ...string) (string, error) {
-	if composeBin.Path != "" {
-		return execute.Run(installPath, composeBin.Path, args...)
-	}
+// runCompose runs a docker compose command via execute.Run and returns the output.
+func runCompose(installPath string, args ...string) (string, error) {
 	allArgs := append([]string{"compose"}, args...)
 	return execute.Run(installPath, "docker", allArgs...)
 }
 
-// composeCommand returns an exec.Cmd configured for the compose orchestrator.
-func composeCommand(composeBin composeBinary, args ...string) *exec.Cmd {
-	if composeBin.Path != "" {
-		// composeBin.Path is from system lookup.
-		//nolint:gosec
-		return exec.Command(composeBin.Path, args...)
-	}
+// composeCommand returns an exec.Cmd configured for docker compose.
+func composeCommand(args ...string) *exec.Cmd {
 	allArgs := append([]string{"compose"}, args...)
 	return exec.Command("docker", allArgs...)
 }
 
 func (c *ComposeOrchestrator) CheckDependencies() error {
-	composeBin, err := c.getCompose()
-	if err != nil {
-		return err
-	}
-	cmd := composeCommand(composeBin, "version")
+	cmd := composeCommand("version")
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("docker compose is not available: %w", err)
 	}
@@ -121,16 +95,12 @@ func (c *ComposeOrchestrator) Start(instance config.Instance) error {
 		logging.Print("Starting Canasta\n")
 	}
 
-	composeBin, err := c.getCompose()
-	if err != nil {
-		return err
-	}
 	var args []string
 	for _, f := range files {
 		args = append(args, "-f", f)
 	}
 	args = append(args, "up", "-d")
-	output, err := runCompose(instance.Path, composeBin, args...)
+	output, err := runCompose(instance.Path, args...)
 	if err != nil {
 		return fmt.Errorf("failed to start containers at %s: %s", instance.Path, output)
 	}
@@ -146,16 +116,12 @@ func (c *ComposeOrchestrator) Stop(instance config.Instance) error {
 		logging.Print("Stopping the containers\n")
 	}
 
-	composeBin, err := c.getCompose()
-	if err != nil {
-		return err
-	}
 	var args []string
 	for _, f := range files {
 		args = append(args, "-f", f)
 	}
 	args = append(args, "down")
-	output, err := runCompose(instance.Path, composeBin, args...)
+	output, err := runCompose(instance.Path, args...)
 	if err != nil {
 		return fmt.Errorf("failed to stop containers at %s: %s", instance.Path, output)
 	}
@@ -164,11 +130,7 @@ func (c *ComposeOrchestrator) Stop(instance config.Instance) error {
 
 func (c *ComposeOrchestrator) Pull(installPath string) error {
 	logging.Print("Pulling Canasta image\n")
-	composeBin, err := c.getCompose()
-	if err != nil {
-		return err
-	}
-	output, err := runCompose(installPath, composeBin, "pull", "--ignore-buildable", "--ignore-pull-failures")
+	output, err := runCompose(installPath, "pull", "--ignore-buildable", "--ignore-pull-failures")
 	if err != nil {
 		return fmt.Errorf("failed to pull images at %s: %s", installPath, output)
 	}
@@ -177,25 +139,21 @@ func (c *ComposeOrchestrator) Pull(installPath string) error {
 
 func (c *ComposeOrchestrator) Update(installPath string) (*UpdateReport, error) {
 	report := &UpdateReport{}
-	composeBin, err := c.getCompose()
-	if err != nil {
-		return nil, err
-	}
 
 	// Get image info before pull
-	beforeImages, err := getComposeImages(installPath, composeBin)
+	beforeImages, err := getComposeImages(installPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get images before pull: %w", err)
 	}
 
 	// Run pull
-	output, err := runCompose(installPath, composeBin, "pull", "--ignore-buildable", "--ignore-pull-failures")
+	output, err := runCompose(installPath, "pull", "--ignore-buildable", "--ignore-pull-failures")
 	if err != nil {
 		return nil, fmt.Errorf("failed to pull images for update at %s: %s", installPath, output)
 	}
 
 	// Get image info after pull
-	afterImages, err := getComposeImages(installPath, composeBin)
+	afterImages, err := getComposeImages(installPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get images after pull: %w", err)
 	}
@@ -218,16 +176,12 @@ func (c *ComposeOrchestrator) Update(installPath string) (*UpdateReport, error) 
 
 func (c *ComposeOrchestrator) Build(installPath string, files ...string) error {
 	logging.Print("Building images\n")
-	composeBin, err := c.getCompose()
-	if err != nil {
-		return err
-	}
 	var args []string
 	for _, f := range files {
 		args = append(args, "-f", f)
 	}
 	args = append(args, "build")
-	output, err := runCompose(installPath, composeBin, args...)
+	output, err := runCompose(installPath, args...)
 	if err != nil {
 		return fmt.Errorf("failed to build images at %s: %s", installPath, output)
 	}
@@ -235,11 +189,7 @@ func (c *ComposeOrchestrator) Build(installPath string, files ...string) error {
 }
 
 func (c *ComposeOrchestrator) Destroy(installPath string) (string, error) {
-	composeBin, err := c.getCompose()
-	if err != nil {
-		return "", err
-	}
-	output, err := runCompose(installPath, composeBin, "down", "-v")
+	output, err := runCompose(installPath, "down", "-v")
 	if err != nil {
 		return output, err
 	}
@@ -253,11 +203,7 @@ func (c *ComposeOrchestrator) Destroy(installPath string) (string, error) {
 }
 
 func (c *ComposeOrchestrator) ListServices(instance config.Instance) ([]string, error) {
-	composeBin, err := c.getCompose()
-	if err != nil {
-		return nil, err
-	}
-	cmd := composeCommand(composeBin, "ps", "--services")
+	cmd := composeCommand("ps", "--services")
 	cmd.Dir = instance.Path
 	outputByte, err := cmd.CombinedOutput()
 	if err != nil {
@@ -274,12 +220,8 @@ func (c *ComposeOrchestrator) ListServices(instance config.Instance) ([]string, 
 }
 
 func (c *ComposeOrchestrator) ExecInteractive(instance config.Instance, service string, command []string) error {
-	composeBin, err := c.getCompose()
-	if err != nil {
-		return err
-	}
 	args := append([]string{"exec", service}, command...)
-	cmd := composeCommand(composeBin, args...)
+	cmd := composeCommand(args...)
 	cmd.Dir = instance.Path
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
@@ -288,11 +230,7 @@ func (c *ComposeOrchestrator) ExecInteractive(instance config.Instance, service 
 }
 
 func (c *ComposeOrchestrator) ExecWithError(installPath, service, command string) (string, error) {
-	composeBin, err := c.getCompose()
-	if err != nil {
-		return "", err
-	}
-	cmd := composeCommand(composeBin, "exec", "-T", service, "/bin/bash", "-c", command)
+	cmd := composeCommand("exec", "-T", service, "/bin/bash", "-c", command)
 	if installPath != "" {
 		cmd.Dir = installPath
 	}
@@ -303,11 +241,7 @@ func (c *ComposeOrchestrator) ExecWithError(installPath, service, command string
 }
 
 func (c *ComposeOrchestrator) ExecStreaming(installPath, service, command string) error {
-	composeBin, err := c.getCompose()
-	if err != nil {
-		return err
-	}
-	cmd := composeCommand(composeBin, "exec", "-T", service, "/bin/bash", "-c", command)
+	cmd := composeCommand("exec", "-T", service, "/bin/bash", "-c", command)
 	if installPath != "" {
 		cmd.Dir = installPath
 	}
@@ -321,11 +255,7 @@ func (c *ComposeOrchestrator) ExecStreaming(installPath, service, command string
 
 func (c *ComposeOrchestrator) CheckRunningStatus(instance config.Instance) error {
 	containerName := "web"
-	composeBin, err := c.getCompose()
-	if err != nil {
-		return err
-	}
-	output, err := runCompose(instance.Path, composeBin, "ps", "-q", containerName)
+	output, err := runCompose(instance.Path, "ps", "-q", containerName)
 	if err != nil || output == "" {
 		return fmt.Errorf("container %s is not running", containerName)
 	}
@@ -333,11 +263,7 @@ func (c *ComposeOrchestrator) CheckRunningStatus(instance config.Instance) error
 }
 
 func (c *ComposeOrchestrator) CopyFrom(installPath, service, containerPath, hostPath string) error {
-	composeBin, err := c.getCompose()
-	if err != nil {
-		return err
-	}
-	cmd := composeCommand(composeBin, "cp", service+":"+containerPath, hostPath)
+	cmd := composeCommand("cp", service+":"+containerPath, hostPath)
 	if installPath != "" {
 		cmd.Dir = installPath
 	}
@@ -349,11 +275,7 @@ func (c *ComposeOrchestrator) CopyFrom(installPath, service, containerPath, host
 }
 
 func (c *ComposeOrchestrator) CopyTo(installPath, service, hostPath, containerPath string) error {
-	composeBin, err := c.getCompose()
-	if err != nil {
-		return err
-	}
-	cmd := composeCommand(composeBin, "cp", hostPath, service+":"+containerPath)
+	cmd := composeCommand("cp", hostPath, service+":"+containerPath)
 	if installPath != "" {
 		cmd.Dir = installPath
 	}
@@ -436,8 +358,8 @@ type composeImageEntry struct {
 }
 
 // getComposeImages returns a map of service name to ImageInfo.
-func getComposeImages(installPath string, composeBin composeBinary) (map[string]ImageInfo, error) {
-	output, err := runCompose(installPath, composeBin, "images", "--format", "json")
+func getComposeImages(installPath string) (map[string]ImageInfo, error) {
+	output, err := runCompose(installPath, "images", "--format", "json")
 	if err != nil {
 		return nil, fmt.Errorf("failed to run docker compose images: %s", output)
 	}


### PR DESCRIPTION
## Summary
- Remove `composeBinary` struct and `getCompose()` LookPath discovery from #722
- Simplify `runCompose`, `composeCommand`, `getComposeImages` to always use `docker compose` directly
- Canasta requires `docker compose` (the plugin), not standalone `docker-compose`

Fixes #727

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes