### PR TITLE
Add integration tests for config, maintenance, gitops pull/diff

### DIFF
--- a/tests/integration/config_test.go
+++ b/tests/integration/config_test.go
@@ -1,0 +1,71 @@
+//go:build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestConfig_GetSetDelete exercises config set, get (single key and all keys),
+// and unset, verifying that values are correctly stored and removed.
+func TestConfig_GetSetDelete(t *testing.T) {
+	inst := createTestInstance(t, "inttest-config")
+
+	// Create the instance
+	out, err := inst.run(t, "create",
+		"-i", inst.ID,
+		"-w", "main",
+		"-n", "localhost",
+		"-p", inst.WorkDir,
+		"-e", inst.EnvFile,
+	)
+	if err != nil {
+		t.Fatalf("canasta create failed: %v\n%s", err, out)
+	}
+
+	// Wait for the wiki to be ready
+	waitForWiki(t, inst.HTTPPort, 5*time.Minute)
+
+	// Set a known configuration key
+	out, err = inst.run(t, "config", "set", "-i", inst.ID,
+		"MW_SITE_SERVER=https://test.example.com", "--no-restart")
+	if err != nil {
+		t.Fatalf("config set MW_SITE_SERVER failed: %v\n%s", err, out)
+	}
+
+	// Get the specific key and verify the value
+	out, err = inst.run(t, "config", "get", "-i", inst.ID, "MW_SITE_SERVER")
+	if err != nil {
+		t.Fatalf("config get MW_SITE_SERVER failed: %v\n%s", err, out)
+	}
+	if got := strings.TrimSpace(out); got != "https://test.example.com" {
+		t.Errorf("config get MW_SITE_SERVER = %q, want %q", got, "https://test.example.com")
+	}
+
+	// Get all settings and verify our key is present
+	out, err = inst.run(t, "config", "get", "-i", inst.ID)
+	if err != nil {
+		t.Fatalf("config get (all) failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "MW_SITE_SERVER=https://test.example.com") {
+		t.Errorf("config get (all) should contain MW_SITE_SERVER=https://test.example.com, got:\n%s", out)
+	}
+
+	// Unset the key
+	out, err = inst.run(t, "config", "unset", "-i", inst.ID,
+		"MW_SITE_SERVER", "--no-restart")
+	if err != nil {
+		t.Fatalf("config unset MW_SITE_SERVER failed: %v\n%s", err, out)
+	}
+
+	// Verify the key is gone — config get should return an error
+	out, err = inst.run(t, "config", "get", "-i", inst.ID, "MW_SITE_SERVER")
+	if err == nil {
+		t.Errorf("config get MW_SITE_SERVER should fail after unset, but got: %s", out)
+	}
+	if !strings.Contains(out, "not set") {
+		t.Errorf("expected 'not set' in error output, got: %s", out)
+	}
+}

--- a/tests/integration/gitops_diff_test.go
+++ b/tests/integration/gitops_diff_test.go
@@ -1,0 +1,144 @@
+//go:build integration
+
+package integration
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestGitops_Diff creates an instance, initializes gitops with a local bare
+// repo, then tests that "canasta gitops diff" correctly reports both local
+// uncommitted changes and remote changes.
+func TestGitops_Diff(t *testing.T) {
+	inst := createTestInstance(t, "inttest-gitdiff")
+
+	// Create a bare git repo to use as the remote
+	bareRepo := t.TempDir()
+	if out, err := exec.Command("git", "init", "--bare", "-b", "main", bareRepo).CombinedOutput(); err != nil {
+		t.Fatalf("git init --bare failed: %v\n%s", err, out)
+	}
+
+	// Create the instance
+	out, err := inst.run(t, "create",
+		"-i", inst.ID,
+		"-w", "main",
+		"-n", "localhost",
+		"-p", inst.WorkDir,
+		"-e", inst.EnvFile,
+	)
+	if err != nil {
+		t.Fatalf("canasta create failed: %v\n%s", err, out)
+	}
+
+	// Wait for the wiki to be ready
+	waitForWiki(t, inst.HTTPPort, 5*time.Minute)
+
+	// Initialize gitops with the local bare repo as the remote
+	keyFile := filepath.Join(inst.WorkDir, "gitops-key")
+	installDir := filepath.Join(inst.WorkDir, inst.ID)
+	out, err = inst.run(t, "gitops", "init",
+		"-i", inst.ID,
+		"-n", "testhost",
+		"--repo", bareRepo,
+		"--key", keyFile,
+	)
+	if err != nil {
+		t.Fatalf("gitops init failed: %v\n%s", err, out)
+	}
+
+	// Verify clean state — diff should report no changes
+	out, err = inst.run(t, "gitops", "diff", "-i", inst.ID)
+	if err != nil {
+		t.Fatalf("gitops diff (clean state) failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "No changes") && !strings.Contains(out, "in sync") {
+		t.Logf("Note: initial diff output was not 'no changes': %s", out)
+	}
+
+	// Make a local uncommitted change to a tracked file
+	settingsFile := filepath.Join(installDir, "config", "settings", "global", "DiffTest.php")
+	if err := os.WriteFile(settingsFile, []byte("<?php\n// diff local test\n"), 0644); err != nil {
+		t.Fatalf("failed to write local test file: %v", err)
+	}
+	// Stage the file so it shows as an uncommitted change
+	gitAdd := exec.Command("git", "-C", installDir, "add", "config/settings/global/DiffTest.php")
+	if addOut, err := gitAdd.CombinedOutput(); err != nil {
+		t.Fatalf("git add failed: %v\n%s", err, addOut)
+	}
+
+	// Verify diff detects the local change
+	out, err = inst.run(t, "gitops", "diff", "-i", inst.ID)
+	if err != nil {
+		t.Fatalf("gitops diff (local change) failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "DiffTest.php") {
+		t.Errorf("gitops diff should mention DiffTest.php for local change, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Uncommitted") && !strings.Contains(out, "uncommitted") {
+		t.Errorf("gitops diff should report uncommitted changes, got:\n%s", out)
+	}
+
+	// Commit the local change so we can test committed local vs remote
+	gitCommit := exec.Command("git", "-C", installDir, "commit", "-m", "Add DiffTest.php")
+	gitCommit.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=Test",
+		"GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=Test",
+		"GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	if commitOut, err := gitCommit.CombinedOutput(); err != nil {
+		t.Fatalf("git commit failed: %v\n%s", err, commitOut)
+	}
+
+	// Now make a remote change: clone bare repo, add a file, push
+	cloneDir := t.TempDir()
+	if cloneOut, err := exec.Command("git", "clone", bareRepo, cloneDir).CombinedOutput(); err != nil {
+		t.Fatalf("git clone failed: %v\n%s", err, cloneOut)
+	}
+
+	remoteSettingsDir := filepath.Join(cloneDir, "config", "settings", "global")
+	if err := os.MkdirAll(remoteSettingsDir, 0755); err != nil {
+		t.Fatalf("failed to create settings dir in clone: %v", err)
+	}
+	remoteFile := filepath.Join(remoteSettingsDir, "RemoteDiffTest.php")
+	if err := os.WriteFile(remoteFile, []byte("<?php\n// remote diff test\n"), 0644); err != nil {
+		t.Fatalf("failed to write remote test file: %v", err)
+	}
+
+	gitAddRemote := exec.Command("git", "-C", cloneDir, "add", "config/settings/global/RemoteDiffTest.php")
+	if addOut, err := gitAddRemote.CombinedOutput(); err != nil {
+		t.Fatalf("git add in clone failed: %v\n%s", err, addOut)
+	}
+	gitCommitRemote := exec.Command("git", "-C", cloneDir, "commit", "-m", "Add RemoteDiffTest.php")
+	gitCommitRemote.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=Test",
+		"GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=Test",
+		"GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	if commitOut, err := gitCommitRemote.CombinedOutput(); err != nil {
+		t.Fatalf("git commit in clone failed: %v\n%s", err, commitOut)
+	}
+	gitPushRemote := exec.Command("git", "-C", cloneDir, "push", "origin", "main")
+	if pushOut, err := gitPushRemote.CombinedOutput(); err != nil {
+		t.Fatalf("git push from clone failed: %v\n%s", err, pushOut)
+	}
+
+	// Verify diff detects both local and remote changes
+	out, err = inst.run(t, "gitops", "diff", "-i", inst.ID)
+	if err != nil {
+		t.Fatalf("gitops diff (local + remote) failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "DiffTest.php") {
+		t.Errorf("gitops diff should mention DiffTest.php as a local change, got:\n%s", out)
+	}
+	if !strings.Contains(out, "RemoteDiffTest.php") {
+		t.Errorf("gitops diff should mention RemoteDiffTest.php as a remote change, got:\n%s", out)
+	}
+	t.Logf("gitops diff output:\n%s", out)
+}

--- a/tests/integration/gitops_pull_test.go
+++ b/tests/integration/gitops_pull_test.go
@@ -1,0 +1,124 @@
+//go:build integration
+
+package integration
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestGitops_Pull creates an instance, initializes gitops with a local bare
+// repo, pushes the initial state, then makes a change via a clone of the bare
+// repo and verifies that "canasta gitops pull" brings the change into the
+// instance directory.
+func TestGitops_Pull(t *testing.T) {
+	inst := createTestInstance(t, "inttest-gitpull")
+
+	// Create a bare git repo to use as the remote
+	bareRepo := t.TempDir()
+	if out, err := exec.Command("git", "init", "--bare", "-b", "main", bareRepo).CombinedOutput(); err != nil {
+		t.Fatalf("git init --bare failed: %v\n%s", err, out)
+	}
+
+	// Create the instance
+	out, err := inst.run(t, "create",
+		"-i", inst.ID,
+		"-w", "main",
+		"-n", "localhost",
+		"-p", inst.WorkDir,
+		"-e", inst.EnvFile,
+	)
+	if err != nil {
+		t.Fatalf("canasta create failed: %v\n%s", err, out)
+	}
+
+	// Wait for the wiki to be ready
+	waitForWiki(t, inst.HTTPPort, 5*time.Minute)
+
+	// Initialize gitops with the local bare repo as the remote
+	keyFile := filepath.Join(inst.WorkDir, "gitops-key")
+	installDir := filepath.Join(inst.WorkDir, inst.ID)
+	out, err = inst.run(t, "gitops", "init",
+		"-i", inst.ID,
+		"-n", "testhost",
+		"--repo", bareRepo,
+		"--key", keyFile,
+	)
+	if err != nil {
+		t.Fatalf("gitops init failed: %v\n%s", err, out)
+	}
+
+	// Verify the initial commit was pushed to the bare repo
+	logCmd := exec.Command("git", "--git-dir", bareRepo, "log", "--oneline", "-1")
+	logOut, err := logCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git log on bare repo failed: %v\n%s", err, logOut)
+	}
+	if !strings.Contains(string(logOut), "Initial gitops") {
+		t.Fatalf("expected initial commit in bare repo, got: %s", string(logOut))
+	}
+
+	// Clone the bare repo to a temp dir and make a change
+	cloneDir := t.TempDir()
+	if out, err := exec.Command("git", "clone", bareRepo, cloneDir).CombinedOutput(); err != nil {
+		t.Fatalf("git clone failed: %v\n%s", err, out)
+	}
+
+	// Create a new settings file in the clone
+	settingsDir := filepath.Join(cloneDir, "config", "settings", "global")
+	if err := os.MkdirAll(settingsDir, 0755); err != nil {
+		t.Fatalf("failed to create settings dir in clone: %v", err)
+	}
+	testFile := filepath.Join(settingsDir, "PullTest.php")
+	if err := os.WriteFile(testFile, []byte("<?php\n// pull integration test\n"), 0644); err != nil {
+		t.Fatalf("failed to write test file in clone: %v", err)
+	}
+
+	// Commit and push the change from the clone
+	gitAdd := exec.Command("git", "-C", cloneDir, "add", "config/settings/global/PullTest.php")
+	if out, err := gitAdd.CombinedOutput(); err != nil {
+		t.Fatalf("git add in clone failed: %v\n%s", err, out)
+	}
+	gitCommit := exec.Command("git", "-C", cloneDir, "commit", "-m", "Add PullTest.php")
+	gitCommit.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=Test",
+		"GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=Test",
+		"GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	if out, err := gitCommit.CombinedOutput(); err != nil {
+		t.Fatalf("git commit in clone failed: %v\n%s", err, out)
+	}
+	gitPush := exec.Command("git", "-C", cloneDir, "push", "origin", "main")
+	if out, err := gitPush.CombinedOutput(); err != nil {
+		t.Fatalf("git push from clone failed: %v\n%s", err, out)
+	}
+
+	// Pull the change into the instance
+	out, err = inst.run(t, "gitops", "pull", "-i", inst.ID)
+	if err != nil {
+		t.Fatalf("gitops pull failed: %v\n%s", err, out)
+	}
+
+	// Verify the change appears in the instance directory
+	pulledFile := filepath.Join(installDir, "config", "settings", "global", "PullTest.php")
+	data, err := os.ReadFile(pulledFile)
+	if err != nil {
+		t.Fatalf("PullTest.php not found in instance after pull: %v", err)
+	}
+	if !strings.Contains(string(data), "pull integration test") {
+		t.Errorf("PullTest.php has unexpected content: %s", string(data))
+	}
+
+	// Verify the pull output reports the change
+	if strings.Contains(out, "Already up to date") {
+		t.Error("gitops pull reported 'Already up to date' but we pushed a new commit")
+	}
+	if !strings.Contains(out, "PullTest.php") {
+		t.Logf("Note: pull output did not mention PullTest.php (may be expected depending on output format)")
+	}
+}

--- a/tests/integration/maintenance_test.go
+++ b/tests/integration/maintenance_test.go
@@ -1,0 +1,72 @@
+//go:build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestMaintenance_ExtensionScripts exercises the maintenance extension, script,
+// and script execution subcommands against a running Canasta instance.
+func TestMaintenance_ExtensionScripts(t *testing.T) {
+	inst := createTestInstance(t, "inttest-maint")
+
+	// Create the instance
+	out, err := inst.run(t, "create",
+		"-i", inst.ID,
+		"-w", "main",
+		"-n", "localhost",
+		"-p", inst.WorkDir,
+		"-e", inst.EnvFile,
+	)
+	if err != nil {
+		t.Fatalf("canasta create failed: %v\n%s", err, out)
+	}
+
+	// Wait for the wiki to be ready
+	waitForWiki(t, inst.HTTPPort, 5*time.Minute)
+
+	// List extensions with maintenance scripts — should include well-known extensions
+	out, err = inst.run(t, "maintenance", "extension", "-i", inst.ID)
+	if err != nil {
+		t.Fatalf("maintenance extension (list) failed: %v\n%s", err, out)
+	}
+	// Canasta ships with many extensions; check for a few that are known to have
+	// maintenance directories.
+	for _, ext := range []string{"CirrusSearch", "SemanticMediaWiki"} {
+		if strings.Contains(out, ext) {
+			t.Logf("Found expected extension with maintenance scripts: %s", ext)
+		}
+		// Not a hard failure — the exact set depends on the image version.
+	}
+	// At minimum, the command should have listed something.
+	if !strings.Contains(out, "Extensions with maintenance scripts") &&
+		!strings.Contains(out, "No loaded extensions") {
+		t.Errorf("unexpected output from maintenance extension list:\n%s", out)
+	}
+
+	// List available core maintenance scripts
+	out, err = inst.run(t, "maintenance", "script", "-i", inst.ID)
+	if err != nil {
+		t.Fatalf("maintenance script (list) failed: %v\n%s", err, out)
+	}
+	// Verify well-known scripts are present
+	for _, script := range []string{"update.php", "runJobs.php"} {
+		if !strings.Contains(out, script) {
+			t.Errorf("maintenance script list should contain %s, got:\n%s", script, out)
+		}
+	}
+
+	// Run a maintenance script — showSiteStats.php produces output about site statistics
+	out, err = inst.run(t, "maintenance", "script", "-i", inst.ID, "showSiteStats.php")
+	if err != nil {
+		t.Fatalf("maintenance script showSiteStats.php failed: %v\n%s", err, out)
+	}
+	// The script should produce some output (stats or at least a header)
+	if strings.TrimSpace(out) == "" {
+		t.Error("maintenance script showSiteStats.php produced no output")
+	}
+	t.Logf("showSiteStats.php output:\n%s", out)
+}


### PR DESCRIPTION
## Summary
4 new integration tests covering the remaining test issues:

- **TestConfig_GetSetDelete**: set, get (single key + all), unset config keys (#708)
- **TestMaintenance_ExtensionScripts**: list extensions, list scripts, run showSiteStats.php (#707)
- **TestGitops_Pull**: init gitops, push remote change via clone, pull, verify file appears (#709)
- **TestGitops_Diff**: local uncommitted changes, remote changes, verify diff output (#710)

Fixes #707, #708, #709, #710

## Test plan
- [x] `go vet -tags integration ./tests/integration/` passes
- [x] `gofmt` clean
- [ ] Integration tests pass in CI