### PR TITLE
Add integration tests for wiki farm and extension/skin lifecycle

### DIFF
--- a/tests/integration/extension_skin_test.go
+++ b/tests/integration/extension_skin_test.go
@@ -1,0 +1,153 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// siteInfoResponse is used to unmarshal the MediaWiki siteinfo API response
+// for extensions and skins queries.
+type siteInfoResponse struct {
+	Query struct {
+		Extensions []struct {
+			Name string `json:"name"`
+		} `json:"extensions"`
+		Skins []struct {
+			Code string `json:"code"`
+		} `json:"skins"`
+	} `json:"query"`
+}
+
+// querySiteInfo fetches siteinfo from the MediaWiki API with the given siprop
+// (e.g., "extensions" or "skins") and returns the parsed response. It retries
+// up to maxRetries times with a delay between attempts to allow the wiki to
+// reload after configuration changes.
+func querySiteInfo(t *testing.T, httpPort, siprop string, maxRetries int) siteInfoResponse {
+	t.Helper()
+	apiURL := fmt.Sprintf("http://127.0.0.1:%s/w/api.php?action=query&meta=siteinfo&siprop=%s&format=json", httpPort, siprop)
+
+	var result siteInfoResponse
+	var lastErr error
+	for i := 0; i < maxRetries; i++ {
+		req, err := http.NewRequest("GET", apiURL, nil)
+		if err != nil {
+			t.Fatalf("failed to create request: %v", err)
+		}
+		req.Host = "localhost"
+		client := &http.Client{Timeout: 10 * time.Second}
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		decodeErr := json.NewDecoder(resp.Body).Decode(&result)
+		resp.Body.Close()
+		if decodeErr != nil {
+			lastErr = decodeErr
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		return result
+	}
+	t.Fatalf("failed to query siteinfo siprop=%s after %d retries: %v", siprop, maxRetries, lastErr)
+	return result // unreachable
+}
+
+// hasExtension checks if the given extension name appears in the siteinfo response.
+func hasExtension(info siteInfoResponse, name string) bool {
+	for _, ext := range info.Query.Extensions {
+		if ext.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// hasSkin checks if the given skin code appears in the siteinfo response.
+// Skin codes are lowercase (e.g., "timeless").
+func hasSkin(info siteInfoResponse, code string) bool {
+	code = strings.ToLower(code)
+	for _, skin := range info.Query.Skins {
+		if strings.ToLower(skin.Code) == code {
+			return true
+		}
+	}
+	return false
+}
+
+// TestExtensionSkin_EnableDisable creates an instance, then exercises the
+// extension enable/disable and skin enable/disable commands, verifying each
+// change via the MediaWiki siteinfo API.
+func TestExtensionSkin_EnableDisable(t *testing.T) {
+	inst := createTestInstance(t, "inttest-extskin")
+
+	// Create the instance with the main wiki
+	out, err := inst.run(t, "create",
+		"-i", inst.ID,
+		"-w", "main",
+		"-n", "localhost",
+		"-p", inst.WorkDir,
+		"-e", inst.EnvFile,
+	)
+	if err != nil {
+		t.Fatalf("canasta create failed: %v\n%s", err, out)
+	}
+
+	// Wait for the wiki to be accessible
+	waitForWiki(t, inst.HTTPPort, 5*time.Minute)
+
+	// --- Extension enable ---
+	out, err = inst.run(t, "extension", "enable", "-i", inst.ID, "Cite")
+	if err != nil {
+		t.Fatalf("canasta extension enable failed: %v\n%s", err, out)
+	}
+	time.Sleep(5 * time.Second)
+
+	info := querySiteInfo(t, inst.HTTPPort, "extensions", 6)
+	if !hasExtension(info, "Cite") {
+		t.Errorf("expected Cite extension to be enabled, but it was not found in siteinfo")
+	}
+
+	// --- Extension disable ---
+	out, err = inst.run(t, "extension", "disable", "-i", inst.ID, "Cite")
+	if err != nil {
+		t.Fatalf("canasta extension disable failed: %v\n%s", err, out)
+	}
+	time.Sleep(5 * time.Second)
+
+	info = querySiteInfo(t, inst.HTTPPort, "extensions", 6)
+	if hasExtension(info, "Cite") {
+		t.Errorf("expected Cite extension to be disabled, but it still appears in siteinfo")
+	}
+
+	// --- Skin enable ---
+	out, err = inst.run(t, "skin", "enable", "-i", inst.ID, "Timeless")
+	if err != nil {
+		t.Fatalf("canasta skin enable failed: %v\n%s", err, out)
+	}
+	time.Sleep(5 * time.Second)
+
+	info = querySiteInfo(t, inst.HTTPPort, "skins", 6)
+	if !hasSkin(info, "timeless") {
+		t.Errorf("expected Timeless skin to be enabled, but it was not found in siteinfo")
+	}
+
+	// --- Skin disable ---
+	out, err = inst.run(t, "skin", "disable", "-i", inst.ID, "Timeless")
+	if err != nil {
+		t.Fatalf("canasta skin disable failed: %v\n%s", err, out)
+	}
+	time.Sleep(5 * time.Second)
+
+	info = querySiteInfo(t, inst.HTTPPort, "skins", 6)
+	if hasSkin(info, "timeless") {
+		t.Errorf("expected Timeless skin to be disabled, but it still appears in siteinfo")
+	}
+}

--- a/tests/integration/farm_test.go
+++ b/tests/integration/farm_test.go
@@ -1,0 +1,127 @@
+//go:build integration
+
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// waitForWikiAtPath polls the MediaWiki API at a specific path until it gets a
+// valid response or the timeout expires. The path should include a leading slash
+// (e.g., "/docs"). An empty path behaves like waitForWiki.
+func waitForWikiAtPath(t *testing.T, httpPort, path string, timeout time.Duration) {
+	t.Helper()
+	apiURL := fmt.Sprintf("http://127.0.0.1:%s%s/w/api.php?action=query&meta=siteinfo&format=json", httpPort, path)
+	deadline := time.Now().Add(timeout)
+
+	var lastErr string
+	for time.Now().Before(deadline) {
+		req, reqErr := http.NewRequest("GET", apiURL, nil)
+		if reqErr != nil {
+			t.Fatalf("failed to create request: %v", reqErr)
+		}
+		req.Host = "localhost"
+		client := &http.Client{Timeout: 10 * time.Second}
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = fmt.Sprintf("connection error: %v", err)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			t.Logf("Wiki is up at port %s path %s", httpPort, path)
+			return
+		}
+		lastErr = fmt.Sprintf("HTTP %d", resp.StatusCode)
+		time.Sleep(5 * time.Second)
+	}
+
+	t.Fatalf("wiki at path %q did not become ready at port %s within %v (last: %s)", path, httpPort, timeout, lastErr)
+}
+
+// wikiNotAccessibleAtPath verifies that the wiki at the given path is NOT
+// accessible (connection refused, timeout, or non-200 status).
+func wikiNotAccessibleAtPath(t *testing.T, httpPort, path string) {
+	t.Helper()
+	apiURL := fmt.Sprintf("http://127.0.0.1:%s%s/w/api.php?action=query&meta=siteinfo&format=json", httpPort, path)
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Host = "localhost"
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		// Connection refused or similar — wiki is down, which is expected.
+		t.Logf("Wiki at path %q is not accessible (expected): %v", path, err)
+		return
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Logf("Wiki at path %q returned HTTP %d (expected non-200)", path, resp.StatusCode)
+		return
+	}
+	t.Errorf("wiki at path %q is still accessible (HTTP 200), expected it to be removed", path)
+}
+
+// TestFarm_AddAndRemoveWiki creates an instance with a main wiki, adds a second
+// wiki at a subpath, verifies both are accessible, removes the second wiki, and
+// confirms the main wiki still works while the second wiki is gone.
+func TestFarm_AddAndRemoveWiki(t *testing.T) {
+	inst := createTestInstance(t, "inttest-farm")
+
+	// Create the instance with the main wiki
+	out, err := inst.run(t, "create",
+		"-i", inst.ID,
+		"-w", "main",
+		"-n", "localhost",
+		"-p", inst.WorkDir,
+		"-e", inst.EnvFile,
+	)
+	if err != nil {
+		t.Fatalf("canasta create failed: %v\n%s", err, out)
+	}
+
+	// Wait for the main wiki to be accessible
+	waitForWiki(t, inst.HTTPPort, 5*time.Minute)
+
+	// Add a second wiki at /docs
+	wikiURL := fmt.Sprintf("localhost:%s/docs", inst.HTTPPort)
+	out, err = inst.run(t, "add",
+		"-i", inst.ID,
+		"-w", "docs",
+		"-u", wikiURL,
+	)
+	if err != nil {
+		t.Fatalf("canasta add failed: %v\n%s", err, out)
+	}
+
+	// Wait for the docs wiki to be accessible
+	waitForWikiAtPath(t, inst.HTTPPort, "/docs", 5*time.Minute)
+
+	// Verify main wiki still responds
+	waitForWiki(t, inst.HTTPPort, 2*time.Minute)
+
+	// Remove the docs wiki
+	out, err = inst.run(t, "remove",
+		"-i", inst.ID,
+		"-w", "docs",
+		"-y",
+	)
+	if err != nil {
+		t.Fatalf("canasta remove failed: %v\n%s", err, out)
+	}
+
+	// Wait for restart to settle
+	waitForWiki(t, inst.HTTPPort, 2*time.Minute)
+
+	// Verify main wiki still responds after removing docs
+	waitForWiki(t, inst.HTTPPort, 2*time.Minute)
+
+	// Verify docs wiki no longer responds
+	wikiNotAccessibleAtPath(t, inst.HTTPPort, "/docs")
+}


### PR DESCRIPTION
## Summary
- **TestFarm_AddAndRemoveWiki**: create instance, add wiki, verify both respond, remove wiki, verify cleanup (#620)
- **TestExtensionSkin_EnableDisable**: enable/disable Cite extension and Timeless skin, verify via siteinfo API (#619)

These were intended for #732 but the PR was merged before the second commit landed.

Fixes #619, #620

## Test plan
- [x] `go vet -tags integration ./tests/integration/` passes
- [x] `gofmt` clean
- [ ] Integration tests pass in CI