### PR TITLE
Fix export writing to instance directory instead of working directory

### DIFF
--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -67,6 +67,16 @@ Use a .gz extension on the output path to get a gzip-compressed dump.`,
 				outputPath = wikiID + ".sql"
 			}
 
+			// Resolve relative paths against the current working directory,
+			// not the instance directory (docker compose cp uses chdir).
+			if !filepath.IsAbs(outputPath) {
+				cwd, err := os.Getwd()
+				if err != nil {
+					return fmt.Errorf("failed to get working directory: %w", err)
+				}
+				outputPath = filepath.Join(cwd, outputPath)
+			}
+
 			fmt.Printf("Exporting database for wiki '%s'...\n", wikiID)
 			if err := exportDatabase(instance, wikiID, outputPath); err != nil {
 				return err


### PR DESCRIPTION
## Summary
Resolve relative output paths against the current working directory before passing to `docker compose cp`, which runs with `chdir` set to the instance path. Previously, `canasta export -f test.sql` would write to `{instance_path}/test.sql` instead of `{cwd}/test.sql`.

Fixes #724

## Test plan
- [x] `go build ./...` passes
- [ ] `canasta export -i mysite -w main -f test.sql` writes to the current directory
- [ ] `canasta export -i mysite -w main -f /tmp/test.sql` writes to `/tmp/test.sql`
- [ ] `canasta export -i mysite -w main` writes to `{cwd}/main.sql`