### PR TITLE
Fix upgrade overriding user-set CANASTA_IMAGE

### DIFF
--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -648,10 +648,11 @@ func removeLegacyGitDir(installPath string, dryRun bool) (bool, error) {
 	return true, nil
 }
 
-// backfillCanastaImage ensures CANASTA_IMAGE in .env matches the current
-// CLI's default image tag. This handles both instances that predate the
-// CANASTA_IMAGE variable and instances where the CLI was upgraded to a
-// newer version but the image tag was not updated.
+// backfillCanastaImage ensures CANASTA_IMAGE is present in .env for
+// instances that predate the variable. If the user has already set
+// CANASTA_IMAGE (e.g. via config set to pin a specific version), the
+// existing value is preserved — upgrade should not override intentional
+// user configuration.
 func backfillCanastaImage(installPath string, dryRun bool) (bool, error) {
 	envPath := filepath.Join(installPath, ".env")
 
@@ -662,7 +663,7 @@ func backfillCanastaImage(installPath string, dryRun bool) (bool, error) {
 
 	image := canasta.GetDefaultImage()
 
-	if val, ok := envVars["CANASTA_IMAGE"]; ok && val == image {
+	if _, ok := envVars["CANASTA_IMAGE"]; ok {
 		return false, nil
 	}
 

--- a/cmd/upgrade/upgrade_test.go
+++ b/cmd/upgrade/upgrade_test.go
@@ -241,9 +241,9 @@ func TestBackfillCanastaImage(t *testing.T) {
 			wantChanged: true,
 		},
 		{
-			name:        "outdated version",
+			name:        "user-set version preserved",
 			envContent:  "CANASTA_IMAGE=ghcr.io/canastawiki/canasta:3.3.1\nMYSQL_PASSWORD=secret\n",
-			wantChanged: true,
+			wantChanged: false,
 		},
 		{
 			name:        "already current",
@@ -251,9 +251,9 @@ func TestBackfillCanastaImage(t *testing.T) {
 			wantChanged: false,
 		},
 		{
-			name:        "empty value",
+			name:        "empty value preserved",
 			envContent:  "CANASTA_IMAGE=\nMYSQL_PASSWORD=secret\n",
-			wantChanged: true,
+			wantChanged: false,
 		},
 	}
 


### PR DESCRIPTION
## Summary

`backfillCanastaImage` was overwriting `CANASTA_IMAGE` with the CLI's built-in default on every upgrade, even when the user had intentionally set a different version via `canasta config set`. Now it only sets the value when the key is **missing** from `.env` (the original backfill intent for pre-CANASTA_IMAGE instances).

Fixes #735

## Test plan

- [x] Unit tests updated and passing
- [ ] `canasta config set CANASTA_IMAGE=ghcr.io/canastawiki/canasta:3.5.4` followed by `canasta upgrade` preserves 3.5.4
- [ ] Fresh instance without CANASTA_IMAGE in .env gets it backfilled on upgrade
