### PR TITLE
Add deprecation warning and cross-repo release mirror (replaces #740)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,3 +88,38 @@ jobs:
           ./build/canasta-linux-arm64
           ./build/canasta-darwin-amd64
           ./build/canasta-darwin-arm64
+
+    # After this repo is renamed to Canasta-Go and Canasta-Ansible
+    # takes over the Canasta-CLI repo name, mirror the same release
+    # artifacts to the new Canasta-CLI repo so legacy 3.x clients
+    # continue to find a working binary at the URL their selfupdate
+    # logic queries (api.github.com/repos/CanastaWiki/Canasta-CLI/
+    # releases/latest). Skipped automatically when the App isn't
+    # configured (pre-rename, dev forks) or when this workflow runs
+    # from CanastaWiki/Canasta-CLI itself (which would self-mirror).
+    - name: Mint cross-repo token
+      if: ${{ vars.RELEASE_BOT_APP_ID != '' && github.repository != 'CanastaWiki/Canasta-CLI' }}
+      id: app-token
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+        private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+        owner: CanastaWiki
+        repositories: Canasta-CLI
+
+    - name: Mirror release to CanastaWiki/Canasta-CLI
+      if: ${{ vars.RELEASE_BOT_APP_ID != '' && github.repository != 'CanastaWiki/Canasta-CLI' }}
+      uses: softprops/action-gh-release@v2
+      with:
+        repository: CanastaWiki/Canasta-CLI
+        token: ${{ steps.app-token.outputs.token }}
+        draft: false
+        tag_name: ${{ needs.version.outputs.new_version }}
+        fail_on_unmatched_files: true
+        generate_release_notes: true
+        append_body: true
+        files: |
+          ./build/canasta-linux-amd64
+          ./build/canasta-linux-arm64
+          ./build/canasta-darwin-amd64
+          ./build/canasta-darwin-arm64

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	addCmd "github.com/CanastaWiki/Canasta-CLI/cmd/add"
 	backupCmd "github.com/CanastaWiki/Canasta-CLI/cmd/backup"
 	configCmd "github.com/CanastaWiki/Canasta-CLI/cmd/config"
@@ -28,6 +31,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const deprecationWarning = `WARNING: This is the final Canasta CLI 3.x (Go) release. Future versions
+ship as Canasta CLI 4.x (Python/Ansible). To migrate:
+    curl -fsSL https://get.canasta.wiki | bash
+See https://canasta.wiki/wiki/Help:Installation.
+(Set CANASTA_SUPPRESS_DEPRECATION_WARNING=1 to silence.)
+`
+
+func printDeprecationWarning() {
+	if os.Getenv("CANASTA_SUPPRESS_DEPRECATION_WARNING") != "" {
+		return
+	}
+	fmt.Fprint(os.Stderr, deprecationWarning)
+}
+
 var verbose bool
 
 var rootCmd = &cobra.Command{
@@ -40,6 +57,7 @@ wikis per instance.`,
 	SilenceErrors: true,
 	SilenceUsage:  true,
 	PersistentPreRun: func(_ *cobra.Command, _ []string) {
+		printDeprecationWarning()
 		logging.SetVerbose(verbose)
 		logging.Print("Verbose logging enabled")
 	},


### PR DESCRIPTION
## Summary

Replaces the bridge-binary approach in #740 (which would have bricked working installs on `canasta upgrade`) with: keep shipping the **real** Go CLI, add a deprecation warning, and mirror the release artifacts to a sister repo so legacy clients keep finding a working binary after the rename.

- **`cmd/root/root.go`** — print a deprecation warning to stderr from `PersistentPreRun` on every `canasta` invocation. Suppressible via `CANASTA_SUPPRESS_DEPRECATION_WARNING=1` for users who've intentionally pinned 3.x. The CLI continues to work normally; the warning just appears each command.
- **`.github/workflows/release.yml`** — after the existing publish step, mint a cross-repo token via a CanastaWiki GitHub App and mirror the same artifacts to `CanastaWiki/Canasta-CLI`. Mirror step is gated on:
  - `vars.RELEASE_BOT_APP_ID != ''` — skipped on forks and pre-App-setup.
  - `github.repository != 'CanastaWiki/Canasta-CLI'` — skipped when this workflow is running from Canasta-CLI itself (post-rename self-mirror defense).

VERSION is intentionally **not** bumped in this PR.

Refs #739 (original bridge proposal — superseding). Blocks on #742 (org GitHub App setup) before the merge prerequisites can be satisfied.

## DO NOT merge until

1. PR #740 is closed without merging.
2. This repo has been renamed (`CanastaWiki/Canasta-CLI` → `CanastaWiki/Canasta-Go`).
3. `CanastaWiki/Canasta-Ansible` has been renamed to `CanastaWiki/Canasta-CLI`.
4. A CanastaWiki GitHub App with `Contents: Read and write` has been installed on both Canasta-Go and Canasta-CLI, with `vars.RELEASE_BOT_APP_ID` and `secrets.RELEASE_BOT_PRIVATE_KEY` set at the org level.

The reason: if VERSION gets bumped while this PR is merged but the renames haven't happened, the regular publish step would land v3.7.0 in `CanastaWiki/Canasta-CLI` (the about-to-be-renamed repo), and the new `Canasta-CLI` repo would have zero releases for legacy clients to find.

After all four prerequisites are met, merge this PR (no release fires — VERSION unchanged), then bump VERSION to 3.7.0 in a follow-up commit. That bump triggers a v3.7.0 release in Canasta-Go (regular publish) and in Canasta-CLI (mirror step).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` clean
- [x] `go vet ./...` clean
- [x] Local smoke test: `canasta version` writes the binary's version to stdout and the deprecation warning to stderr; `CANASTA_SUPPRESS_DEPRECATION_WARNING=1 canasta version` writes nothing to stderr.
- [x] YAML validates (`yaml.safe_load(release.yml)`).
- [ ] Post-rename + post-App-setup: dry-run the workflow on a non-VERSION push to confirm the build matrix succeeds without firing the release / mirror steps (the existing `if: needs.version.outputs.changed == 'true'` gate stays in place).
- [ ] Post-rename + post-VERSION-bump: confirm v3.7.0 release lands in both `Canasta-Go` and `Canasta-CLI`, and that `https://api.github.com/repos/CanastaWiki/Canasta-CLI/releases/latest` returns `tag_name: v3.7.0` with the four binary assets attached.