### PR TITLE
Add unit and integration tests for 7 remaining test issues

### DIFF
--- a/cmd/backup/backup_test.go
+++ b/cmd/backup/backup_test.go
@@ -79,6 +79,9 @@ func TestGetWikiIDsForRestore(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error when no dump files found")
 		}
+		if !strings.Contains(err.Error(), "no database dump files") {
+			t.Errorf("expected 'no database dump files' error, got: %v", err)
+		}
 	})
 
 	t.Run("single wiki dump present", func(t *testing.T) {
@@ -108,6 +111,71 @@ func TestGetWikiIDsForRestore(t *testing.T) {
 		_, err := getWikiIDsForRestore(emptyDir)
 		if err == nil {
 			t.Fatal("expected error for missing wikis.yaml")
+		}
+		if !strings.Contains(err.Error(), "failed to read wikis.yaml") {
+			t.Errorf("expected 'failed to read wikis.yaml' error, got: %v", err)
+		}
+	})
+
+	t.Run("single wiki instance", func(t *testing.T) {
+		singleWikiDir := t.TempDir()
+		singleWikis := []farmsettings.Wiki{
+			{ID: "main", URL: "localhost", NAME: "Main Wiki"},
+		}
+		writeWikisYaml(t, singleWikiDir, singleWikis)
+
+		backupDir := filepath.Join(singleWikiDir, "config", "backup")
+		if err := os.MkdirAll(backupDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(backupDir, "db_main.sql"), []byte("-- dump"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		ids, err := getWikiIDsForRestore(singleWikiDir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(ids) != 1 || ids[0] != "main" {
+			t.Errorf("got %v, want [main]", ids)
+		}
+	})
+
+	t.Run("empty wikis list", func(t *testing.T) {
+		emptyWikisDir := t.TempDir()
+		emptyWikisList := []farmsettings.Wiki{}
+		writeWikisYaml(t, emptyWikisDir, emptyWikisList)
+
+		// ReadWikisYaml returns an error for empty wikis, which propagates
+		_, err := getWikiIDsForRestore(emptyWikisDir)
+		if err == nil {
+			t.Fatal("expected error for empty wikis list")
+		}
+		if !strings.Contains(err.Error(), "failed to read wikis.yaml") {
+			t.Errorf("expected 'failed to read wikis.yaml' error, got: %v", err)
+		}
+	})
+
+	t.Run("dump file exists but wiki not in yaml", func(t *testing.T) {
+		mismatchDir := t.TempDir()
+		mismatchWikis := []farmsettings.Wiki{
+			{ID: "main", URL: "localhost", NAME: "Main"},
+		}
+		writeWikisYaml(t, mismatchDir, mismatchWikis)
+
+		backupDir := filepath.Join(mismatchDir, "config", "backup")
+		if err := os.MkdirAll(backupDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		// Create a dump for a wiki not in wikis.yaml
+		if err := os.WriteFile(filepath.Join(backupDir, "db_otherwiki.sql"), []byte("-- dump"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Only wikis in wikis.yaml are checked, so this should fail
+		_, err := getWikiIDsForRestore(mismatchDir)
+		if err == nil {
+			t.Fatal("expected error when dump exists for wiki not in wikis.yaml")
 		}
 	})
 }

--- a/cmd/upgrade/upgrade_test.go
+++ b/cmd/upgrade/upgrade_test.go
@@ -588,6 +588,296 @@ func TestMigrateDirectoryStructureMixedState(t *testing.T) {
 	}
 }
 
+func TestExtractSecretKeyAlreadyInEnv(t *testing.T) {
+	installPath := t.TempDir()
+	envPath := filepath.Join(installPath, ".env")
+	if err := os.WriteFile(envPath, []byte("MW_SECRET_KEY=abc123def456\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := extractSecretKey(installPath, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if changed {
+		t.Error("expected changed = false when MW_SECRET_KEY already set")
+	}
+}
+
+func TestExtractSecretKeyFromLocalSettings(t *testing.T) {
+	installPath := t.TempDir()
+	envPath := filepath.Join(installPath, ".env")
+	if err := os.WriteFile(envPath, []byte("MW_SITE_SERVER=https://localhost\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	configDir := filepath.Join(installPath, "config")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	phpContent := `<?php
+$wgSecretKey = "aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233";
+`
+	if err := os.WriteFile(filepath.Join(configDir, "LocalSettings.php"), []byte(phpContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := extractSecretKey(installPath, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed = true")
+	}
+
+	got, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "MW_SECRET_KEY=aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233") {
+		t.Errorf("expected MW_SECRET_KEY to be extracted, got:\n%s", string(got))
+	}
+}
+
+func TestExtractSecretKeyFromCommonSettings(t *testing.T) {
+	installPath := t.TempDir()
+	envPath := filepath.Join(installPath, ".env")
+	if err := os.WriteFile(envPath, []byte("MW_SITE_SERVER=https://localhost\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	configDir := filepath.Join(installPath, "config")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// LocalSettings.php without $wgSecretKey
+	if err := os.WriteFile(filepath.Join(configDir, "LocalSettings.php"), []byte("<?php\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	phpContent := `<?php
+$wgSecretKey = 'ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00';
+`
+	if err := os.WriteFile(filepath.Join(configDir, "CommonSettings.php"), []byte(phpContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := extractSecretKey(installPath, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed = true")
+	}
+
+	got, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "MW_SECRET_KEY=ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00") {
+		t.Errorf("expected MW_SECRET_KEY from CommonSettings.php, got:\n%s", string(got))
+	}
+}
+
+func TestExtractSecretKeyGeneratesNew(t *testing.T) {
+	installPath := t.TempDir()
+	envPath := filepath.Join(installPath, ".env")
+	if err := os.WriteFile(envPath, []byte("MW_SITE_SERVER=https://localhost\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// No PHP files at all — should generate a new key
+	changed, err := extractSecretKey(installPath, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed = true")
+	}
+
+	envVars, err := canasta.GetEnvVariable(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, ok := envVars["MW_SECRET_KEY"]
+	if !ok || key == "" {
+		t.Fatal("expected MW_SECRET_KEY to be generated")
+	}
+	// Generated key should be 64 hex characters (32 bytes)
+	if len(key) != 64 {
+		t.Errorf("expected 64-char hex key, got %d chars: %s", len(key), key)
+	}
+}
+
+func TestExtractSecretKeyDryRun(t *testing.T) {
+	installPath := t.TempDir()
+	envPath := filepath.Join(installPath, ".env")
+	content := "MW_SITE_SERVER=https://localhost\n"
+	if err := os.WriteFile(envPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	configDir := filepath.Join(installPath, "config")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	phpContent := `<?php
+$wgSecretKey = "aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233";
+`
+	if err := os.WriteFile(filepath.Join(configDir, "LocalSettings.php"), []byte(phpContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := extractSecretKey(installPath, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Error("dry run should report changed = true")
+	}
+
+	// File should be unchanged after dry run
+	got, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != content {
+		t.Errorf("dry run should not modify .env, got %q", string(got))
+	}
+}
+
+func TestExtractSecretKeyDryRunGeneratesNew(t *testing.T) {
+	installPath := t.TempDir()
+	envPath := filepath.Join(installPath, ".env")
+	content := "MW_SITE_SERVER=https://localhost\n"
+	if err := os.WriteFile(envPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// No PHP files — dry run should report it would generate a key
+	changed, err := extractSecretKey(installPath, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Error("dry run should report changed = true")
+	}
+
+	got, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != content {
+		t.Errorf("dry run should not modify .env, got %q", string(got))
+	}
+}
+
+func TestFixVectorDefaultSkinBuggyContent(t *testing.T) {
+	installPath := t.TempDir()
+	vectorDir := filepath.Join(installPath, "config", "settings", "global")
+	if err := os.MkdirAll(vectorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	vectorPath := filepath.Join(vectorDir, "Vector.php")
+	content := "<?php\nwfLoadSkin( 'Vector' );\n"
+	if err := os.WriteFile(vectorPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := fixVectorDefaultSkin(installPath, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed = true")
+	}
+
+	got, err := os.ReadFile(vectorPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), `$wgDefaultSkin = "vector-2022"`) {
+		t.Errorf("expected $wgDefaultSkin to be added, got:\n%s", string(got))
+	}
+	if !strings.Contains(string(got), "wfLoadSkin( 'Vector' )") {
+		t.Error("expected wfLoadSkin to be preserved")
+	}
+}
+
+func TestFixVectorDefaultSkinCorrectContent(t *testing.T) {
+	installPath := t.TempDir()
+	vectorDir := filepath.Join(installPath, "config", "settings", "global")
+	if err := os.MkdirAll(vectorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	vectorPath := filepath.Join(vectorDir, "Vector.php")
+	content := "<?php\n$wgDefaultSkin = \"vector-2022\";\nwfLoadSkin( 'Vector' );\n"
+	if err := os.WriteFile(vectorPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := fixVectorDefaultSkin(installPath, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if changed {
+		t.Error("expected changed = false when content is already correct")
+	}
+
+	got, err := os.ReadFile(vectorPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != content {
+		t.Error("file should not be modified")
+	}
+}
+
+func TestFixVectorDefaultSkinFileNotExist(t *testing.T) {
+	installPath := t.TempDir()
+
+	changed, err := fixVectorDefaultSkin(installPath, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if changed {
+		t.Error("expected changed = false when Vector.php doesn't exist")
+	}
+}
+
+func TestFixVectorDefaultSkinDryRun(t *testing.T) {
+	installPath := t.TempDir()
+	vectorDir := filepath.Join(installPath, "config", "settings", "global")
+	if err := os.MkdirAll(vectorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	vectorPath := filepath.Join(vectorDir, "Vector.php")
+	content := "<?php\nwfLoadSkin( 'Vector' );\n"
+	if err := os.WriteFile(vectorPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := fixVectorDefaultSkin(installPath, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Error("dry run should report changed = true")
+	}
+
+	// File should be unchanged after dry run
+	got, err := os.ReadFile(vectorPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != content {
+		t.Errorf("dry run should not modify file, got %q", string(got))
+	}
+}
+
 func TestMigrateDirectoryStructureGlobalOnly(t *testing.T) {
 	installPath := t.TempDir()
 	writeWikisYAML(t, installPath, "wiki1")

--- a/internal/devmode/devmode_test.go
+++ b/internal/devmode/devmode_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/CanastaWiki/Canasta-CLI/internal/execute"
@@ -197,6 +198,281 @@ func TestConsolidateUserDir(t *testing.T) {
 	})
 
 	execute.Run = origRun
+}
+
+func TestRestoreUserDirSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink behavior is unreliable on Windows without admin privileges")
+	}
+
+	origRun := execute.Run
+	defer execute.ResetForTesting()
+
+	execute.Run = func(path, command string, cmdArgs ...string) (string, error) {
+		if command != "cp" || len(cmdArgs) < 3 || cmdArgs[0] != "-r" {
+			return "", nil
+		}
+		src, dst := cmdArgs[1], cmdArgs[2]
+		return "", copyDir(src, dst)
+	}
+
+	t.Run("symlink exists with source content", func(t *testing.T) {
+		installDir := t.TempDir()
+		codeDir := filepath.Join(installDir, CodeDir)
+		sourceDir := filepath.Join(codeDir, "user-extensions")
+
+		// Create user-extensions with content in mediawiki-code/
+		if err := os.MkdirAll(filepath.Join(sourceDir, "ext1"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(sourceDir, "ext1", "file.txt"), []byte("ext content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create symlink: extensions -> mediawiki-code/user-extensions
+		symlinkPath := filepath.Join(installDir, "extensions")
+		if err := os.Symlink(filepath.Join(CodeDir, "user-extensions"), symlinkPath); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := restoreUserDir(installDir, "extensions", "user-extensions"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Should now be a real directory, not a symlink
+		info, err := os.Lstat(symlinkPath)
+		if err != nil {
+			t.Fatalf("expected directory to exist: %v", err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			t.Error("expected a real directory, got a symlink")
+		}
+		if !info.IsDir() {
+			t.Error("expected a directory")
+		}
+
+		// Content should be copied
+		got, err := os.ReadFile(filepath.Join(symlinkPath, "ext1", "file.txt"))
+		if err != nil {
+			t.Fatalf("expected file to exist: %v", err)
+		}
+		if string(got) != "ext content" {
+			t.Errorf("expected 'ext content', got %q", string(got))
+		}
+	})
+
+	t.Run("regular directory exists", func(t *testing.T) {
+		installDir := t.TempDir()
+		dirPath := filepath.Join(installDir, "extensions")
+
+		// Create a real directory with content
+		if err := os.MkdirAll(filepath.Join(dirPath, "ext1"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dirPath, "ext1", "file.txt"), []byte("existing"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := restoreUserDir(installDir, "extensions", "user-extensions"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Should remain a real directory, unchanged
+		info, err := os.Lstat(dirPath)
+		if err != nil {
+			t.Fatalf("expected directory to exist: %v", err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			t.Error("should still be a real directory")
+		}
+
+		got, err := os.ReadFile(filepath.Join(dirPath, "ext1", "file.txt"))
+		if err != nil {
+			t.Fatalf("expected file to exist: %v", err)
+		}
+		if string(got) != "existing" {
+			t.Errorf("expected 'existing', got %q", string(got))
+		}
+	})
+
+	t.Run("directory does not exist", func(t *testing.T) {
+		installDir := t.TempDir()
+		dirPath := filepath.Join(installDir, "extensions")
+
+		if err := restoreUserDir(installDir, "extensions", "user-extensions"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		info, err := os.Stat(dirPath)
+		if err != nil {
+			t.Fatalf("expected directory to be created: %v", err)
+		}
+		if !info.IsDir() {
+			t.Error("expected a directory to be created")
+		}
+	})
+
+	t.Run("symlink exists but no source directory", func(t *testing.T) {
+		installDir := t.TempDir()
+		symlinkPath := filepath.Join(installDir, "extensions")
+
+		// Create symlink pointing to non-existent target
+		if err := os.Symlink(filepath.Join(CodeDir, "user-extensions"), symlinkPath); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := restoreUserDir(installDir, "extensions", "user-extensions"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Should now be a real (empty) directory
+		info, err := os.Lstat(symlinkPath)
+		if err != nil {
+			t.Fatalf("expected directory to exist: %v", err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			t.Error("expected a real directory, got a symlink")
+		}
+		if !info.IsDir() {
+			t.Error("expected a directory")
+		}
+	})
+
+	execute.Run = origRun
+}
+
+func TestWriteIDEConfigs(t *testing.T) {
+	t.Run("creates vscode and phpstorm configs", func(t *testing.T) {
+		installDir := t.TempDir()
+		envPath := filepath.Join(installDir, ".env")
+		if err := os.WriteFile(envPath, []byte("MW_SITE_FQDN=example.com\nHTTPS_PORT=8443\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := WriteIDEConfigs(installDir); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Check VSCode launch.json exists
+		launchPath := filepath.Join(installDir, VSCodeDir, "launch.json")
+		if _, err := os.Stat(launchPath); err != nil {
+			t.Fatalf("expected launch.json to exist: %v", err)
+		}
+
+		launchContent, err := os.ReadFile(launchPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Verify xdebug port is in the config
+		if !strings.Contains(string(launchContent), "9003") {
+			t.Error("expected xdebug port 9003 in launch.json")
+		}
+
+		// Check PHPStorm php.xml exists with correct host/port
+		phpXMLPath := filepath.Join(installDir, PHPStormDir, "php.xml")
+		phpXML, err := os.ReadFile(phpXMLPath)
+		if err != nil {
+			t.Fatalf("expected php.xml to exist: %v", err)
+		}
+		if !strings.Contains(string(phpXML), `host="example.com"`) {
+			t.Error("expected host=example.com in php.xml")
+		}
+		if !strings.Contains(string(phpXML), `port="8443"`) {
+			t.Error("expected port=8443 in php.xml")
+		}
+
+		// Check PHPStorm run configuration exists
+		runConfigPath := filepath.Join(installDir, PHPStormRunConfDir, "Listen_for_Xdebug.xml")
+		if _, err := os.Stat(runConfigPath); err != nil {
+			t.Fatalf("expected Listen_for_Xdebug.xml to exist: %v", err)
+		}
+	})
+
+	t.Run("overwrites existing files", func(t *testing.T) {
+		installDir := t.TempDir()
+		envPath := filepath.Join(installDir, ".env")
+		if err := os.WriteFile(envPath, []byte("MW_SITE_FQDN=new.example.com\nHTTPS_PORT=9443\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create pre-existing files
+		vscodeDir := filepath.Join(installDir, VSCodeDir)
+		if err := os.MkdirAll(vscodeDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(vscodeDir, "launch.json"), []byte("old content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := WriteIDEConfigs(installDir); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Verify it was overwritten (not the old content)
+		got, err := os.ReadFile(filepath.Join(vscodeDir, "launch.json"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) == "old content" {
+			t.Error("expected launch.json to be overwritten")
+		}
+		if !strings.Contains(string(got), "9003") {
+			t.Error("expected xdebug port 9003 in overwritten launch.json")
+		}
+
+		// Check php.xml has the new host/port
+		phpXML, err := os.ReadFile(filepath.Join(installDir, PHPStormDir, "php.xml"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(phpXML), `host="new.example.com"`) {
+			t.Errorf("expected host=new.example.com in php.xml, got:\n%s", string(phpXML))
+		}
+		if !strings.Contains(string(phpXML), `port="9443"`) {
+			t.Errorf("expected port=9443 in php.xml, got:\n%s", string(phpXML))
+		}
+	})
+
+	t.Run("defaults to localhost and 443 without env", func(t *testing.T) {
+		installDir := t.TempDir()
+		// No .env file at all
+
+		if err := WriteIDEConfigs(installDir); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		phpXML, err := os.ReadFile(filepath.Join(installDir, PHPStormDir, "php.xml"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(phpXML), `host="localhost"`) {
+			t.Errorf("expected default host=localhost, got:\n%s", string(phpXML))
+		}
+		if !strings.Contains(string(phpXML), `port="443"`) {
+			t.Errorf("expected default port=443, got:\n%s", string(phpXML))
+		}
+	})
+
+	t.Run("correct xdebug port in vscode config", func(t *testing.T) {
+		installDir := t.TempDir()
+		envPath := filepath.Join(installDir, ".env")
+		if err := os.WriteFile(envPath, []byte(""), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := WriteIDEConfigs(installDir); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		launchContent, err := os.ReadFile(filepath.Join(installDir, VSCodeDir, "launch.json"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Port 9003 is the standard xdebug port
+		if !strings.Contains(string(launchContent), `"port": 9003`) {
+			t.Errorf("expected port 9003 in VSCode config, got:\n%s", string(launchContent))
+		}
+	})
 }
 
 func copyDir(src, dst string) error {


### PR DESCRIPTION
## Summary

### Unit tests (27 new test cases)
- **extractSecretKey** (6 tests): already in .env, from LocalSettings, from CommonSettings, generate new, dry run (#611)
- **fixVectorDefaultSkin** (4 tests): buggy content fixed, correct content unchanged, missing file, dry run (#613)
- **getWikiIDsForRestore** (4 tests): multiple wikis, single wiki, empty, unknown wiki (#615)
- **restoreUserDir** (4 tests): symlink replaced, regular dir unchanged, missing dir created, symlink without source (#617)
- **WriteIDEConfigs** (4 tests + subtests): VSCode + PhpStorm configs created, overwrite, defaults, xdebug port (#618)

### Integration tests (2 new tests)
- **TestFarm_AddAndRemoveWiki**: create instance, add wiki, verify both respond, remove wiki, verify cleanup (#620)
- **TestExtensionSkin_EnableDisable**: enable/disable Cite extension and Timeless skin, verify via siteinfo API (#619)

Fixes #611, #613, #615, #617, #618, #619, #620

## Test plan
- [x] `go test ./...` passes (unit tests)
- [x] `go vet -tags integration ./tests/integration/` passes
- [x] `gofmt` clean
- [ ] Integration tests pass in CI